### PR TITLE
Enable external Python packages to register new array wrappers

### DIFF
--- a/equistore/_c_lib.py
+++ b/equistore/_c_lib.py
@@ -4,6 +4,8 @@ import sys
 from ctypes import cdll
 
 from ._c_api import setup_functions
+from .data import register_external_data_wrapper
+from .data.extract import _RustNDArray
 
 _HERE = os.path.realpath(os.path.dirname(__file__))
 
@@ -36,6 +38,8 @@ class LibraryFinder(object):
             # initial setup, disable printing of the error in case of panic
             # the error will be transformed to a Python exception anyway
             self._cached_dll.eqs_disable_panic_printing()
+
+            register_external_data_wrapper("rust.ndarray", _RustNDArray)
 
         return self._cached_dll
 

--- a/equistore/block.py
+++ b/equistore/block.py
@@ -8,7 +8,8 @@ from ._c_lib import _get_library
 from .data import (
     Array,
     ArrayWrapper,
-    eqs_array_to_python_object,
+    eqs_array_to_python_array,
+    eqs_array_to_python_wrapper,
     eqs_array_was_allocated_by_python,
 )
 from .labels import Labels
@@ -108,18 +109,18 @@ class TensorBlock:
         new_ptr = self._lib.eqs_block_copy(self._ptr)
         copy = TensorBlock._from_ptr(new_ptr, parent=None, owning=True)
 
-        # Keep references to the arrays in this block if the arrays were
+        # Keep references to the wrappers in this block if the arrays were
         # allocated by Python
-        raw_values = _get_raw_array(self._lib, copy._ptr, "values")
-        if eqs_array_was_allocated_by_python(raw_values):
-            copy._values = eqs_array_to_python_object(raw_values)
+        raw_array = _get_raw_array(self._lib, copy._ptr, "values")
+        if eqs_array_was_allocated_by_python(raw_array):
+            copy._values = eqs_array_to_python_wrapper(raw_array)
         else:
             copy._values = None
 
         for parameter in self.gradients_list():
             raw_array = _get_raw_array(self._lib, copy._ptr, parameter)
             if eqs_array_was_allocated_by_python(raw_array):
-                copy._gradients.append(eqs_array_to_python_object(raw_array))
+                copy._gradients.append(eqs_array_to_python_wrapper(raw_array))
             else:
                 pass
 
@@ -173,7 +174,7 @@ class TensorBlock:
         """
 
         raw_array = _get_raw_array(self._lib, self._ptr, "values")
-        return eqs_array_to_python_object(raw_array, parent=self).array
+        return eqs_array_to_python_array(raw_array, parent=self)
 
     @property
     def samples(self) -> Labels:
@@ -344,7 +345,7 @@ class Gradient:
         """
 
         raw_array = _get_raw_array(self._lib, self._block._ptr, self._name)
-        return eqs_array_to_python_object(raw_array, parent=self).array
+        return eqs_array_to_python_array(raw_array, parent=self)
 
     @property
     def samples(self) -> Labels:

--- a/equistore/data/__init__.py
+++ b/equistore/data/__init__.py
@@ -1,0 +1,10 @@
+from .array import ArrayWrapper  # noqa
+from .extract import (  # noqa
+    Array,
+    data_origin,
+    data_origin_name,
+    eqs_array_to_python_array,
+    eqs_array_to_python_wrapper,
+    eqs_array_was_allocated_by_python,
+    register_external_data_wrapper,
+)

--- a/equistore/data/array.py
+++ b/equistore/data/array.py
@@ -1,11 +1,9 @@
 import ctypes
-from typing import NewType, Union
 
 import numpy as np
 
-from ._c_api import c_uintptr_t, eqs_array_t, eqs_data_origin_t
-from ._c_lib import _get_library
-from .utils import _call_with_growing_buffer, _ptr_to_ndarray, catch_exceptions
+from .._c_api import c_uintptr_t, eqs_array_t, eqs_data_origin_t
+from ..utils import catch_exceptions
 
 try:
     import torch
@@ -15,34 +13,13 @@ except ImportError:
     HAS_TORCH = False
 
 
-_NUMPY_STORAGE_ORIGIN = None
-_TORCH_STORAGE_ORIGIN = None
-_RUST_STORAGE_ORIGIN = None
+def _register_origin(name):
+    from .._c_lib import _get_library
 
