### PR TITLE
Allow to provide values for the keys in keys_to_properties

### DIFF
--- a/equistore/_c_api.py
+++ b/equistore/_c_api.py
@@ -185,8 +185,7 @@ def setup_functions(lib):
 
     lib.eqs_tensormap_keys_to_properties.argtypes = [
         POINTER(eqs_tensormap_t),
-        POINTER(ctypes.c_char_p),
-        ctypes.c_uint64,
+        eqs_labels_t,
         ctypes.c_bool
     ]
     lib.eqs_tensormap_keys_to_properties.restype = _check_status
@@ -200,8 +199,7 @@ def setup_functions(lib):
 
     lib.eqs_tensormap_keys_to_samples.argtypes = [
         POINTER(eqs_tensormap_t),
-        POINTER(ctypes.c_char_p),
-        ctypes.c_uint64,
+        eqs_labels_t,
         ctypes.c_bool
     ]
     lib.eqs_tensormap_keys_to_samples.restype = _check_status

--- a/include/equistore.h
+++ b/include/equistore.h
@@ -484,35 +484,44 @@ eqs_status_t eqs_tensormap_block_selection(const struct eqs_tensormap_t *tensor,
                                            struct eqs_labels_t selection);
 
 /**
- * Move the given `variables` from the keys to the property labels of the
- * blocks.
+ * Merge blocks with the same value for selected keys variables along the
+ * property axis.
  *
- * Blocks containing the same values in the keys for the `variables` will
- * be merged together. The resulting merged blocks will have `variables` as
- * the first property variables, followed by the current properties. The
- * new sample labels will contains all of the merged blocks sample labels.
+ * The variables (names) of `keys_to_move` will be moved from the keys to
+ * the property labels, and blocks with the same remaining keys variables
+ * will be merged together along the property axis.
  *
- * The order of the samples is controlled by `sort_samples`. If
+ * If `keys_to_move` does not contains any entries (`keys_to_move.count
+ * == 0`), then the new property labels will contain entries corresponding
+ * to the merged blocks only. For example, merging a block with key `a=0`
+ * and properties `p=1, 2` with a block with key `a=2` and properties `p=1,
+ * 3` will produce a block with properties `a, p = (0, 1), (0, 2), (2, 1),
+ * (2, 3)`.
+ *
+ * If `keys_to_move` contains entries, then the property labels must be the
+ * same for all the merged blocks. In that case, the merged property labels
+ * will contains each of the entries of `keys_to_move` and then the current
+ * property labels. For example, using `a=2, 3` in `keys_to_move`, and
+ * blocks with properties `p=1, 2` will result in `a, p = (2, 1), (2, 2),
+ * (3, 1), (3, 2)`.
+ *
+ * The new sample labels will contains all of the merged blocks sample
+ * labels. The order of the samples is controlled by `sort_samples`. If
  * `sort_samples` is true, samples are re-ordered to keep them
  * lexicographically sorted. Otherwise they are kept in the order in which
  * they appear in the blocks.
  *
- * `variables` must be an array of `variables_count` NULL-terminated strings,
- * encoded as UTF-8.
- *
  * @param tensor pointer to an existing tensor map
- * @param variables names of the key variables to move to the properties
- * @param variables_count number of entries in the `variables` array
+ * @param keys_to_move description of the keys to move
  * @param sort_samples whether to sort the samples lexicographically after
- *                     merging blocks or not
+ *                     merging blocks
  *
  * @returns The status code of this operation. If the status is not
  *          `EQS_SUCCESS`, you can use `eqs_last_error()` to get the full
  *          error message.
  */
 eqs_status_t eqs_tensormap_keys_to_properties(struct eqs_tensormap_t *tensor,
-                                              const char *const *variables,
-                                              uint64_t variables_count,
+                                              struct eqs_labels_t keys_to_move,
                                               bool sort_samples);
 
 /**
@@ -535,14 +544,19 @@ eqs_status_t eqs_tensormap_components_to_properties(struct eqs_tensormap_t *tens
                                                     uint64_t variables_count);
 
 /**
- * Move the given `variables` from the keys to the sample labels of the
- * blocks.
+ * Merge blocks with the same value for selected keys variables along the
+ * samples axis.
  *
- * Blocks containing the same values in the keys for the `variables` will
- * be merged together. The resulting merged blocks will have `variables` as
- * the last sample variables, preceded by the current samples.
+ * The variables (names) of `keys_to_move` will be moved from the keys to
+ * the sample labels, and blocks with the same remaining keys variables
+ * will be merged together along the sample axis.
  *
- * The order of the samples is controlled by `sort_samples`. If
+ * `keys_to_move` must be empty (`keys_to_move.count == 0`), and the new
+ * sample labels will contain entries corresponding to the merged blocks'
+ * keys.
+ *
+ * The new sample labels will contains all of the merged blocks sample
+ * labels. The order of the samples is controlled by `sort_samples`. If
  * `sort_samples` is true, samples are re-ordered to keep them
  * lexicographically sorted. Otherwise they are kept in the order in which
  * they appear in the blocks.
@@ -550,12 +564,8 @@ eqs_status_t eqs_tensormap_components_to_properties(struct eqs_tensormap_t *tens
  * This function is only implemented if all merged block have the same
  * property labels.
  *
- * `variables` must be an array of `variables_count` NULL-terminated strings,
- * encoded as UTF-8.
- *
  * @param tensor pointer to an existing tensor map
- * @param variables names of the key variables to move to the samples
- * @param variables_count number of entries in the `variables` array
+ * @param keys_to_move description of the keys to move
  * @param sort_samples whether to sort the samples lexicographically after
  *                     merging blocks or not
  *
@@ -564,8 +574,7 @@ eqs_status_t eqs_tensormap_components_to_properties(struct eqs_tensormap_t *tens
  *          error message.
  */
 eqs_status_t eqs_tensormap_keys_to_samples(struct eqs_tensormap_t *tensor,
-                                           const char *const *variables,
-                                           uint64_t variables_count,
+                                           struct eqs_labels_t keys_to_move,
                                            bool sort_samples);
 
 #ifdef __cplusplus

