### PR TITLE
Rename TensorMap::block_mut to TensorMap::block_mut_by_id

### DIFF
--- a/src/labels.rs
+++ b/src/labels.rs
@@ -264,6 +264,11 @@ impl Labels {
         return builder.finish();
     }
 
+    /// Create a set of `Labels` with the given names, containing no entries.
+    pub fn empty(names: Vec<&str>) -> Labels {
+        return LabelsBuilder::new(names).finish()
+    }
+
     /// Create a set of `Labels` containing a single entry, to be used when
     /// there is no relevant information to store.
     pub fn single() -> Labels {
@@ -295,7 +300,7 @@ impl Labels {
     }
 
     /// Check if this set of Labels is empty (contains no entry)
-    pub fn empty(&self) -> bool {
+    pub fn is_empty(&self) -> bool {
         self.count() == 0
     }
 

--- a/src/tensor/mod.rs
+++ b/src/tensor/mod.rs
@@ -154,8 +154,26 @@ impl TensorMap {
         &self.blocks
     }
 
-    /// Get read-write access to the block at the given index in this `TensorMap`
-    pub fn block_mut(&mut self, index: usize) -> TensorBlockRefMut<'_> {
+    /// Get mutable access to the list of blocks in this `TensorMap`
+    pub fn blocks_mut(&mut self) -> &mut [TensorBlock] {
+        &mut self.blocks
+    }
+
+    /// Get a reference to the block with the given id
+    ///
+    /// # Panics
+    ///
+    /// If the id is larger than the number of blocks
+    pub fn block_by_id(&self, id: usize) -> &TensorBlock {
+        return &self.blocks[id];
+    }
+
+    /// Get a mutable reference to the block with the given id
+    ///
+    /// # Panics
+    ///
+    /// If the id is larger than the number of blocks
+    pub fn block_mut_by_id(&mut self, index: usize) -> TensorBlockRefMut<'_> {
         self.blocks[index].as_mut()
     }
 
@@ -251,15 +269,6 @@ impl TensorMap {
     /// matching block.
     pub fn block(&self, selection: &Labels) -> Result<&TensorBlock, Error> {
         return Ok(&self.blocks[self.block_matching(selection)?]);
-    }
-
-    /// Get a reference to the block with the given id
-    ///
-    /// # Panics
-    ///
-    /// If the id is larger than the number of blocks
-    pub fn block_by_id(&self, id: usize) -> &TensorBlock {
-        return &self.blocks[id];
     }
 
     /// Move the given variables from the component labels to the property labels


### PR DESCRIPTION
Follow up to #60, for consistency in the methods naming