-if HAS_TORCH:
-    # This NewType is only used for typechecking and documentation purposes
-    Array = NewType("Array", Union[np.ndarray, torch.Tensor])
-    """
-    An ``Array`` contains the actual data stored in a
-    :py:class:`equistore.TensorBlock`.
-
-    This data is manipulated by ``equistore`` in a completely opaque way: this
-    library does not know what's inside the arrays appart from a small set of
-    constrains:
-
-    - array contains numeric data;
-    - they are stored as row-major, n-dimensional arrays with at least 2
-      dimensions;
-    - it is possible to create new arrays and move data from one array to
-      another.
-
-    The actual type of an ``Array`` depends on how the
-    :py:class:`equistore.TensorBlock` was created. Currently, numpy ``ndarray``
-    and torch ``Tensor`` are supported.
-    """
-
-else:
-    Array = NewType("Array", np.ndarray)
+    lib = _get_library()
+    origin = eqs_data_origin_t(0)
+    lib.eqs_register_data_origin(name.encode("utf8"), origin)
+    return origin.value
 
 
 def _is_numpy_array(array):
@@ -56,14 +33,11 @@ def _is_torch_array(array):
     return isinstance(array, torch.Tensor)
 
 
-def _register_origin(name):
-    lib = _get_library()
-    origin = eqs_data_origin_t(0)
-    lib.eqs_register_data_origin(name.encode("utf8"), origin)
-    return origin.value
+_NUMPY_STORAGE_ORIGIN = None
+_TORCH_STORAGE_ORIGIN = None
 
 
-def _numpy_origin():
+def _origin_numpy():
     global _NUMPY_STORAGE_ORIGIN
     if _NUMPY_STORAGE_ORIGIN is None:
         _NUMPY_STORAGE_ORIGIN = _register_origin(__name__ + ".numpy")
@@ -71,89 +45,12 @@ def _numpy_origin():
     return _NUMPY_STORAGE_ORIGIN
 
 
-def _torch_origin():
+def _origin_pytorch():
     global _TORCH_STORAGE_ORIGIN
     if _TORCH_STORAGE_ORIGIN is None:
         _TORCH_STORAGE_ORIGIN = _register_origin(__name__ + ".torch")
 
     return _TORCH_STORAGE_ORIGIN
-
-
-def _rust_origin():
-    global _RUST_STORAGE_ORIGIN
-    if _RUST_STORAGE_ORIGIN is None:
-        _RUST_STORAGE_ORIGIN = _register_origin("rust.ndarray")
-
-    return _RUST_STORAGE_ORIGIN
-
-
-class _RustNDArray(np.ndarray):
-    """
-    Small wrapper class around ``np.ndarray``, adding a reference to a parent
-    Python object that actually owns the memory used inside the array. This
-    prevents the parent from being garbage collected while the ndarray is still
-    alive, thus preventing use-after-free.
-    """
-
-    def __new__(cls, eqs_array, parent):
-        lib = _get_library()
-
-        data = ctypes.POINTER(ctypes.c_double)()
-        shape_ptr = ctypes.POINTER(c_uintptr_t)()
-        shape_count = c_uintptr_t()
-
-        # this requires the data origin of this array is "rust.ndarray", which
-        # is guaranteed by `eqs_array_to_python_object`. This function call will
-        # fail anyway if this is not the case.
-        lib.eqs_get_rust_array(eqs_array, data, shape_ptr, shape_count)
-
-        shape = []
-        for i in range(shape_count.value):
-            shape.append(shape_ptr[i])
-
-        array = _ptr_to_ndarray(data, shape, np.float64)
-        obj = array.view(cls)
-
-        # keep a reference to the parent object (if any) to prevent it from
-        # being garbage-collected too early.
-        obj._parent = parent
-
-        return obj
-
-    def __array_finalize__(self, obj):
-        # keep the parent around when creating sub-views of this array
-        self._parent = getattr(obj, "_parent", None)
-
-
-def eqs_array_to_python_object(eqs_array, parent=None):
-    origin = data_origin(eqs_array)
-    if origin in [_numpy_origin(), _torch_origin()]:
-        return _object_from_ptr(eqs_array.ptr)
-    elif origin == _rust_origin():
-        return ArrayWrapper(_RustNDArray(eqs_array, parent=parent))
-    else:
-        raise ValueError(
-            f"unable to handle data coming from '{data_origin_name(origin)}'"
-        )
-
-
-def eqs_array_was_allocated_by_python(eqs_array):
-    origin = data_origin(eqs_array)
-    return origin in [_numpy_origin(), _torch_origin()]
-
-
-def data_origin(eqs_array):
-    origin = eqs_data_origin_t()
-    eqs_array.origin(eqs_array.ptr, origin)
-    return origin.value
-
-
-def data_origin_name(origin):
-    lib = _get_library()
-
-    return _call_with_growing_buffer(
-        lambda buffer, bufflen: lib.eqs_get_data_origin(origin, buffer, bufflen)
-    )
 
 
 class ArrayWrapper:
@@ -165,9 +62,9 @@ class ArrayWrapper:
 
         self._children = []
         if _is_numpy_array(array):
-            array_origin = _numpy_origin()
+            array_origin = _origin_numpy()
         elif _is_torch_array(array):
-            array_origin = _torch_origin()
+            array_origin = _origin_pytorch()
         else:
             raise ValueError(f"unknown array type: {type(array)}")
 

--- a/equistore/data/extract.py
+++ b/equistore/data/extract.py
@@ -1,0 +1,170 @@
+import ctypes
+from typing import NewType, Union
+
+import numpy as np
+
+from .._c_api import c_uintptr_t, eqs_data_origin_t
+from ..utils import _call_with_growing_buffer, _ptr_to_ndarray
+from .array import _object_from_ptr, _origin_numpy, _origin_pytorch, _register_origin
+
+try:
+    import torch
+
+    HAS_TORCH = True
+except ImportError:
+    HAS_TORCH = False
+
+
+if HAS_TORCH:
+    # This NewType is only used for typechecking and documentation purposes
+    Array = NewType("Array", Union[np.ndarray, torch.Tensor])
+    """
+    An ``Array`` contains the actual data stored in a
+    :py:class:`equistore.TensorBlock`.
+
+    This data is manipulated by ``equistore`` in a completely opaque way: this
+    library does not know what's inside the arrays appart from a small set of
+    constrains:
+
+    - array contains numeric data;
+    - they are stored as row-major, n-dimensional arrays with at least 2
+      dimensions;
+    - it is possible to create new arrays and move data from one array to
+      another.
+
+    The actual type of an ``Array`` depends on how the
+    :py:class:`equistore.TensorBlock` was created. Currently, numpy ``ndarray``
+    and torch ``Tensor`` are supported.
+    """
+
+else:
+    Array = NewType("Array", np.ndarray)
+
+
+_ADDITIONAL_ORIGINS = {}
+
+
+def register_external_data_wrapper(origin, klass):
+    """
+    Register a non-Python data origin and the corresponding class wrapper.
+
+    The wrapper class constructor must take two arguments (raw ``eqs_array`` and
+    python ``parent`` object) and return a subclass of either ``numpy.ndarray``
+    or ``torch.Tensor``, which keeps ``parent`` alive.
+
+    :param origin: new origin to register as a string
+    :param klass: wrapper class to use for this origin
+    """
+
+    if not isinstance(origin, str):
+        raise ValueError(f"origin must be a string, got {type(origin)}")
+
+    global _ADDITIONAL_ORIGINS
+    _ADDITIONAL_ORIGINS[_register_origin(origin)] = klass
+
+
+def eqs_array_to_python_wrapper(eqs_array):
+    """
+    Convert a raw eqs_array to the corresponding Python ``ArrayWrapper``
+    instance.
+    """
+    origin = data_origin(eqs_array)
+    if _is_python_origin(origin):
+        return _object_from_ptr(eqs_array.ptr)
+    else:
+        raise ValueError(
+            f"unable to handle data coming from '{data_origin_name(origin)}'"
+        )
+
+
+def eqs_array_to_python_array(eqs_array, parent=None):
+    """Convert a raw eqs_array to a Python ``Array``.
+
+    Either the underlying array was allocated by Python, and the Python object
+    is directly returned; or the underlying array was not allocated by Python,
+    and additional origins are searched for a suitable Python wrapper class.
+    """
+    origin = data_origin(eqs_array)
+    if _is_python_origin(origin):
+        return _object_from_ptr(eqs_array.ptr).array
+    elif origin in _ADDITIONAL_ORIGINS:
+        return _ADDITIONAL_ORIGINS[origin](eqs_array, parent=parent)
+    else:
+        raise ValueError(
+            f"unable to handle data coming from '{data_origin_name(origin)}'"
+        )
+
+
+def eqs_array_was_allocated_by_python(eqs_array):
+    """Check if a given eqs_array was allocated by Python"""
+    return _is_python_origin(data_origin(eqs_array))
+
+
+def _is_python_origin(origin):
+    return origin in [_origin_numpy(), _origin_pytorch()]
+
+
+def data_origin(eqs_array):
+    """Get the data origin of an eqs_array"""
+    origin = eqs_data_origin_t()
+    eqs_array.origin(eqs_array.ptr, origin)
+    return origin.value
+
+
+def data_origin_name(origin):
+    """Get the name of the data origin of an eqs_array"""
+    from .._c_lib import _get_library
+
+    lib = _get_library()
+
+    return _call_with_growing_buffer(
+        lambda buffer, bufflen: lib.eqs_get_data_origin(origin, buffer, bufflen)
+    )
+
+
+# ============================================================================ #
+
+
+class _RustNDArray(np.ndarray):
+    """
+    Small wrapper class around ``np.ndarray``, adding a reference to a parent
+    Python object that actually owns the memory used inside the array. This
+    prevents the parent from being garbage collected while the ndarray is still
+    alive, thus preventing use-after-free.
+
+    This is intended to be used to wrap Rust-owned memory inside a ndarray,
+    while making sure the memory owner is kept around for long enough.
+
+    This will be registered when loading the equistore library for the first time.
+    """
+
+    def __new__(cls, eqs_array, parent):
+        from .._c_lib import _get_library
+
+        lib = _get_library()
+
+        data = ctypes.POINTER(ctypes.c_double)()
+        shape_ptr = ctypes.POINTER(c_uintptr_t)()
+        shape_count = c_uintptr_t()
+
+        # this requires the data origin of this array is "rust.ndarray", which
+        # is guaranteed by `eqs_array_to_python_object`. This function call will
+        # fail anyway if this is not the case.
+        lib.eqs_get_rust_array(eqs_array, data, shape_ptr, shape_count)
+
+        shape = []
+        for i in range(shape_count.value):
+            shape.append(shape_ptr[i])
+
+        array = _ptr_to_ndarray(data, shape, np.float64)
+        obj = array.view(cls)
+
+        # keep a reference to the parent object (if any) to prevent it from
+        # being garbage-collected too early.
+        obj._parent = parent
+
+        return obj
+
+    def __array_finalize__(self, obj):
+        # keep the parent around when creating sub-views of this array
+        self._parent = getattr(obj, "_parent", None)