--- a/src/c_api/tensor.rs
+++ b/src/c_api/tensor.rs
@@ -205,27 +205,37 @@ pub unsafe extern fn eqs_tensormap_block_selection(
 }
 
 
-/// Move the given `variables` from the keys to the property labels of the
-/// blocks.
+/// Merge blocks with the same value for selected keys variables along the
+/// property axis.
 ///
-/// Blocks containing the same values in the keys for the `variables` will
-/// be merged together. The resulting merged blocks will have `variables` as
-/// the first property variables, followed by the current properties. The
-/// new sample labels will contains all of the merged blocks sample labels.
+/// The variables (names) of `keys_to_move` will be moved from the keys to
+/// the property labels, and blocks with the same remaining keys variables
+/// will be merged together along the property axis.
 ///
-/// The order of the samples is controlled by `sort_samples`. If
+/// If `keys_to_move` does not contains any entries (`keys_to_move.count
+/// == 0`), then the new property labels will contain entries corresponding
+/// to the merged blocks only. For example, merging a block with key `a=0`
+/// and properties `p=1, 2` with a block with key `a=2` and properties `p=1,
+/// 3` will produce a block with properties `a, p = (0, 1), (0, 2), (2, 1),
+/// (2, 3)`.
+///
+/// If `keys_to_move` contains entries, then the property labels must be the
+/// same for all the merged blocks. In that case, the merged property labels
+/// will contains each of the entries of `keys_to_move` and then the current
+/// property labels. For example, using `a=2, 3` in `keys_to_move`, and
+/// blocks with properties `p=1, 2` will result in `a, p = (2, 1), (2, 2),
+/// (3, 1), (3, 2)`.
+///
+/// The new sample labels will contains all of the merged blocks sample
+/// labels. The order of the samples is controlled by `sort_samples`. If
 /// `sort_samples` is true, samples are re-ordered to keep them
 /// lexicographically sorted. Otherwise they are kept in the order in which
 /// they appear in the blocks.
 ///
-/// `variables` must be an array of `variables_count` NULL-terminated strings,
-/// encoded as UTF-8.
-///
 /// @param tensor pointer to an existing tensor map
-/// @param variables names of the key variables to move to the properties
-/// @param variables_count number of entries in the `variables` array
+/// @param keys_to_move description of the keys to move
 /// @param sort_samples whether to sort the samples lexicographically after
-///                     merging blocks or not
+///                     merging blocks
 ///
 /// @returns The status code of this operation. If the status is not
 ///          `EQS_SUCCESS`, you can use `eqs_last_error()` to get the full
@@ -234,21 +244,14 @@ pub unsafe extern fn eqs_tensormap_block_selection(
 #[allow(clippy::cast_possible_truncation)]
 pub unsafe extern fn eqs_tensormap_keys_to_properties(
     tensor: *mut eqs_tensormap_t,
-    variables: *const *const c_char,
-    variables_count: u64,
+    keys_to_move: eqs_labels_t,
     sort_samples: bool,
 ) -> eqs_status_t {
     catch_unwind(|| {
-        check_pointers!(tensor, variables);
+        check_pointers!(tensor);
 
-        let mut rust_variables = Vec::new();
-        for &variable in std::slice::from_raw_parts(variables, variables_count as usize) {
-            check_pointers!(variable);
-            let variable = CStr::from_ptr(variable).to_str().expect("invalid utf8");
-            rust_variables.push(variable);
-        }
-
-        (*tensor).keys_to_properties(&rust_variables, sort_samples)?;
+        let keys_to_move = Labels::try_from(&keys_to_move)?;
+        (*tensor).keys_to_properties(&keys_to_move, sort_samples)?;
 
         Ok(())
     })
@@ -291,14 +294,19 @@ pub unsafe extern fn eqs_tensormap_components_to_properties(
     })
 }
 
-/// Move the given `variables` from the keys to the sample labels of the
-/// blocks.
+/// Merge blocks with the same value for selected keys variables along the
+/// samples axis.
 ///
