### PR TITLE
Added first attempt of __repr__ for TensorMap and TensorBlock

### DIFF
--- a/equistore/block.py
+++ b/equistore/block.py
@@ -125,8 +125,41 @@ class TensorBlock:
         return copy
 
     def copy(self) -> "TensorBlock":
-        """Get a deep copy of this block"""
+        """
+        Get a deep copy of this block
+        """
         return copy.deepcopy(self)
+
+    def __repr__(self) -> str:
+        s = "TensorBlock \n"
+        s += "samples: ["
+        for sname in self.samples.names[:-1]:
+            s += "'" + sname + "', "
+        s += "'" + self.samples.names[-1] + "']"
+        s += "\n"
+        s += "component: ["
+        for ic in self.components:
+            for name in ic.names[:]:
+                s += "'" + name + "', "
+        if len(self.components) > 0:
+            s = s[:-2]
+        s += "]\n"
+        s += "properties: ["
+        for name in self.properties.names[:-1]:
+            s += "'" + name + "', "
+        s += "'" + self.properties.names[-1] + "']\n"
+        s += "gradients: "
+        if len(self.gradients_list()) > 0:
+            s += "["
+            for gr in self.gradients_list()[:-1]:
+                s += "'{}', ".format(gr)
+            s += "'{}']".format(self.gradients_list()[-1])
+            # s+=", ".join(self.gradients_list())
+            # s+="]"
+        else:
+            s += "No"
+
+        return s
 
     @property
     def values(self) -> Array:
@@ -270,6 +303,28 @@ class Gradient:
 
         self._block = block
         self._name = name
+
+    def __repr__(self) -> str:
+        s = "Gradient TensorBlock \n"
+        s += "parameter: '{}'\n".format(self._name)
+        s += "samples: ["
+        for sname in self.samples.names[:-1]:
+            s += "'" + sname + "', "
+        s += "'" + self.samples.names[-1] + "']"
+        s += "\n"
+        s += "component: ["
+        for ic in self.components:
+            for name in ic.names[:]:
+                s += "'" + name + "', "
+        if len(self.components) > 0:
+            s = s[:-2]
+        s += "]\n"
+        s += "properties: ["
+        for name in self.properties.names[:-1]:
+            s += "'" + name + "', "
+        s += "'" + self.properties.names[-1] + "']"
+
+        return s
 
     @property
     def data(self) -> Array:

--- a/equistore/block.py
+++ b/equistore/block.py
@@ -154,10 +154,8 @@ class TensorBlock:
             for gr in self.gradients_list()[:-1]:
                 s += "'{}', ".format(gr)
             s += "'{}']".format(self.gradients_list()[-1])
-            # s+=", ".join(self.gradients_list())
-            # s+="]"
         else:
-            s += "No"
+            s += "no"
 
         return s
 

--- a/equistore/labels.py
+++ b/equistore/labels.py
@@ -269,7 +269,7 @@ def _print_labels_skip(Labels: Labels, header: str = "names", lskip: int = 10) -
         s += "'{}' ".format(i)
         width.append(len(i) + 3)
     if ln > 0:
-        s = s[:-2]  # cancel last ", "
+        s = s[:-1]  # cancel last " "
     s += "]\n"
     lheader = len(header)
     prev = lheader + 3
@@ -277,21 +277,14 @@ def _print_labels_skip(Labels: Labels, header: str = "names", lskip: int = 10) -
         for ik in Labels:
             for iw, i in zip(width, ik):
                 s += _make_padding(value=i, width=iw, prev=prev)
-                # pad=prev+iw//2-li//2
-                # s+=("{:>"+str(pad)+"}").format(i)
                 prev = iw // 2
             s += "\n"
             prev = lheader + 3
-            # iw=width[-1]
-            # i=ik[-1]
-            # pad=prev+iw//2-len(i)//2
-            # s+=("{:"+str(pad)+"} \n").format(i)
     else:
         for ik in Labels[:3]:
             for iw, i in zip(width, ik):
                 s += _make_padding(value=i, width=iw, prev=prev)
                 prev = iw // 2