--- a/equistore/io.py
+++ b/equistore/io.py
@@ -4,7 +4,7 @@ import numpy as np
 
 from ._c_lib import _get_library
 from .block import TensorBlock
-from .data import _is_numpy_array, _is_torch_array
+from .data.array import _is_numpy_array, _is_torch_array
 from .labels import Labels
 from .tensor import TensorMap
 

--- a/equistore/status.py
+++ b/equistore/status.py
@@ -2,7 +2,6 @@
 from typing import Optional
 
 from ._c_api import EQS_SUCCESS
-from ._c_lib import _get_library
 
 
 class EquistoreError(Exception):
@@ -51,6 +50,8 @@ def _check_pointer(pointer):
 
 def last_error():
     """Get the last error message on this thread"""
+    from ._c_lib import _get_library
+
     lib = _get_library()
     message = lib.eqs_last_error()
     return message.decode("utf8")

--- a/include/equistore.hpp
+++ b/include/equistore.hpp
@@ -589,9 +589,9 @@ public:
     /// DataArrayBase can be copy-assigned
     DataArrayBase& operator=(const DataArrayBase&) = default;
     /// DataArrayBase can be move-constructed
-    DataArrayBase(DataArrayBase&&) = default;
+    DataArrayBase(DataArrayBase&&) noexcept = default;
     /// DataArrayBase can be move-assigned
