### PR TITLE
Added workflow for ReadTheDocs

### DIFF
--- a/.github/workflows/comment-wheels-pr.yml
+++ b/.github/workflows/comment-wheels-pr.yml
@@ -47,10 +47,15 @@ jobs:
             if (!artifacts.length) {
                 return core.error(`No artifacts found`);
             }
-            let body = `Download the artifacts for this pull request:\n`;
-            for (const art of artifacts) {
-                body += `\n* [${art.name}.zip](https://nightly.link/${owner}/${repo}/actions/artifacts/${art.id}.zip)`;
+
+            if (artifacts.length !== 1) {
+                return core.error(`more than one artifact found`);
             }
+            const link = `https://nightly.link/${owner}/${repo}/actions/artifacts/${artifacts[0].id}.zip`
+
+            let body = `Here is a pre-built version of the code in this pull request: [wheels.zip](link), `;
+            body += 'you can install it locally by unzipping `wheels.zip` and using `pip` to install the file matching your system';
+
             core.info("Review thread message body:", body);
             for (const pr of pull_requests) {
                 await insertUpdateComment(owner, repo, pr.number, "link-to-wheels", body);

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -48,3 +48,38 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./gh-pages/
           force_orphan: true
+
+      - name: post link to RTD
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v5
+        with:
+          script: |
+            async function insertUpdateComment(owner, repo, issue_number, purpose, body) {
+                const {data: comments} = await github.rest.issues.listComments(
+                    {owner, repo, issue_number}
+                );
+                const marker = `<!-- bot: ${purpose} -->`;
+                body = marker + "\n" + body;
+                const existing = comments.filter((c) => c.body.includes(marker));
+                if (existing.length > 0) {
+                    const last = existing[existing.length - 1];
+                    core.info(`Updating comment ${last.id}`);
+                    await github.rest.issues.updateComment({
+                        owner, repo,
+                        body,
+                        comment_id: last.id,
+                    });
+                } else {
+                    core.info(`Creating a comment in issue / PR #${issue_number}`);
+                    await github.rest.issues.createComment({issue_number, body, owner, repo});
+                }
+            }
+
+            const {owner, repo} = context.repo;
+            const pr = ${{ toJSON(github.event.pull_request) }};
+
+            let body = 'The documentation for this PR is (or will soon be) available on readthedocs: ';
+            body += `https://equistore--${pr.number}.org.readthedocs.build/en/${pr.number}/`;
+            core.info("Review thread message body:", body);
+
+            await insertUpdateComment(owner, repo, pr.number, "link-to-PR-docs", body);

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -78,7 +78,7 @@ jobs:
             const {owner, repo} = context.repo;
             const pr = ${{ toJSON(github.event.pull_request) }};
 
-            let body = 'The documentation for this PR is (or will soon be) available on readthedocs: ';
+            let body = 'The documentation for this pull request is (or will soon be) available on readthedocs: ';
             body += `https://equistore--${pr.number}.org.readthedocs.build/en/${pr.number}/`;
             core.info("Review thread message body:", body);
 

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,24 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools we need
+build:
+  os: ubuntu-22.04
+  apt_packages:
+    - cmake
+  tools:
+    python: "3.8"
+    rust: "1.61"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+   configuration: docs/src/conf.py
+
+# Declare the Python requirements required to build the docs
+python:
+   install:
+   - requirements: docs/requirements.txt


### PR DESCRIPTION
Same as in [rascaline](https://github.com/Luthaf/rascaline/pull/102), this PR adds the necessary config for a Readthedocs (RTD) workflow. With RTD the docs are build for every PR and can be inspected without checking out the code locally..