-                # s+="\t{},".format(i)
             s += "\n"
             prev = lheader + 3
         s += "...\n".rjust(prev + width[0] // 2)

--- a/equistore/labels.py
+++ b/equistore/labels.py
@@ -239,3 +239,78 @@ def _is_namedtuple(x):
     if not isinstance(f, tuple):
         return False
     return all(type(n) == str for n in f)
+
+
+def _print_labels_skip(Labels: Labels, header: str = "names", lskip: int = 10) -> str:
+    """
+    Utility function to print a Label in a table-like format,
+    with the number alligned under names of the correponding column.
+    If len(Labels)>lskip it will print only the first three columns and the last three,
+    if lskip<6 it will print all the table.
+    if header='names' the result will look like
+
+    names: ['name_1', 'name_2', 'name_3']
+                v11       v12       v13
+                v21       v22       v23
+                v31       v32       v33
+
+    with vij being the corresponding values.
+
+    :param Labels: the input label
+    :param header: the general names of the "column-names"
+    :param lskip: the maximum number of line you want to print without skipping
+    """
+    if lskip < 6:
+        lskip = 10
+    ln = len(Labels)
+    width = []
+    s = header + ": ["
+    for i in Labels.names:
+        s += "'{}' ".format(i)
+        width.append(len(i) + 3)
+    if ln > 0:
+        s = s[:-2]  # cancel last ", "
+    s += "]\n"
+    lheader = len(header)
+    prev = lheader + 3
+    if ln <= lskip:
+        for ik in Labels:
+            for iw, i in zip(width, ik):
+                s += _make_padding(value=i, width=iw, prev=prev)
+                # pad=prev+iw//2-li//2
+                # s+=("{:>"+str(pad)+"}").format(i)
+                prev = iw // 2
+            s += "\n"
+            prev = lheader + 3
+            # iw=width[-1]
+            # i=ik[-1]
+            # pad=prev+iw//2-len(i)//2
+            # s+=("{:"+str(pad)+"} \n").format(i)
+    else:
+        for ik in Labels[:3]:
+            for iw, i in zip(width, ik):
+                s += _make_padding(value=i, width=iw, prev=prev)
+                prev = iw // 2
+                # s+="\t{},".format(i)
+            s += "\n"
+            prev = lheader + 3
+        s += "...\n".rjust(prev + width[0] // 2)
+        for ik in Labels[-3:]:
+            for iw, i in zip(width, ik):
+                s += _make_padding(value=i, width=iw, prev=prev)
+                prev = iw // 2
+            s += "\n"
+            prev = lheader + 3
+    return s[:-1]
+
+
+def _make_padding(value, width: int, prev=0):
+    """
+    Utility to make the padding in the output string
+
+    :param value : value to write
+    :param width : width of the name of that column
+    :param prev  : additional padding
+    """
+    pad = prev + width // 2
+    return ("{:>" + str(pad) + "}").format(value)

--- a/equistore/tensor.py
+++ b/equistore/tensor.py
@@ -6,7 +6,7 @@ import numpy as np
 from ._c_api import c_uintptr_t, eqs_block_t, eqs_labels_t
 from ._c_lib import _get_library
 from .block import TensorBlock
-from .labels import Labels, _is_namedtuple
+from .labels import Labels, _is_namedtuple, _print_labels_skip
 from .status import _check_pointer
 
 
@@ -78,6 +78,17 @@ class TensorMap:
         keys = self.keys
         for i, keys in enumerate(keys):
             yield keys, self._get_block_by_id(i)
+
+    def __repr__(self) -> str:
+        s = f"TensorMap with {len(self.keys)} blocks\n"
+        s += _print_labels_skip(self.keys, header="keys")
+        return s
+
+    def __str__(self) -> str:
+        ln = len(self.keys)
+        s = f"TensorMap with {ln} blocks\n"
+        s += _print_labels_skip(self.keys, header="keys", lskip=ln + 1)
+        return s
 
     @property
     def keys(self) -> Labels:

--- a/equistore/tensor.py
+++ b/equistore/tensor.py
@@ -79,6 +79,9 @@ class TensorMap:
         for i, keys in enumerate(keys):
             yield keys, self._get_block_by_id(i)
 
+    def __len__(self):
+        return len(self.keys)
+
     def __repr__(self) -> str:
         s = f"TensorMap with {len(self.keys)} blocks\n"
         s += _print_labels_skip(self.keys, header="keys")

--- a/tests/python/blocks.py
+++ b/tests/python/blocks.py
@@ -1,4 +1,5 @@
 import unittest
+import os
 
 import numpy as np
 
@@ -6,6 +7,16 @@ from equistore import Labels, TensorBlock
 
 
 class TestBlocks(unittest.TestCase):
+    def test_repr_(self):
+        block = TensorBlock(
+            values=np.full((3, 2), -1.0),
+            samples=Labels(["samples"], np.array([[0], [2], [4]], dtype=np.int32)),
+            components=[],
+            properties=Labels(["properties"], np.array([[5], [3]], dtype=np.int32)),
+        )
+        expected = "TensorBlock \nsamples: ['samples']\ncomponent: []\nproperties: ['properties']\ngradients: no"
+        self.assertTrue(block.__repr__() == expected)
+
     def test_block_no_components(self):
         block = TensorBlock(
             values=np.full((3, 2), -1.0),

--- a/tests/python/tensor.py
+++ b/tests/python/tensor.py
@@ -1,7 +1,8 @@
 import unittest
+import os
 
 import numpy as np
-from utils import test_tensor_map
+from utils import test_tensor_map, test_large_tensor_map
 
 
 class TestTensorMap(unittest.TestCase):
@@ -9,10 +10,39 @@ class TestTensorMap(unittest.TestCase):
         tensor = test_tensor_map()
         self.assertEqual(tensor.keys.names, ("key_1", "key_2"))
         self.assertEqual(len(tensor.keys), 4)
+        self.assertEqual(len(tensor), 4)
         self.assertEqual(tuple(tensor.keys[0]), (0, 0))
         self.assertEqual(tuple(tensor.keys[1]), (1, 0))
         self.assertEqual(tuple(tensor.keys[2]), (2, 2))
         self.assertEqual(tuple(tensor.keys[3]), (2, 3))
+
+    def test_print(self):
+        """
+        Test routine for the print function of the TensorBlock.
+        It compare the reults with those in a file.
+        """
+        tensor = test_tensor_map()
+        repr = tensor.__repr__()
+        expected = """TensorMap with 4 blocks
+keys: ['key_1' 'key_2']
+          0       0
+          1       0
+          2       2
+          2       3"""
+        self.assertTrue(expected == repr)
+
+        tensor = test_large_tensor_map()
+        _print = tensor.__repr__()
+        expected = """TensorMap with 12 blocks
+keys: ['key_1' 'key_2']
+          0       0
+          1       0
+          2       2
+       ...
+          1       5
+          2       5
+          3       5"""
+        self.assertTrue(expected == _print)
 
     def test_labels_names(self):
         tensor = test_tensor_map()

--- a/tests/python/utils.py
+++ b/tests/python/utils.py
@@ -79,3 +79,59 @@ def test_tensor_map():
     )
 
     return TensorMap(keys, [block_1, block_2, block_3, block_4])
+
+
+def test_large_tensor_map():
+    """
+    Create a dummy tensor map of 16 blocks to be used in tests. This is the same
+    tensor map used in `tensor.rs` tests.
+    """
+    tensor = test_tensor_map()
+    block_list = [block.copy() for _, block in tensor]
+
+    for i in range(8):
+        tmp_bl = TensorBlock(
+            values=np.full((4, 3, 1), 4.0),
+            samples=Labels(["samples"], np.array([[0], [1], [4], [5]], dtype=np.int32)),
+            components=[
+                Labels(["components"], np.array([[0], [1], [2]], dtype=np.int32))
+            ],
+            properties=Labels(["properties"], np.array([[i]], dtype=np.int32)),
+        )
+        tmp_bl.add_gradient(
+            "parameter",
+            data=np.full((2, 3, 1), 14.0),
+            samples=Labels(
+                ["sample", "parameter"],
+                np.array([[0, 1], [3, 3]], dtype=np.int32),
+            ),
+            components=[
+                Labels(
+                    ["components"],
+                    np.array([[0], [1], [2]], dtype=np.int32),
+                )
+            ],
+        )
+        block_list.append(tmp_bl)
+
+    keys = Labels(
+        names=["key_1", "key_2"],
+        values=np.array(
+            [
+                [0, 0],
+                [1, 0],
+                [2, 2],
+                [2, 3],
+                [0, 4],
+                [1, 4],
+                [2, 4],
+                [3, 4],
+                [0, 5],
+                [1, 5],
+                [2, 5],
+                [3, 5],
+            ],
+            dtype=np.int32,
+        ),
+    )
+    return TensorMap(keys, block_list)


### PR DESCRIPTION
In the spirit of issue #32. I added an idea for two `__repr__` functions for TensorMap and TensorBlock.
In TensorMap it basically prints the keys and its names:
```
>> Tensor
TensorMap 
keys: [(0, 1, 1), (0, 1, 6), (0, 1, 8), (0, 6, 1), (0, 6, 6), (0, 6, 8), (0, 8, 1), (0, 8, 6), (0, 8, 8)]
key_names: ['spherical_harmonics_l', 'species_center', 'species_neighbor']
```
For the TensorBock, the function prints the names of the samples, components and properties:

```
>> Tensor.block(0)
TensorBlock 
samples: ['structure', 'center']
component: ['spherical_harmonics_m']
properties: ['n']
```

The example are taken from a spherical harmonic expansion Tensor.