-    DataArrayBase& operator=(DataArrayBase&&) = default;
+    DataArrayBase& operator=(DataArrayBase&&) noexcept = default;
 
     /// Convert a concrete `DataArrayBase` to a C-compatible `eqs_array_t`
     static eqs_array_t to_eqs_array_t(std::unique_ptr<DataArrayBase> data) {
@@ -814,9 +814,9 @@ public:
     /// SimpleDataArray can be copy-assigned
     SimpleDataArray& operator=(const SimpleDataArray&) = default;
     /// SimpleDataArray can be move-constructed
-    SimpleDataArray(SimpleDataArray&&) = default;
+    SimpleDataArray(SimpleDataArray&&) noexcept = default;
     /// SimpleDataArray can be move-assigned
-    SimpleDataArray& operator=(SimpleDataArray&&) = default;
+    SimpleDataArray& operator=(SimpleDataArray&&) noexcept = default;
 
     eqs_data_origin_t origin() const override {
         eqs_data_origin_t origin = 0;
@@ -1019,9 +1019,9 @@ public:
     /// GradientProxy can be copy-assigned
     GradientProxy& operator=(const GradientProxy&) = default;
     /// GradientProxy can be move-constructed
-    GradientProxy(GradientProxy&&) = default;
+    GradientProxy(GradientProxy&&) noexcept = default;
     /// GradientProxy can be move-assigned
-    GradientProxy& operator=(GradientProxy&&) = default;
+    GradientProxy& operator=(GradientProxy&&) noexcept = default;
 
     /// Get a const view of the data for this gradient
     NDArray<double> data() const {
@@ -1194,12 +1194,12 @@ public:
     }
 
     /// TensorBlock can be move constructed
-    TensorBlock(TensorBlock&& other): TensorBlock() {
+    TensorBlock(TensorBlock&& other) noexcept : TensorBlock() {
         *this = std::move(other);
     }
 
     /// TensorBlock can be moved assigned
-    TensorBlock& operator=(TensorBlock&& other) {
+    TensorBlock& operator=(TensorBlock&& other) noexcept {
         if (!is_view_) {
             eqs_block_free(block_);
         }
@@ -1482,13 +1482,13 @@ public:
     TensorMap& operator=(const TensorMap&) = delete;
 
     /// TensorMap can be move constructed
-    TensorMap(TensorMap&& other): TensorMap(nullptr) {
+    TensorMap(TensorMap&& other) noexcept : TensorMap(nullptr) {
         *this = std::move(other);
     }
 
     /// TensorMap can be move assigned
-    TensorMap& operator=(TensorMap&& other) {
-        details::check_status(eqs_tensormap_free(tensor_));
+    TensorMap& operator=(TensorMap&& other) noexcept {
+        eqs_tensormap_free(tensor_);
 
         this->tensor_ = other.tensor_;
         other.tensor_ = nullptr;

--- a/tests/python/data.py
+++ b/tests/python/data.py
@@ -22,7 +22,7 @@ class TestArrayWrapperMixin:
         eqs_array = wrapper.eqs_array
 
         self.assertEqual(
-            id(data.eqs_array_to_python_object(eqs_array).array),
+            id(data.eqs_array_to_python_array(eqs_array)),
             id(array),
         )
 
@@ -67,7 +67,7 @@ class TestArrayWrapperMixin:
         status = eqs_array.copy(eqs_array.ptr, copy)
         self.assertEqual(status, EQS_SUCCESS)
 
-        array_copy = data.eqs_array_to_python_object(copy).array
+        array_copy = data.eqs_array_to_python_array(copy)
         self.assertNotEqual(id(array_copy), id(array))
 
         self.assertTrue(np.all(np.array(array_copy) == np.array(array)))
@@ -115,7 +115,7 @@ class TestArrayWrapperMixin:
 
 class TestNumpyData(unittest.TestCase, TestArrayWrapperMixin):
     def expected_origin(self):
-        return "equistore.data.numpy"
+        return "equistore.data.array.numpy"
 
     def create_array(self, shape):
         return np.zeros(shape)
@@ -125,7 +125,7 @@ if HAS_TORCH:
 
     class TestTorchData(unittest.TestCase, TestArrayWrapperMixin):
         def expected_origin(self):
-            return "equistore.data.torch"
+            return "equistore.data.array.torch"
 
         def create_array(self, shape):
             return torch.zeros(shape, device="cpu")


### PR DESCRIPTION
The goal is to expose C++ `torch::Tensor` as Python `torch.Tensor` if possible