### PR TITLE
Editing error in rascaline hypers (gradients)

### DIFF
--- a/python/tests/data/README.md
+++ b/python/tests/data/README.md
@@ -1,8 +1,8 @@
 # Tests data files for equistore-models
 
 - **qm7-spherical-expansion**: SOAP spherical expansion for the first 10
-  structures in QM7, computed with rascaline (commit 81218aca) and the following
-  hyper-parameters:
+  structures in QM7, computed with rascaline (commit 81218aca), with 'cell'
+  and 'positions' gradients, using the following hyper-parameters:
 
 ```py
 cutoff=3.5,
@@ -11,14 +11,14 @@ max_angular=4,
 atomic_gaussian_width=0.3,
 radial_basis={"Gto": {}},
 center_atom_weight=1.0,
-gradients=True,
 cutoff_function={"ShiftedCosine": {"width": 0.5}},
 ```
 
 
+
 - **qm7-power-spectrum**: SOAP power spectrum for the first 10 structures in
-  QM7, computed with rascaline (commit 81218aca) and the following
-  hyper-parameters:
+  QM7, computed with rascaline (commit 81218aca), with 'cell' and 'positions'
+  gradients, using the following hyper-parameters:
 
 ```py
 cutoff=3.5,
@@ -27,6 +27,5 @@ max_angular=4,
 atomic_gaussian_width=0.3,
 radial_basis={"Gto": {}},
 center_atom_weight=1.0,
-gradients=True,
 cutoff_function={"ShiftedCosine": {"width": 0.5}},
 ```

--- a/python/tests/data/README.md
+++ b/python/tests/data/README.md
@@ -11,7 +11,7 @@ max_angular=4,
 atomic_gaussian_width=0.3,
 radial_basis={"Gto": {}},
 center_atom_weight=1.0,
-gradients=False,
+gradients=True,
 cutoff_function={"ShiftedCosine": {"width": 0.5}},
 ```
 
@@ -27,6 +27,6 @@ max_angular=4,
 atomic_gaussian_width=0.3,
 radial_basis={"Gto": {}},
 center_atom_weight=1.0,
-gradients=False,
+gradients=True,
 cutoff_function={"ShiftedCosine": {"width": 0.5}},
 ```


### PR DESCRIPTION
The data files used for unit tests:

- qm7-power-spectrum.npz
- qm7-spherical-expansion.npz

were reported in the rascaline hypers in the README to have no gradients calculated, but in fact have both 'cell' and 'positions' gradients calculated.

These hypers will also need updating to reflect the new format used in Rascaline, but this will be raised in another issue.

Closes #76