### PR TITLE
Tensor slice functions and unit tests

### DIFF
--- a/docs/src/reference/python/operations/index.rst
+++ b/docs/src/reference/python/operations/index.rst
@@ -14,6 +14,7 @@ Operations
     allclose() <allclose>
     dot() <dot>
     lstsq() <lstsq>
+    slice() <slice>
     solve() <solve>
 
     sum_over_samples() and mean_over_samples() <samples-reduction>

--- a/docs/src/reference/python/operations/slice.rst
+++ b/docs/src/reference/python/operations/slice.rst
@@ -1,0 +1,6 @@
+slice
+======
+
+.. autofunction:: equistore.operations.slice
+    
+.. autofunction:: equistore.operations.slice_block

--- a/python/src/equistore/operations/__init__.py
+++ b/python/src/equistore/operations/__init__.py
@@ -17,6 +17,7 @@ from .dot import dot  # noqa
 from .lstsq import lstsq  # noqa
 from .reduce_over_samples import sum_over_samples, mean_over_samples  # noqa
 from .remove_gradients import remove_gradients  # noqa
+from .slice import slice, slice_block  # noqa
 from .solve import solve  # noqa
 
 __all__ = [
@@ -28,6 +29,8 @@ __all__ = [
     "lstsq",
     "mean_over_samples",
     "remove_gradients",
+    "slice",
+    "slice_block",
     "solve",
     "sum_over_samples",
 ]

--- a/python/src/equistore/operations/slice.py
+++ b/python/src/equistore/operations/slice.py
@@ -1,0 +1,399 @@
+import warnings
+
+import numpy as np
+
+from ..tensor import TensorMap
+from ..block import TensorBlock
+from ..labels import Labels
+
+
+def slice(tensormap: TensorMap, samples_to_slice=None, properties_to_slice=None):
+    """
+    Slices an input :py:class:`TensorMap` along the samples and/or properties
+    dimension(s). ``samples_to_slice`` and ``properties_to_slice`` are
+    :py:class:`Labels` objects that specify the samples/properties
+    (respectively) names and indices that should be sliced, i.e. kept in the
+    output tensor.
+
+    Note that either ``samples_to_slice`` or ``properties_to_slice``, or both,
+    should be specified as input.
+
+    .. code-block:: python
+
+        sliced_tensormap = slice(
+            tensormap,
+            samples=Labels(
+                names=["structure", "center"],
+                values=np.array(
+                    [[0, 1], [0, 6], [1, 6], [3, 16]]
+                ),  # must be a 2D-array
+            )
+            properties=Labels(
+                names=["n",],  # radial channel
+                values=np.array([[3,], [4,], [5,]]),
+            )
+        )
+
+    Also note that this function will return a :py:class:`TensorMap` whose
+    blocks are of equal or smaller dimensions (due to slicing) than those of the
+    input. However, the returned :py:class:`TensorMap` will be returned with the
+    same number of blocks and the corresponding keys as the input. If any block
+    upon slicing is reduced to nothing, i.e. in the case that it has none of the
+    specified ``samples_to_slice`` or ``properties_to_slice``, an empty block
+    will be returned but will still be accessible by its key. User warnings will
+    be issued if any blocks are sliced to contain no values.
+
+    For the empty blocks that may be returned, although there will be no actual
+    values in its ``TensorBlock.values`` array, the shape of this array will be
+    non-zero in the dimensions that haven't been sliced. This allows the slicing
+    of dimensions to be tracked.
+
+    For example, if a TensorBlock of shape (52, 1, 5) is passed, and only some
+    samples are specified to be sliced but none of these appear in the input
+    TesnorBlock, the returned TensorBlock values array will be empty, but its
+    shape will be (0, 1, 5) - i.e. the samples dimension has been sliced to zero
+    but the components and properties dimensions remain in-tact. The same logic
+    applies to any Gradient TensorBlocks the input TensorBlock may have
+    associated with it.
+
+    See the documentation for the :py:func:`slice_block` function to see how an
+    individual :py:class:`TensorBlock` is sliced.
+
+    :param tensor: the input :py:class:`TensorMap` to be sliced.
+    :param samples_to_slice: a :py:class:`Labels` object containing the names
+        and indices of samples to keep in the each of the sliced
+        :py:class:`TensorBlock` of the output :py:class:`TensorMap`. Default
+        value of None indicates no slicing along the samples dimension should
+        occur.
+    :param properties_to_slice: a :py:class:`Labels` object containing the names
+        and indices of properties to keep in each of the sliced
+        :py:class:`TensorBlock` of the output :py:class:`TensorMap`. Default
+        value of None indicates no slicing along the properties dimension should
+        occur.
+
+    :return: a :py:class:`TensorMap` that corresponds to the sliced input
+        tensor.
+    """
+
+    # Perform input checks
+    if not isinstance(tensormap, TensorMap):
+        raise TypeError(
+            "Input tensor must be an equistore `TensorMap` object."
+            + " If attempting to slice an equistore `TensorBlock`,"
+            + " use the `slice_block()` function instead."
+        )
+    if samples_to_slice is None and properties_to_slice is None:
+        raise ValueError(
+            "Must specify either some samples or properties (or both) to slice by."
+        )
+    if samples_to_slice is not None:
+        if not isinstance(samples_to_slice, Labels):
+            raise TypeError(
+                "samples_to_slice must be passed as a equistore `Labels` object."
+            )
+        sample_names = tensormap.sample_names
+        for name in samples_to_slice.names:
+            if name not in sample_names:
+                raise ValueError(
+                    "Invalid sample name '"
+                    + name
+                    + "' - doesn't exist in input `TensorMap`."
+                )
+    if properties_to_slice is not None:
+        if not isinstance(properties_to_slice, Labels):
+            raise TypeError(
+                "properties_to_slice must be passed as a equistore `Labels` object."
+            )
+        property_names = tensormap.property_names
+        for name in properties_to_slice.names:
+            if name not in property_names:
+                raise ValueError(
+                    "Invalid property name '"
+                    + name
+                    + "' - doesn't exist in input `TensorMap`."
+                )
+
+    # Slice TensorMap
+    sliced_tensormap = _slice_tensormap(
+        tensormap,
+        samples_to_slice=samples_to_slice,
+        properties_to_slice=properties_to_slice,
+    )
+
+    # Calculate which blocks have been sliced to now be empty. True if any
+    # dimension of block.values is 0, False otherwise.
+    empty_blocks = np.array(
+        [np.any(np.array(block.values.shape) == 0) for _, block in sliced_tensormap]
+    )
+
+    # Issue warnings if some or all of the blocks are now empty.
+    if np.any(empty_blocks):
+        if np.all(empty_blocks):
+            warnings.warn(
+                "\nAll TensorBlocks in the sliced TensorMap are now empty, "
+                + "based on your choice of samples and/or properties to slice by. "
+            )
+        else:
+            warnings.warn(
+                "\nSome TensorBlocks in the sliced TensorMap are now empty, "
+                + "based on your choice of samples and/or properties to slice by. "
+                + "The keys of the empty TensorBlocks are:\n"
+                + str(tensormap.keys[empty_blocks])
+            )
+
+    return sliced_tensormap
+
+
+def slice_block(
+    tensorblock: TensorBlock,
+    samples_to_slice=None,
+    properties_to_slice=None,
+) -> TensorBlock:
+    """
+    Slices an input :py:class:`TensorBlock` along the samples and/or properties
+    dimension(s). ``samples_to_slice`` and ``properties_to_slice`` are
+    :py:class:`Labels` objects that specify the samples/properties
+    (respectively) names and indices that should be sliced, i.e. kept in the
+    output :py:class:`TensorBlock`.
+
+    Note that either ``samples_to_slice`` or ``properties_to_slice``, or both,
+    should be specified as input.
+
+    Example: take an input :py:class:`TensorBlock` of shape (100, 1, 6), where
+    there are 100 'samples', 1 'components', and 6 'properties'. Say we want to
+    slice this tensor along the samples and properties dimensions. As in the
+    code-block below, we can specify, for example, 4 samples and 3 properties
+    indices to keep. The returned :py:class:`TensorBlock` will have shape (4, 1,
+    3).
+
+    .. code-block:: python
+
+        sliced_tensorblock = slice_block(
+            tensorblock,
+            samples=Labels(
+                names=["structure", "center"],
+                values=np.array(
+                    [[0, 1], [0, 6], [1, 6], [3, 16]]
+                ),  # must be a 2D-array
+            )
+            properties=Labels(
+                names=["n",],  # radial channel
+                values=np.array([[3], [4], [5]]),
+            )
+        )
+
+    For the empty blocks that may be returned, although there will be no actual
+    values in its TensorBlock.values tensor, the shape of this tensor will be
+    non-zero in the dimensions that haven't been sliced. This is created by
+    slicing the input TensorBlock, as opposed to just returning an
+    artificially-created empty one (with no shape or dimensions), and is
+    intentional. It allows the slicing of dimensions to be tracked.
+
+    For instance, if a TensorBlock of shape (52, 1, 5) is passed, and only some
+    samples are specified to be sliced but none of these appear in the input
+    TesnorBlock, the returned TensorBlock values array will be empty, but its
+    shape will be (0, 1, 5) - i.e. the samples dimension has been sliced to zero
+    but the components and properties dimensions remain in-tact. The same logic
+    applies to any Gradient TensorBlocks the input TensorBlock may have
+    associated with it.
+
+    :param tensorblock: the input :py:class:`TensorBlock` to be sliced.
+    :param samples_to_slice: a :py:class:`Labels` object containing the names
+        and indices of samples to keep in the sliced output
+        :py:class:`TensorBlock`. Default value of None indicates no slicing
+        along the samples dimension should occur.
+    :param properties_to_slice: a :py:class:`Labels` object containing the names
+        and indices of properties to keep in the sliced output
+        :py:class:`TensorBlock`. Default value of None indicates no slicing
+        along the properties dimension should occur.
+
+    :return new_block: a :py:class:`TensorBlock` that corresponds to the sliced
+        input.
+    """
+
+    # Perform input checks
+    if not isinstance(tensorblock, TensorBlock):
+        raise TypeError(
+            "Input tensor must be an equistore `TensorBlock` object."
+            + " If attempting to slice an equistore `TensorMap`,"
+            + " use the `slice()` function instead."
+        )
+    if samples_to_slice is None and properties_to_slice is None:
+        raise ValueError(
+            "Must specify either some samples or properties (or both) to slice by."
+        )
+    if samples_to_slice is not None:
+        if not isinstance(samples_to_slice, Labels):
+            raise TypeError(
+                "samples_to_slice must be passed as a equistore.Labels object."
+            )
+        sample_names = tensorblock.samples.names
+        for name in samples_to_slice.names:
+            if name not in sample_names:
+                raise ValueError(
+                    "Invalid sample name '"
+                    + name
+                    + "' - doesn't exist in input `TensorBlock`."
+                )
+    if properties_to_slice is not None:
+        if not isinstance(properties_to_slice, Labels):
+            raise TypeError(
+                "properties_to_slice must be passed as a equistore.Labels object."
+            )
+        property_names = tensorblock.properties.names
+        for name in properties_to_slice.names:
+            if name not in property_names:
+                raise ValueError(
+                    "Invalid property name '"
+                    + name
+                    + "' - doesn't exist in input `TensorBlock`."
+                )
+
+    # Slice TensorMap and issue warning if the output block is empty
+    sliced_tensorblock = _slice_tensorblock(
+        tensorblock,
+        samples_to_slice=samples_to_slice,
+        properties_to_slice=properties_to_slice,
+    )
+    if np.any(np.array(sliced_tensorblock.values.shape) == 0):
+        warnings.warn(
+            "Your input TensorBlock is now empty, based on your choice of samples "
+            + "and/or properties to slice by. "
+        )
+
+    return sliced_tensorblock
+
+
+def _slice_tensorblock(
+    tensorblock: TensorBlock, samples_to_slice=None, properties_to_slice=None
+) -> TensorBlock:
+    """
+    Slices an input :py:class:`TensorBlock` along the samples and/or properties
+    dimension(s). ``samples_to_slice`` and ``properties_to_slice`` are
+    :py:class:`Labels` objects that specify the samples/properties
+    (respectively) names and indices that should be sliced, i.e. kept in the
+    output :py:class:`TensorBlock`.
+
+    Note that either ``samples_to_slice`` or ``properties_to_slice``, or both,
+    should be specified as input.
+
+    :param tensorblock: the input :py:class:`TensorBlock` to be sliced.
+    :param samples_to_slice: a :py:class:`Labels` object containing the names
+        and indices of samples to keep in the sliced output
+        :py:class:`TensorBlock`. Default value of None indicates no slicing
+        along the samples dimension should occur.
+    :param properties_to_slice: a :py:class:`Labels` object containing the names
+        and indices of properties to keep in the sliced output
+        :py:class:`TensorBlock`. Default value of None indicates no slicing
+        along the properties dimension should occur.
+
+    :return new_block: a :py:class:`TensorBlock` that corresponds to the sliced
+        input.
+    """
+
+    new_values = tensorblock.values
+    new_samples = tensorblock.samples
+    new_properties = tensorblock.properties
+
+    # Generate arrays of bools indicating which samples indices to keep upon slicing.
+    if samples_to_slice is not None:
+        samples = tensorblock.samples[list(samples_to_slice.names)].tolist()
+        set_samples_to_slice = set(samples_to_slice.tolist())
+        samples_filter = np.array(
+            [sample in set_samples_to_slice for sample in samples]
+        )
+        new_values = new_values[samples_filter]
+        new_samples = new_samples[samples_filter]
+
+    # Generate array of bools indicating which properties indices to keep upon slicing.
+    if properties_to_slice is not None:
+        properties = tensorblock.properties[list(properties_to_slice.names)].tolist()
+        set_properties_to_slice = set(properties_to_slice.tolist())
+        properties_filter = np.array(
+            [prop in set_properties_to_slice for prop in properties]
+        )
+        new_values = new_values[..., properties_filter]
+        new_properties = new_properties[properties_filter]
+
+    # Create a new TensorBlock, sliced along the samples and properties dimension.
+    new_block = TensorBlock(
+        values=new_values,
+        samples=new_samples,
+        components=tensorblock.components,
+        properties=new_properties,
+    )
+
+    # Create a list of numeric indices of the samples that were sliced. Needed to
+    # create filters for Gradient TensorBlocks as there isn't a one-to-one mapping
+    # between samples of the parent TensorBlock and its Gradients. This doesn't
+    # need to be done for properties as the mapping is by definition a one-to-one.
+    if samples_to_slice is not None:
+        set_samples_idxs_to_slice = set(
+            i for i, val in enumerate(samples_filter) if val
+        )
+
+    # Slice each Gradient TensorBlock and add to the new_block.
+    for parameter, gradient in tensorblock.gradients():
+
+        new_grad_data = gradient.data
+        new_grad_samples = gradient.samples
+
+        # Create a samples filter for the Gradient TensorBlock
+        if samples_to_slice is not None:
+            grad_samples = gradient.samples["sample"].tolist()
+            grad_samples_filter = np.array(
+                [grad_samp in set_samples_idxs_to_slice for grad_samp in grad_samples]
+            )
+            new_grad_samples = new_grad_samples[grad_samples_filter]
+            new_grad_data = new_grad_data[grad_samples_filter]
+        if properties_to_slice is not None:
+            new_grad_data = new_grad_data[..., properties_filter]
+
+        # Add sliced Gradient to the TensorBlock
+        new_block.add_gradient(
+            parameter=parameter,
+            samples=new_grad_samples,
+            components=gradient.components,
+            data=new_grad_data,
+        )
+
+    return new_block
+
+
+def _slice_tensormap(
+    tensormap: TensorMap, samples_to_slice=None, properties_to_slice=None
+) -> TensorMap:
+    """
+    Slices an input :py:class:`TensorMap` along the samples and/or properties
+    dimension(s). ``samples_to_slice`` and ``properties_to_slice`` are
+    :py:class:`Labels` objects that specify the samples/properties
+    (respectively) names and indices that should be sliced, i.e. kept in the
+    output tensor.
+
+    Note that either ``samples_to_slice`` or ``properties_to_slice``, or both,
+    should be specified as input.
+
+    :param tensor: the input :py:class:`TensorMap` to be sliced.
+    :param samples_to_slice: a :py:class:`Labels` object containing the names
+        and indices of samples to keep in the sliced :py:class:`TensorBlock`
+        output, or each of the sliced :py:class:`TensorBlock` objects of the
+        output :py:class:`TensorMap`. Default value of None indicates no slicing
+        along the samples dimension should occur.
+    :param properties_to_slice: a :py:class:`Labels` object containing the names
+        and indices of properties to keep in the sliced :py:class:`TensorBlock`
+        output, or each of the sliced :py:class:`TensorBlock` objects of the
+        output :py:class:`TensorMap`. Default value of None indicates no slicing
+        along the properties dimension should occur.
+
+    :return: a :py:class:`TensorMap` that corresponds to the sliced input
+        tensor.
+    """
+
+    # Iterate over, and slice, each block (+ gradients) of the input TensorMap in turn.
+    return TensorMap(
+        keys=tensormap.keys,
+        blocks=[
+            _slice_tensorblock(block, samples_to_slice, properties_to_slice)
+            for _, block in tensormap
+        ],
+    )

--- a/python/tests/operations/slice.py
+++ b/python/tests/operations/slice.py
@@ -1,0 +1,816 @@
+import os
+import unittest
+
+import numpy as np
+
+import equistore.io
+import equistore.operations as fn
+from equistore import Labels, TensorBlock, TensorMap
+
+DATA_ROOT = os.path.join(os.path.dirname(__file__), "..", "data")
+TEST_FILE = "qm7-spherical-expansion.npz"
+
+
+class TestSlice(unittest.TestCase):
+    """
+    Unit tests for the slice functions.
+    Tests are organised into several 'Test Blocks' as follows:
+        1) Slicing samples dimension of tensors without gradients.
+        2) Slicing samples dimension of tensors with gradients.
+        3) Slicing properties dimension of tensors without gradients.
+        4) Slicing properties dimension of tensors with gradients.
+        5) Slicing samples and properties dimensions simultaneously.
+        6) Testing the type handling of the user-facing slice function.
+        7) Checking issuance of user warnings when empty blocks are
+            created.
+    """
+
+    # TEST BLOCK 1: SLICING SAMPLES WITHOUT GRADIENTS
+
+    def test_slice_samples_tensorblock_no_gradients(self):
+        tensormap = equistore.io.load(
+            os.path.join(DATA_ROOT, TEST_FILE),
+            use_numpy=True,
+        )
+        # Remove the gradients to simplify test
+        tensormap = fn.remove_gradients(tensormap)
+        # Define a single block to test
+        tensorblock = tensormap.block(0)
+        # Slice only 'structures' 2, 4, 6, 8
+        structures_to_keep = np.arange(2, 10, 2).reshape(-1, 1)
+        samples_to_slice = Labels(
+            names=["structure"],
+            values=structures_to_keep,
+        )
+        sliced_tensorblock = fn.slice_block(
+            tensorblock,
+            samples_to_slice=samples_to_slice,
+        )
+        # Check 1: no slicing of properties has occurred
+        self.assertTrue(
+            tensorblock.properties.asarray().shape,
+            sliced_tensorblock.properties.asarray().shape,
+        )
+        # Check 2: samples have been sliced to the correct dimension
+        self.assertEqual(
+            len(sliced_tensorblock.samples),
+            len(
+                [
+                    struct_i
+                    for struct_i in tensorblock.samples["structure"]
+                    if struct_i in structures_to_keep
+                ]
+            ),
+        )
+        # Check 3: samples in sliced block only feature desired strutcure indices
+        self.assertTrue(
+            np.all(
+                [
+                    struct_i in structures_to_keep
+                    for struct_i in sliced_tensorblock.samples["structure"]
+                ]
+            )
+        )
+        # Check 4: no components have been sliced
+        for i, comp in enumerate(sliced_tensorblock.components):
+            self.assertEqual(len(comp), len(tensorblock.components[i]))
+
+    def test_slice_samples_tensormap_no_gradients(self):
+        tensormap = equistore.io.load(
+            os.path.join(DATA_ROOT, TEST_FILE),
+            use_numpy=True,
+        )
+        # Remove the gradients to simplify test
+        tensormap = fn.remove_gradients(tensormap)
+        # Slice only 'structures' 2, 4, 6, 8
+        structures_to_keep = np.arange(2, 10, 2).reshape(-1, 1)
+        samples_to_slice = Labels(
+            names=["structure"],
+            values=structures_to_keep,
+        )
+        sliced_tensormap = fn.slice(
+            tensormap,
+            samples_to_slice=samples_to_slice,
+        )
+        for i, (key, block) in enumerate(tensormap):
+            # Check 1: no slicing of properties has occurred
+            self.assertEqual(
+                sliced_tensormap.block(i).properties.asarray().shape,
+                block.properties.asarray().shape,
+            )
+            # Check 2: samples have been sliced to the correct dimension
+            self.assertEqual(
+                len(sliced_tensormap.block(i).samples),
+                len(
+                    [
+                        struct_i
+                        for struct_i in block.samples["structure"]
+                        if struct_i in structures_to_keep
+                    ]
+                ),
+            )
+            # Check 3: samples in sliced block only feature desired structure indices
+            self.assertTrue(
+                np.all(
+                    [
+                        struct_i in structures_to_keep
+                        for struct_i in sliced_tensormap.block(i).samples["structure"]
+                    ]
+                )
+            )
+            # Check 4: no components have been sliced
+            for j, comp in enumerate(block.components):
+                self.assertEqual(
+                    len(comp), len(sliced_tensormap.block(i).components[j])
+                )
+
+        # Check 5: all the keys in the sliced tensormap are in the original
+        self.assertTrue(
+            np.all([key in tensormap.keys for key in sliced_tensormap.keys])
+        )
+
+    def test_slice_samples_tensorblock_empty_no_gradients(self):
+        tensormap = equistore.io.load(
+            os.path.join(DATA_ROOT, TEST_FILE),
+            use_numpy=True,
+        )
+        # Remove the gradients to simplify test
+        tensormap = fn.remove_gradients(tensormap)
+        # Define a single block to test
+        tensorblock = tensormap.block(0)
+        # Slice only 'structures' -1 (i.e. a sample that doesn't exist in the data)
+        structures_to_keep = np.array([-1]).reshape(-1, 1)
+        samples_to_slice = Labels(
+            names=["structure"],
+            values=structures_to_keep,
+        )
+        sliced_tensorblock = fn.slice_block(
+            tensorblock,
+            samples_to_slice=samples_to_slice,
+        )
+        # Check 1: returned tensorblock has no values
+        self.assertTrue(len(sliced_tensorblock.values.flatten()) == 0)
+
+        # Check 2: returned tensorblock has dimension zero for samples
+        self.assertTrue(sliced_tensorblock.values.shape[0] == 0)
+
+        # Check 3: returned tensorblock has original dimension for properties
+        self.assertEqual(
+            sliced_tensorblock.values.shape[-1], tensorblock.values.shape[-1]
+        )
+
+    def test_slice_samples_tensormap_empty_no_gradients(self):
+        tensormap = equistore.io.load(
+            os.path.join(DATA_ROOT, TEST_FILE),
+            use_numpy=True,
+        )
+        # Remove the gradients to simplify test
+        tensormap = fn.remove_gradients(tensormap)
+        # Slice only 'structures' -1 (i.e. a sample that doesn't exist in the data)
+        structures_to_keep = np.array([-1]).reshape(-1, 1)
+        samples_to_slice = Labels(
+            names=["structure"],
+            values=structures_to_keep,
+        )
+        sliced_tensormap = fn.slice(
+            tensormap,
+            samples_to_slice=samples_to_slice,
+        )
+        for _, block in sliced_tensormap:
+            # Check 1: all blocks are empty
+            self.assertEqual(len(block.values.flatten()), 0)
+
+        # Check 2: all the original keys are kept in the output tensormap
+        self.assertTrue(
+            np.all([key in sliced_tensormap.keys for key in tensormap.keys])
+        )
+
+    # TEST BLOCK 2: SLICING SAMPLES WITH GRADIENTS
+
+    def test_slice_samples_tensorblock_gradients(self):
+        tensormap = equistore.io.load(
+            os.path.join(DATA_ROOT, TEST_FILE),
+            use_numpy=True,
+        )
+        # Define a single block to test
+        tensorblock = tensormap.block(0)
+        # Slice only 'structures' 2, 4, 6, 8
+        structures_to_keep = np.arange(2, 10, 2).reshape(-1, 1)
+        samples_to_slice = Labels(
+            names=["structure"],
+            values=structures_to_keep,
+        )
+        sliced_tensorblock = fn.slice_block(
+            tensorblock,
+            samples_to_slice=samples_to_slice,
+        )
+        for i, (parameter, gradient) in enumerate(sliced_tensorblock.gradients()):
+            # Check 1: no slicing of properties has occurred
+            self.assertEqual(
+                list(tensorblock.gradients())[i][1].properties.asarray().shape,
+                gradient.properties.asarray().shape,
+            )
+            # Check 2: samples have been sliced to the correct dimension
+            self.assertEqual(
+                len(sliced_tensorblock.samples),
+                len(
+                    [
+                        struct_i
+                        for struct_i in tensorblock.samples["structure"]
+                        if struct_i in structures_to_keep
+                    ]
+                ),
+            )
+            # Check 3: samples in sliced block only feature desired structure indices
+            self.assertTrue(
+                np.all(
+                    [
+                        struct_i in structures_to_keep
+                        for struct_i in sliced_tensorblock.samples["structure"]
+                    ]
+                )
+            )
+            # Check 4: same number of components as original
+            self.assertEqual(
+                len(gradient.components),
+                len(list(tensorblock.gradients())[i][1].components),
+            )
+
+    def test_slice_samples_tensorblock_empty_gradients(self):
+        tensormap = equistore.io.load(
+            os.path.join(DATA_ROOT, TEST_FILE),
+            use_numpy=True,
+        )
+        # Define a single block to test
+        tensorblock = tensormap.block(0)
+        # Slice only 'structures' -1 (i.e. a sample that doesn't exist in the data)
+        structures_to_keep = np.array([-1]).reshape(-1, 1)
+        samples_to_slice = Labels(
+            names=["structure"],
+            values=structures_to_keep,
+        )
+        sliced_tensorblock = fn.slice_block(
+            tensorblock,
+            samples_to_slice=samples_to_slice,
+        )
+        # Check 1: returned tensorblock has no values
+        self.assertEqual(len(sliced_tensorblock.values.flatten()), 0)
+
+        for i, (_, gradient) in enumerate(sliced_tensorblock.gradients()):
+            # Check 2: all gradients have no values
+            self.assertEqual(len(gradient.data), 0)
+
+            # Check 3: the shape of the Gradient values is equivalent to the
+            # original in all but the samples (i.e. 1st) dimension
+            self.assertEqual(
+                gradient.data.shape[1:],
+                list(tensorblock.gradients())[i][1].data.shape[1:],
+            )
+
+    def test_slice_samples_tensormap_empty_gradients(self):
+        tensormap = equistore.io.load(
+            os.path.join(DATA_ROOT, TEST_FILE),
+            use_numpy=True,
+        )
+        # Slice only 'structures' -1 (i.e. a sample that doesn't exist in the data)
+        structures_to_keep = np.array([-1]).reshape(-1, 1)
+        samples_to_slice = Labels(
+            names=["structure"],
+            values=structures_to_keep,
+        )
+        sliced_tensormap = fn.slice(
+            tensormap,
+            samples_to_slice=samples_to_slice,
+        )
+        for i, (_, block) in enumerate(sliced_tensormap):
+            for j, (_, gradient) in enumerate(block.gradients()):
+                # Check 1: all gradient blocks are empty
+                self.assertEqual(len(gradient.data.flatten()), 0)
+
+                # Check 2: the shape of the Gradient values is equivalent to the
+                # original in all but the samples (i.e. 1st) dimension
+                self.assertEqual(
+                    gradient.data.shape[1:],
+                    list(tensormap.block(i).gradients())[j][1].data.shape[1:],
+                )
+
+        # Check 3: all the original keys are kept in the output tensormap
+        self.assertTrue(
+            np.all([key in sliced_tensormap.keys for key in tensormap.keys])
+        )
+
+    # TEST BLOCK 3: SLICING PROPERTIES WITHOUT GRADIENTS
+
+    def test_slice_properties_tensorblock_no_gradients(self):
+        tensormap = equistore.io.load(
+            os.path.join(DATA_ROOT, TEST_FILE),
+            use_numpy=True,
+        )
+        # Remove the gradients to simplify test
+        tensormap = fn.remove_gradients(tensormap)
+        # Define a single block to test
+        tensorblock = tensormap.block(0)
+        # Slice only 'n' (i.e. radial channels) 1, 3
+        channels_to_keep = np.arange(1, 5, 2).reshape(-1, 1)
+        properties_to_slice = Labels(
+            names=["n"],
+            values=channels_to_keep,
+        )
+        sliced_tensorblock = fn.slice_block(
+            tensorblock,
+            properties_to_slice=properties_to_slice,
+        )
+        # Check 1: no slicing of samples has occurred
+        self.assertEqual(
+            tensorblock.samples.asarray().shape,
+            sliced_tensorblock.samples.asarray().shape,
+        )
+        # Check 2: properties have been sliced to the correct dimension
+        self.assertEqual(
+            len(sliced_tensorblock.properties),
+            len(
+                [
+                    channel_i
+                    for channel_i in tensorblock.properties["n"]
+                    if channel_i in channels_to_keep
+                ]
+            ),
+        )
+        # Check 3: properties in sliced block only feature desired channel indices
+        self.assertTrue(
+            np.all(
+                [
+                    channel_i in channels_to_keep
+                    for channel_i in sliced_tensorblock.properties["n"]
+                ]
+            )
+        )
+        # Check 4: no components have been sliced
+        for i, comp in enumerate(sliced_tensorblock.components):
+            self.assertEqual(len(comp), len(tensorblock.components[i]))
+
+    def test_slice_properties_tensormap_no_gradients(self):
+        tensormap = equistore.io.load(
+            os.path.join(DATA_ROOT, TEST_FILE),
+            use_numpy=True,
+        )
+        # Remove the gradients to simplify test
+        tensormap = fn.remove_gradients(tensormap)
+        # Slice only 'n' (i.e. radial channels) 1, 3
+        channels_to_keep = np.arange(1, 5, 2).reshape(-1, 1)
+        properties_to_slice = Labels(
+            names=["n"],
+            values=channels_to_keep,
+        )
+        sliced_tensormap = fn.slice(
+            tensormap,
+            properties_to_slice=properties_to_slice,
+        )
+        for i, (key, block) in enumerate(tensormap):
+            # Check 1: no slicing of samples has occurred
+            self.assertEqual(
+                sliced_tensormap.block(i).samples.asarray().shape,
+                block.samples.asarray().shape,
+            )
+            # Check 2: properties have been sliced to the correct dimension
+            self.assertEqual(
+                len(sliced_tensormap.block(i).properties),
+                len(
+                    [
+                        channel_i
+                        for channel_i in block.properties["n"]
+                        if channel_i in channels_to_keep
+                    ]
+                ),
+            )
+            # Check 3: properties in sliced block only feature desired channel indices
+            self.assertTrue(
+                np.all(
+                    [
+                        channel_i in channels_to_keep
+                        for channel_i in sliced_tensormap.block(i).properties["n"]
+                    ]
+                )
+            )
+            # Check 4: no components have been sliced
+            for j, comp in enumerate(block.components):
+                self.assertEqual(
+                    len(comp), len(sliced_tensormap.block(i).components[j])
+                )
+
+        # Check 5: all the keys in the sliced tensormap are in the original
+        self.assertTrue(
+            np.all([key in tensormap.keys for key in sliced_tensormap.keys])
+        )
+
+    def test_slice_properties_tensorblock_empty_no_gradients(self):
+        tensormap = equistore.io.load(
+            os.path.join(DATA_ROOT, TEST_FILE),
+            use_numpy=True,
+        )
+        # Remove the gradients to simplify test
+        tensormap = fn.remove_gradients(tensormap)
+        # Define a single block to test
+        tensorblock = tensormap.block(0)
+        # Slice only 'n' (i.e. radial channels) -1 (i.e. non-existent channel)
+        channels_to_keep = np.array([-1]).reshape(-1, 1)
+        properties_to_slice = Labels(
+            names=["n"],
+            values=channels_to_keep,
+        )
+        sliced_tensorblock = fn.slice_block(
+            tensorblock,
+            properties_to_slice=properties_to_slice,
+        )
+        # Check 1: returned tensorblock has no values
+        self.assertEqual(len(sliced_tensorblock.values.flatten()), 0)
+
+        # Check 2: returned tensorblock has dimension zero for properties
+        self.assertEqual(sliced_tensorblock.values.shape[-1], 0)
+
+        # Check 3: returned tensorblock has original dimension for samples
+        self.assertEqual(
+            sliced_tensorblock.values.shape[0], tensorblock.values.shape[0]
+        )
+
+    def test_slice_properties_tensormap_empty_no_gradients(self):
+        tensormap = equistore.io.load(
+            os.path.join(DATA_ROOT, TEST_FILE),
+            use_numpy=True,
+        )
+        # Remove the gradients to simplify test
+        tensormap = fn.remove_gradients(tensormap)
+        # Slice only 'n' (i.e. radial channels) -1 (i.e. non-existent channel)
+        channels_to_keep = np.array([-1]).reshape(-1, 1)
+        properties_to_slice = Labels(
+            names=["n"],
+            values=channels_to_keep,
+        )
+        sliced_tensormap = fn.slice(
+            tensormap,
+            properties_to_slice=properties_to_slice,
+        )
+        for _, block in sliced_tensormap:
+            # Check 1: all blocks are empty
+            self.assertEqual(len(block.values.flatten()), 0)
+
+            # Check 2: the properties dimension is zero
+            self.assertEqual(block.values.shape[-1], 0)
+
+        # Check 2: all the original keys are kept in the output tensormap
+        self.assertTrue(
+            np.all([key in sliced_tensormap.keys for key in tensormap.keys])
+        )
+
+    # TEST BLOCK 4: SLICING PROPERTIES WITH GRADIENTS
+
+    def test_slice_properties_tensorblock_gradients(self):
+        tensormap = equistore.io.load(
+            os.path.join(DATA_ROOT, TEST_FILE),
+            use_numpy=True,
+        )
+        # Define a single block to test
+        tensorblock = tensormap.block(0)
+        # Slice only 'n' (i.e. radial channels) 1, 3
+        channels_to_keep = np.arange(1, 5, 2).reshape(-1, 1)
+        properties_to_slice = Labels(
+            names=["n"],
+            values=channels_to_keep,
+        )
+        sliced_tensorblock = fn.slice_block(
+            tensorblock,
+            properties_to_slice=properties_to_slice,
+        )
+        for i, (parameter, gradient) in enumerate(sliced_tensorblock.gradients()):
+            # Check 1: no slicing of samples has occurred
+            self.assertEqual(
+                list(tensorblock.gradients())[i][1].samples.asarray().shape,
+                gradient.samples.asarray().shape,
+            )
+            # Check 2: properties have been sliced to the correct dimension
+            self.assertEqual(
+                len(sliced_tensorblock.properties),
+                len(
+                    [
+                        channel_i
+                        for channel_i in tensorblock.properties["n"]
+                        if channel_i in channels_to_keep
+                    ]
+                ),
+            )
+            # Check 3: properties in sliced block only feature desired channel indices
+            self.assertTrue(
+                np.all(
+                    [
+                        channel_i in channels_to_keep
+                        for channel_i in sliced_tensorblock.properties["n"]
+                    ]
+                )
+            )
+            # Check 4: same number of components as original
+            self.assertEqual(
+                len(gradient.components),
+                len(list(tensorblock.gradients())[i][1].components),
+            )
+
+    def test_slice_properties_tensorblock_empty_gradients(self):
+        tensormap = equistore.io.load(
+            os.path.join(DATA_ROOT, TEST_FILE),
+            use_numpy=True,
+        )
+        # Define a single block to test
+        tensorblock = tensormap.block(0)
+        # Slice only 'n' (i.e. radial channels) -1 (i.e. non-existent channel)
+        channels_to_keep = np.array([-1]).reshape(-1, 1)
+        properties_to_slice = Labels(
+            names=["n"],
+            values=channels_to_keep,
+        )
+        sliced_tensorblock = fn.slice_block(
+            tensorblock,
+            properties_to_slice=properties_to_slice,
+        )
+        # Check 1: returned tensorblock has no values
+        self.assertEqual(len(sliced_tensorblock.values.flatten()), 0)
+
+        for i, (_, gradient) in enumerate(sliced_tensorblock.gradients()):
+            # Check 2: all gradients have no values
+            self.assertEqual(len(gradient.data.flatten()), 0)
+
+            # Check 3: the shape of the Gradient values is equivalent to the
+            # original in all but the properties (i.e. last) dimension
+            self.assertEqual(
+                gradient.data.shape[:-1],
+                list(tensorblock.gradients())[i][1].data.shape[:-1],
+            )
+
+    def test_slice_properties_tensormap_empty_gradients(self):
+        tensormap = equistore.io.load(
+            os.path.join(DATA_ROOT, TEST_FILE),
+            use_numpy=True,
+        )
+        # Slice only 'n' (i.e. radial channels) -1 (i.e. non-existent channel)
+        channels_to_keep = np.array([-1]).reshape(-1, 1)
+        properties_to_slice = Labels(
+            names=["n"],
+            values=channels_to_keep,
+        )
+        sliced_tensormap = fn.slice(
+            tensormap,
+            properties_to_slice=properties_to_slice,
+        )
+        for i, (_, block) in enumerate(sliced_tensormap):
+            for j, (_, gradient) in enumerate(block.gradients()):
+                # Check 1: all gradient blocks are empty
+                self.assertEqual(len(gradient.data.flatten()), 0)
+
+                # Check 2: the shape of the Gradient values is equivalent to the
+                # original in all but the properties (i.e. last) dimension
+                self.assertEqual(
+                    gradient.data.shape[:-1],
+                    list(tensormap.block(i).gradients())[j][1].data.shape[:-1],
+                )
+
+        # Check 3: all the original keys are kept in the output tensormap
+        self.assertTrue(
+            np.all([key in sliced_tensormap.keys for key in tensormap.keys])
+        )
+
+    # TEST BLOCK 5: SLICING SAMPLES AND PROPERTIES SIMULTANEOUSLY
+
+    def test_slice_samples_properties_tensorblock(self):
+        tensormap = equistore.io.load(
+            os.path.join(DATA_ROOT, TEST_FILE),
+            use_numpy=True,
+        )
+        tensorblock = tensormap.block(5)
+        # Slice 'center' 1, 3, 5
+        centers_to_keep = np.arange(1, 7, 2).reshape(-1, 1)
+        samples_to_slice = Labels(
+            names=["center"],
+            values=centers_to_keep,
+        )
+        # Slice 'n' (i.e. radial channel) 0, 1, 2
+        channels_to_keep = np.arange(0, 3).reshape(-1, 1)
+        properties_to_slice = Labels(
+            names=["n"],
+            values=channels_to_keep,
+        )
+        sliced_tensorblock = fn.slice_block(
+            tensorblock,
+            samples_to_slice=samples_to_slice,
+            properties_to_slice=properties_to_slice,
+        )
+        # Check 1: only desired centers indices are in the output.
+        self.assertTrue(
+            np.all(
+                [
+                    center_i in centers_to_keep
+                    for center_i in sliced_tensorblock.samples["center"]
+                ]
+            )
+        )
+        # Check 2: only desired centers indices are in the output.
+        self.assertTrue(
+            np.all(
+                [
+                    channel_i in channels_to_keep
+                    for channel_i in sliced_tensorblock.properties["n"]
+                ]
+            )
+        )
+        # Check 3: There are the correct number of samples
+        self.assertEqual(
+            sliced_tensorblock.values.shape[0],
+            len(
+                [
+                    sample
+                    for sample in tensorblock.samples
+                    if sample["center"] in centers_to_keep
+                ]
+            ),
+        )
+        # Check 4: There are the correct number of properties
+        self.assertEqual(
+            sliced_tensorblock.values.shape[-1],
+            len(
+                [
+                    prop
+                    for prop in tensorblock.properties
+                    if prop["n"] in channels_to_keep
+                ]
+            ),
+        )
+        # Check 6: actual values are what they should be
+        samples_filter = [
+            sample["center"] in centers_to_keep for sample in tensorblock.samples
+        ]
+        properties_filter = [
+            prop["n"] in channels_to_keep for prop in tensorblock.properties
+        ]
+        self.assertTrue(
+            np.array_equal(
+                tensorblock.values[samples_filter][..., properties_filter],
+                sliced_tensorblock.values,
+            )
+        )
+
+    # TEST BLOCK 6: TESTING TYPE HANDLING OF USER-FACING SLICE FUNCTION
+
+    def test_slice_type_handling(self):
+        tensormap = equistore.io.load(
+            os.path.join(DATA_ROOT, TEST_FILE),
+            use_numpy=True,
+        )
+        # Define a single block to test
+        tensorblock = tensormap.block(0)
+        # Slice 'center' 1, 3, 5
+        structures_to_keep = np.arange(1, 7, 2).reshape(-1, 1)
+        samples_to_slice = Labels(
+            names=["center"],
+            values=structures_to_keep,
+        )
+        # Check 1: TensorBlock -> TypeError
+        with self.assertRaises(TypeError):
+            fn.slice(tensorblock, samples_to_slice=samples_to_slice),
+        # Check 2: TensorMap -> TensorMap
+        self.assertTrue(
+            isinstance(
+                fn.slice(tensormap, samples_to_slice=samples_to_slice), TensorMap
+            )
+        )
+        # Check 3: passing tensor=float raises TypeError
+        with self.assertRaises(TypeError):
+            fn.slice(5.0, samples_to_slice=samples_to_slice)
+        # Check 4: passing samples_to_slice=np.array raises TypeError
+        with self.assertRaises(TypeError):
+            fn.slice(
+                tensormap,
+                samples_to_slice=np.array(
+                    [
+                        [
+                            5,
+                        ],
+                        [
+                            6,
+                        ],
+                    ]
+                ),
+            )
+
+    def test_slice_block_type_handling(self):
+        tensormap = equistore.io.load(
+            os.path.join(DATA_ROOT, TEST_FILE),
+            use_numpy=True,
+        )
+        # Define a single block to test
+        tensorblock = tensormap.block(0)
+        # Slice 'center' 1, 3, 5
+        structures_to_keep = np.arange(1, 7, 2).reshape(-1, 1)
+        samples_to_slice = Labels(
+            names=["center"],
+            values=structures_to_keep,
+        )
+        # Check 1: TensorMap -> TypeError
+        with self.assertRaises(TypeError):
+            fn.slice_block(tensormap, samples_to_slice=samples_to_slice),
+        # Check 2: TensorBlock -> TensorBlock
+        self.assertTrue(
+            isinstance(
+                fn.slice_block(tensorblock, samples_to_slice=samples_to_slice),
+                TensorBlock,
+            )
+        )
+        # Check 3: passing tensor=float raises TypeError
+        with self.assertRaises(TypeError):
+            fn.slice_block(5.0, samples_to_slice=samples_to_slice)
+        # Check 4: passing samples_to_slice=np.array raises TypeError
+        with self.assertRaises(TypeError):
+            fn.slice_block(
+                tensorblock,
+                samples_to_slice=np.array(
+                    [
+                        [
+                            5,
+                        ],
+                        [
+                            6,
+                        ],
+                    ]
+                ),
+            )
+
+    # TEST BLOCK 7: TESTING WARNINGS OF THE SLICE FUNCTION
+
+    def test_slice_samples_tensormap_partially_empty_warning(self):
+        tensormap = equistore.io.load(
+            os.path.join(DATA_ROOT, TEST_FILE),
+            use_numpy=True,
+        )
+        # Remove the gradients to simplify test
+        tensormap = fn.remove_gradients(tensormap)
+        # Slice only 'structures' 2
+        structures_to_keep = np.array([2]).reshape(-1, 1)
+        samples_to_slice = Labels(
+            names=["structure"],
+            values=structures_to_keep,
+        )
+        with self.assertWarns(UserWarning) as cm:
+            # Check 1: warning raised as some empty blocks produced
+            fn.slice(
+                tensormap,
+                samples_to_slice=samples_to_slice,
+            )
+        self.assertTrue(
+            "Some TensorBlocks in the sliced TensorMap are now empty" in str(cm.warning)
+        )
+
+    def test_slice_samples_tensormap_completely_empty_warning(self):
+        tensormap = equistore.io.load(
+            os.path.join(DATA_ROOT, TEST_FILE),
+            use_numpy=True,
+        )
+        # Remove the gradients to simplify test
+        tensormap = fn.remove_gradients(tensormap)
+        # Slice only 'structures' -1 (i.e. a sample that doesn't exist in the data)
+        structures_to_keep = np.array([-1]).reshape(-1, 1)
+        samples_to_slice = Labels(
+            names=["structure"],
+            values=structures_to_keep,
+        )
+        with self.assertWarns(UserWarning) as cm:
+            # Check 1: warning raised as all empty blocks produced
+            fn.slice(
+                tensormap,
+                samples_to_slice=samples_to_slice,
+            )
+        self.assertTrue(
+            "All TensorBlocks in the sliced TensorMap are now empty" in str(cm.warning)
+        )
+
+    def test_slice_properties_tensormap_completely_empty_warning(self):
+        tensormap = equistore.io.load(
+            os.path.join(DATA_ROOT, TEST_FILE),
+            use_numpy=True,
+        )
+        # Remove the gradients to simplify test
+        tensormap = fn.remove_gradients(tensormap)
+        # Slice only 'n' (i.e. radial channels) -1 (i.e. non-existent channel)
+        channels_to_keep = np.array([-1]).reshape(-1, 1)
+        properties_to_slice = Labels(
+            names=["n"],
+            values=channels_to_keep,
+        )
+        with self.assertWarns(UserWarning) as cm:
+            # Check 1: warning raised as all empty blocks produced
+            fn.slice(
+                tensormap,
+                properties_to_slice=properties_to_slice,
+            )
+        self.assertTrue(
+            "All TensorBlocks in the sliced TensorMap are now empty" in str(cm.warning)
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**Overview**

Functions to slice equistore tensors based on some specified samples, properties, or both. All functions are documented, and there is a suite of associated unit tests.

This pull request supersedes that of PR #37. These slice functions have been implemented as a helper module in the `operations/` subdirectory as opposed to as a class method in `tensor.py`. 


**Functionality**

In `slice.py`, there are 3 new functions. All are documented and have unit tests.

**1. `_slice_tensorblock(tensorblock, samples_to_slice=None, properties_to_slice=None)`**

* This slices an individual `TensorBlock`, including gradients, according to the arguments `samples_to_slice` and `properties_to_slice`. It returns a new `TensorBlock`, where the shape of the values tensor (`TensorBlock.values`) is smaller than (if slicing has occurred) or equal to (if no slicing has occurred) the input `TensorBlock`.

* `samples_to_slice` and `properties_to_slice` must be passed as `Labels` objects, specifying the name(s) and values of the samples and/or properties to slice by.

* Note that the values tensor could be empty if none of the specified samples and/or properties belong to the input `TensorBlock`. In this case, although there will be no actual values in the `TensorBlock.values` array, the shape of this tensor will be non-zero in the dimensions that haven't been sliced. This is created by slicing the input `TensorBlock`, as opposed to just returning an artificially-created empty one (with no shape or dimensions), and is intentional. It allows the slicing of dimensions to be tracked. 

* For example, if a `TensorBlock` of shape `(52, 1, 5)` is passed, and only some samples are specified to be sliced but none of these appear in the input `TesnorBlock`, the returned `TensorBlock` values array will be empty, but its shape will be `(0, 1, 5)` - i.e. the samples dimension has been sliced to zero but the components and properties dimensions remain in-tact. The same logic applies to any `Gradient TensorBlocks` the input `TensorBlock` may have associated with it.

**2. `_slice_tensormap(tensormap, samples_to_slice=None, properties_to_slice=None)`**

* This works by iterating over and slicing each block of the input `TensorMap` and returning a new `TensorMap`. 

* The returned `TensorMap` will have the same number of blocks, indexed by the same keys, as the input, but some (or all) might be empty, depending on the samples or properties the user has chosen to slice by.

**3. `slice(tensor, samples_to_slice=None, properties_to_slice=None)`**

* This is the user-facing function. It identifies the type of the input tensor (either a `TensorBlock` or a `TensorMap`) and calls the appropriate function from the 2 above. 

* It also handles input checking, and warns users if their returned tensor is empty (in the case of the user passing a `TensorBlock`) or if it contains any (or all) empty blocks (in the case of the user passing a `TensorMap`.


**Outlook**

The split function is useful to allow users to split up their data along the samples or properties dimensions, or both. It works by explicit specification of samples and/or properties. However, on top of this module could be built a 'train_test_split' module where tensors are sliced randomly without the need to explicitly specify the exact indices of the samples/properties they want to keep (which can be tedious). This could also be extended even further to include a function to split data according to a k-fold cross validation scheme. Using the split function, both would be relatively easy to implement and generalise.