-/// Blocks containing the same values in the keys for the `variables` will
-/// be merged together. The resulting merged blocks will have `variables` as
-/// the last sample variables, preceded by the current samples.
+/// The variables (names) of `keys_to_move` will be moved from the keys to
+/// the sample labels, and blocks with the same remaining keys variables
+/// will be merged together along the sample axis.
 ///
-/// The order of the samples is controlled by `sort_samples`. If
+/// `keys_to_move` must be empty (`keys_to_move.count == 0`), and the new
+/// sample labels will contain entries corresponding to the merged blocks'
+/// keys.
+///
+/// The new sample labels will contains all of the merged blocks sample
+/// labels. The order of the samples is controlled by `sort_samples`. If
 /// `sort_samples` is true, samples are re-ordered to keep them
 /// lexicographically sorted. Otherwise they are kept in the order in which
 /// they appear in the blocks.
@@ -306,12 +314,8 @@ pub unsafe extern fn eqs_tensormap_components_to_properties(
 /// This function is only implemented if all merged block have the same
 /// property labels.
 ///
-/// `variables` must be an array of `variables_count` NULL-terminated strings,
-/// encoded as UTF-8.
-///
 /// @param tensor pointer to an existing tensor map
-/// @param variables names of the key variables to move to the samples
-/// @param variables_count number of entries in the `variables` array
+/// @param keys_to_move description of the keys to move
 /// @param sort_samples whether to sort the samples lexicographically after
 ///                     merging blocks or not
 ///
@@ -322,21 +326,14 @@ pub unsafe extern fn eqs_tensormap_components_to_properties(
 #[allow(clippy::cast_possible_truncation)]
 pub unsafe extern fn eqs_tensormap_keys_to_samples(
     tensor: *mut eqs_tensormap_t,
-    variables: *const *const c_char,
-    variables_count: u64,
+    keys_to_move: eqs_labels_t,
     sort_samples: bool,
 ) -> eqs_status_t {
     catch_unwind(|| {
-        check_pointers!(tensor, variables);
+        check_pointers!(tensor);
 
-        let mut rust_variables = Vec::new();
-        for &variable in std::slice::from_raw_parts(variables, variables_count as usize) {
-            check_pointers!(variable);
-            let variable = CStr::from_ptr(variable).to_str().expect("invalid utf8");
-            rust_variables.push(variable);
-        }
-
-        (*tensor).keys_to_samples(&rust_variables, sort_samples)?;
+        let keys_to_move = Labels::try_from(&keys_to_move)?;
+        (*tensor).keys_to_samples(&keys_to_move, sort_samples)?;
 
         Ok(())
     })

--- a/src/data.rs
+++ b/src/data.rs
@@ -646,7 +646,6 @@ impl DataStorage for ndarray::ArrayD<f64> {
 
         let input = input.as_any().downcast_ref::<ndarray::ArrayD<f64>>().expect("input must be a ndarray");
         for sample in samples {
-            dbg!(sample.input);
             let value = input.index_axis(Axis(0), sample.input);
 
             let mut output_location = self.index_axis_mut(Axis(0), sample.output);

--- a/src/tensor/mod.rs
+++ b/src/tensor/mod.rs
@@ -17,7 +17,7 @@ mod keys_to_properties;
 /// It provides functions to merge blocks together by moving some of these keys
 /// to the samples or properties labels of the blocks, transforming the sparse
 /// representation of the data to a dense one.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct TensorMap {
     keys: Labels,
     blocks: Vec<TensorBlock>,
@@ -65,7 +65,11 @@ fn check_labels_names(
 }
 
 impl TensorMap {
-    /// TODO: doc
+    /// Create a new `TensorMap` with the given keys and blocks.
+    ///
+    /// The number of keys must match the number of blocks, and all the blocks
+    /// must contain the same kind of data (same labels names, same gradients
+    /// defined on all blocks).
     #[allow(clippy::similar_names)]
     pub fn new(keys: Labels, blocks: Vec<TensorBlock>) -> Result<TensorMap, Error> {
         if blocks.len() != keys.count() {
@@ -243,7 +247,6 @@ impl TensorMap {
     /// Move the given variables from the component labels to the property labels
     /// for each block in this `TensorMap`.
     pub fn components_to_properties(&mut self, variables: &[&str]) -> Result<(), Error> {
-        // TODO: requested values
         if variables.is_empty() {
             return Ok(());
         }


### PR DESCRIPTION
`keys_to_properties` can now takes as input a set of `Labels` containing the values the user wants to move from keys to properties. The intended use case is to be able to create a "species dense" representation of a frame with a pre-determined set of species, for example predicting AlO3 on a model trained on Al-Si-O dataset. Ideally we would want to do the prediction with (neighbor) species-sparse descriptor, but (neighbor) species dense representation is good enough and much easier to work with.

The previous behavior ("just take whatever is in the keys & use is in properties") is still available by passing an empty set of Labels (or in Python a list of strings).

This is similar to `"expansion_by_species_method": "user defined", "global_species": [1, 5, 6, 33]` in librascal.