### PR TITLE
added __getitem()__ and added a check for multiple positional arguments in tensor.block and tensor.blocks

### DIFF
--- a/equistore/tensor.py
+++ b/equistore/tensor.py
@@ -96,6 +96,14 @@ class TensorMap:
         )
         return result
 
+    def __getitem__(self, *args) -> TensorBlock:
+        """This is equivalent to self.block(*args)"""
+        if args and isinstance(args[0], tuple):
+            raise ValueError(
+                f"only one non-keyword argument is supported, {len(args[0])} are given"
+            )
+        return self.block(*args)
+
     @property
     def keys(self) -> Labels:
         """The set of keys labeling the blocks in this tensor map."""
@@ -130,6 +138,10 @@ class TensorMap:
             )
             block = tensor.block(labels)
         """
+        if len(args) > 1:
+            raise ValueError(
+                f"only one non-keyword argument is supported, {len(args)} are given"
+            )
 
         if args and isinstance(args[0], int):
             return self._get_block_by_id(args[0])
@@ -181,6 +193,10 @@ class TensorMap:
             blocks = tensor.blocks(labels)
         """
 
+        if len(args) > 1:
+            raise ValueError(
+                f"only one non-keyword argument is supported, {len(args)} are given"
+            )
         if args and isinstance(args[0], int):
             return [self._get_block_by_id(args[0])]
 
@@ -207,7 +223,9 @@ class TensorMap:
         selection = None
         if args:
             if len(args) > 1:
-                raise ValueError("only one non-keyword argument is supported")
+                raise ValueError(
+                    f"only one non-keyword argument is supported, {len(args)} are given"
+                )
 
             arg = args[0]
             if isinstance(arg, Labels):

--- a/tests/python/tensor.py
+++ b/tests/python/tensor.py
@@ -57,6 +57,10 @@ keys: ['key_1' 'key_2']
         block = tensor.block(2)
         self.assertTrue(np.all(block.values == np.full((4, 3, 1), 3.0)))
 
+        # block by index with __getitem__
+        block = tensor[2]
+        self.assertTrue(np.all(block.values == np.full((4, 3, 1), 3.0)))
+
         # block by kwargs
         block = tensor.block(key_1=1, key_2=0)
         self.assertTrue(np.all(block.values == np.full((3, 1, 1), 2.0)))
@@ -64,6 +68,47 @@ keys: ['key_1' 'key_2']
         # block by Label entry
         block = tensor.block(tensor.keys[0])
         self.assertTrue(np.all(block.values == np.full((3, 1, 1), 1.0)))
+
+        # block by Label entry with __getitem__
+        block = tensor[tensor.keys[0]]
+        self.assertTrue(np.all(block.values == np.full((3, 1, 1), 1.0)))
+
+        # More arguments than needed: two integers
+        # by index
+        with self.assertRaises(ValueError) as cm:
+            tensor.block(3, 4)
+
+        self.assertEqual(
+            str(cm.exception),
+            "only one non-keyword argument is supported, 2 are given",
+        )
+
+        # 4 input with the first as integer by __getitem__
+        with self.assertRaises(ValueError) as cm:
+            tensor[3, 4, 7.0, "r"]
+
+        self.assertEqual(
+            str(cm.exception),
+            "only one non-keyword argument is supported, 4 are given",
+        )
+
+        # More arguments than needed: 3 Labels
+        with self.assertRaises(ValueError) as cm:
+            tensor.block(tensor.keys[0], tensor.keys[1], tensor.keys[3])
+
+        self.assertEqual(
+            str(cm.exception),
+            "only one non-keyword argument is supported, 3 are given",
+        )
+
+        # by __getitem__
+        with self.assertRaises(ValueError) as cm:
+            tensor[tensor.keys[1], 4]
+
+        self.assertEqual(
+            str(cm.exception),
+            "only one non-keyword argument is supported, 2 are given",
+        )
 
         # 0 blocks matching criteria
         with self.assertRaises(ValueError) as cm:


### PR DESCRIPTION
-- added a few checks in the length of `args` before `tensor.block(0,5)==tensor.block(0)`, because it checked only that the first argument was an `int` and then returned the result. Now the code raises an error:

`raise ValueError(
    f"only one non-keyword argument is supported, {len(args)} are given"
)`

This behaviour was actually true only if the first positional argument was an `int` because a similar check was done by the `blocks_matching` function, which was not called if `args[0]` was `int`. I also left the check inside `blocks_matching` even though now it is probably never called.

-- added the `__getitem__()` function to `TensorMap`.
  Now, `tensor[0]` gives the same result of `tensor.block(0)`
  it works also for keys: `tensor[tensor.keys[0]]` is equivalent to `tensor.block(tensor.keys[0])`. Different behaviour if no input is given:
```
     tensor[] 
           ^ 
SyntaxError: invalid syntax
```
while 
```
tensor.block()
  File "/Users/davidetisi/Documents/EPFL_postdoc/equistore/.tox/tests/lib/python3.10/site-packages/equistore/tensor.py", line 161, in block
    raise ValueError(
ValueError: more than one block matched {}, use `TensorMap.blocks` if you want to get all of them

```

tensor.block() fails because it selects all the blocks, e.g. tensor.blocks() gives all the block
I think this difference is acceptable.

I added tests for the additions above.