### PR TITLE
Fix operator== for NDArray<T>

### DIFF
--- a/include/equistore.hpp
+++ b/include/equistore.hpp
@@ -363,7 +363,7 @@ bool operator==(const NDArray<T>& lhs, const NDArray<T>& rhs) {
     if (lhs.shape() != rhs.shape()) {
         return false;
     }
-    return std::memcmp(lhs.data(), rhs.data(), details::product(lhs.shape())) == 0;
+    return std::memcmp(lhs.data(), rhs.data(), sizeof(T) * details::product(lhs.shape())) == 0;
 }
 
 /// Compare this `NDArray` with another `NDarray`. The array are equal if

--- a/tests/cpp/labels.cpp
+++ b/tests/cpp/labels.cpp
@@ -31,6 +31,7 @@ TEST_CASE("Labels") {
 
     CHECK(labels == Labels({"foo", "bar"}, {{1, 2}, {3, 4}, {5, 6}}));
     CHECK(labels != Labels({"bar", "foo"}, {{1, 2}, {3, 4}, {5, 6}}));
+    CHECK(labels != Labels({"foo", "bar"}, {{1, 2}, {3, 4}, {5, 5}}));
 
 
     CHECK_THROWS_WITH(labels(1), "expected 2 indexes in Labels::operator(), got 1");


### PR DESCRIPTION
memcmp work with bytes, and was only comparing the first few bytes of the data