### PR TITLE
Add join functions

### DIFF
--- a/docs/src/reference/python/operations/index.rst
+++ b/docs/src/reference/python/operations/index.rst
@@ -13,6 +13,7 @@ Operations
 
     allclose() <allclose>
     dot() <dot>
+    join() <join>
     lstsq() <lstsq>
     slice() <slice>
     solve() <solve>

--- a/docs/src/reference/python/operations/join.rst
+++ b/docs/src/reference/python/operations/join.rst
@@ -1,0 +1,4 @@
+join
+====
+
+.. autofunction:: equistore.operations.join

--- a/python/src/equistore/operations/__init__.py
+++ b/python/src/equistore/operations/__init__.py
@@ -14,6 +14,7 @@ from .allclose import (  # noqa
     allclose_raise,
 )
 from .dot import dot  # noqa
+from .join import join  # noqa
 from .lstsq import lstsq  # noqa
 from .reduce_over_samples import mean_over_samples, sum_over_samples  # noqa
 from .remove_gradients import remove_gradients  # noqa
@@ -27,6 +28,7 @@ __all__ = [
     "allclose_block",
     "allclose_block_raise",
     "dot",
+    "join",
     "lstsq",
     "mean_over_samples",
     "remove_gradients",

--- a/python/src/equistore/operations/_dispatch.py
+++ b/python/src/equistore/operations/_dispatch.py
@@ -154,6 +154,21 @@ def lstsq(X, Y, rcond, driver=None):
         raise TypeError(UNKNOWN_ARRAY_TYPE)
 
 
+def hstack(arrays):
+    """Stack horizontally a group of arrays.
+
+    This function has the same behavior as ``numpy.hstack(arrays)``.
+    """
+    if isinstance(arrays[0], np.ndarray):
+        _check_all_same_type(arrays, np.ndarray)
+        return np.hstack(arrays)
+    elif isinstance(arrays[0], TorchTensor):
+        _check_all_same_type(arrays, TorchTensor)
+        return torch.hstack(arrays)
+    else:
+        raise TypeError(UNKNOWN_ARRAY_TYPE)
+
+
 def vstack(arrays):
     """Stack vertically a group of arrays.
 

--- a/python/src/equistore/operations/allclose.py
+++ b/python/src/equistore/operations/allclose.py
@@ -3,7 +3,7 @@ import numpy as np
 from equistore import TensorBlock, TensorMap
 
 from . import _dispatch
-from ._utils import _check_same_gradients, _check_same_keys
+from ._utils import _check_blocks, _check_same_keys
 
 
 def allclose(
@@ -186,8 +186,7 @@ def allclose_block_raise(
             if not np.all(c1 == c2):
                 raise ValueError("components not the same or not in the same order")
 
-    if len(block1.gradients_list()) > 0:
-        _check_same_gradients(block1, block2, "allclose")
+    _check_blocks(block1, block2, ["gradients"], "allclose")
 
     for parameter, gradient1 in block1.gradients():
         gradient2 = block2.gradient(parameter)

--- a/python/src/equistore/operations/join.py
+++ b/python/src/equistore/operations/join.py
@@ -1,0 +1,213 @@
+from typing import List
+
+import numpy as np
+
+from ..block import TensorBlock
+from ..labels import Labels
+from ..tensor import TensorMap
+from . import _dispatch
+from ._utils import _check_blocks, _check_same_gradients_components, _check_same_keys
+
+
+def join(tensormaps: List[TensorMap], axis: str):
+    """Join a sequence of :py:class:`TensorMap` along an axis.
+
+    The ``axis`` parameter specifies the type join.
+    For example, if ``axis='properties'`` it will be the joined along the
+    properties of the TensorMaps and if ``axis='samples'`` it will be the
+    along the samples.
+
+    :param tensormaps: sequence of :py:class:`TensorMap` for join
+    :param axis: A string indicating how the tensormaps are stacked.
+                 Allowed values are ``'properties'`` or ``'samples'``.
+
+    :return: The stacked :py:class:`TensorMap` which has more properties or
+             samples than the input TensorMap.
+    """
+
+    if len(tensormaps) < 2 or type(tensormaps) not in [list, tuple]:
+        raise ValueError("provide at least two `TensorMap`s for joining")
+
+    for ts_to_join in tensormaps[1:]:
+        _check_same_keys(tensormaps[0], ts_to_join, "join")
+
+    blocks = []
+    for key in tensormaps[0].keys:
+        blocks_to_join = [ts.block(key) for ts in tensormaps]
+
+        if axis == "properties":
+            blocks.append(_join_blocks_along_properties(blocks_to_join))
+        elif axis == "samples":
+            blocks.append(_join_blocks_along_samples(blocks_to_join))
+        else:
+            raise ValueError(
+                "Only `'properties'` or `'samples'` are "
+                "valid values for the `axis` parameter."
+            )
+
+    return TensorMap(tensormaps[0].keys, blocks)
+
+
+def _join_labels(labels: List[Labels]) -> Labels:
+    """Join a sequence of :py:class:`Labels`
+
+    Possible name and value clashes are resolved by the following strategy:
+
+    1. If the names are the same and the values are unique we keep the names and
+       join the values vertically. In example::
+
+        labels_1 = ["n"], [0, 2, 3]
+        labels_2 = ["n"], [1, 4, 5]
+
+      will lead to::
+
+        properties = ["n"], [0, 2, 3, 1, 4, 5]
+
+    2. If the names are the same but the values are not unique a new variable
+       "tensor" is added to the names. In example::
+
+            properties_1 = ["n"], [0, 2, 3]
+            properties_2 = ["n"], [0, 2]
+
+        will lead to::
+            properties = ["tensor", "n"], [[0, 0], [0, 2], [0, 3], [1, 0], [1, 2]]
+
+    3. If names of the Labels are different we change the names two to
+       ("tensor", "property"). In example::
+
+            properties_1 = ["a"], [0, 2, 3]
+            properties_2 = ["b", "c], [[0, 0], [1, 2]]
+
+        will lead to::
+
+            properties = ["tensor", "q"], [[0, 0], [0, 1], [0, 2], [1, 0], [1, 1]]
+    """
+    names = [label.names for label in labels]
+    values = [label.tolist() for label in labels]
+    tensor_values = np.repeat(
+        a=np.arange(len(values)), repeats=[len(value) for value in values]
+    )
+
+    unique_names = np.unique(names)
+    unique_values = np.unique(np.vstack(values), axis=0)
+
+    names_are_same = np.all(
+        len(unique_names) == np.array([len(name) for name in names])
+    )
+    values_are_unique = len(unique_values) == len(np.vstack(values))
+
+    if names_are_same and values_are_unique:
+        new_names = names[0]
+        new_values = np.vstack(values)
+    elif names_are_same and not values_are_unique:
+        new_names = ["tensor"] + list(names[0])
+        new_values = np.hstack([tensor_values.reshape(-1, 1), np.vstack(values)])
+    else:
+        new_names = ["tensor", "property"]
+        property_values = np.hstack([np.arange(len(value)) for value in values])
+        new_values = np.vstack([tensor_values, property_values]).T
+
+    return Labels(names=new_names, values=new_values)
+
+
+def _join_blocks_along_properties(blocks: List[TensorBlock]) -> TensorBlock:
+    """Join a sequence of :py:class:`TensorBlock` along their properties."""
+    first_block = blocks[0]
+
+    fname = "_join_blocks_along_properties"
+    for block in blocks[1:]:
+        _check_blocks(first_block, block, ["components", "samples", "gradients"], fname)
+        _check_same_gradients_components(first_block, block, fname)
+
+    properties = _join_labels([block.properties for block in blocks])
+    result_block = TensorBlock(
+        values=_dispatch.hstack([block.values for block in blocks]),
+        samples=first_block.samples,
+        components=first_block.components,
+        properties=properties,
+    )
+
+    for parameter, first_gradient in first_block.gradients():
+
+        # Different blocks might contain different gradient samples
+        gradient_sample_values = np.unique(
+            np.hstack([block.gradient(parameter).samples for block in blocks])
+        ).tolist()
+        gradient_samples = Labels(
+            names=first_gradient.samples.names, values=np.array(gradient_sample_values)
+        )
+
+        gradient_data = np.zeros(
+            (len(gradient_samples),)
+            + first_gradient.data.shape[1:-1]
+            + (len(properties),)
+        )
+
+        properties_start = 0
+        for block in blocks:
+            gradient = block.gradient(parameter)
+
+            # find the correct sample position to put the data
+            for i_grad, sample_grad in enumerate(gradient.samples):
+                # TODO: once C-API is changed replace by:
+                # i_sample = gradient_samples.position(sample_grad)`
+                i_sample = np.where(gradient_samples == sample_grad)[0][0]
+                gradient_data[
+                    i_sample,
+                    ...,
+                    properties_start : properties_start + len(gradient.properties),
+                ] = gradient.data[i_grad]
+
+            properties_start += len(gradient.properties)
+
+        result_block.add_gradient(
+            parameter, gradient_data, gradient_samples, first_gradient.components
+        )
+
+    return result_block
+
+
+def _join_blocks_along_samples(blocks: List[TensorBlock]) -> TensorBlock:
+    """Join a sequence of :py:class:`TensorBlock` along their samples."""
+    first_block = blocks[0]
+
+    fname = "_join_blocks_along_samples"
+    for block in blocks[1:]:
+        _check_blocks(
+            first_block, block, ["components", "properties", "gradients"], fname
+        )
+        _check_same_gradients_components(first_block, block, fname)
+
+    result_block = TensorBlock(
+        values=_dispatch.vstack([block.values for block in blocks]),
+        samples=_join_labels([block.samples for block in blocks]),
+        components=first_block.components,
+        properties=first_block.properties,
+    )
+
+    for parameter, first_gradient in first_block.gradients():
+        gradient_data = [first_gradient.data]
+        gradient_samples = [np.array(first_gradient.samples.tolist())]
+
+        for block in blocks[1:]:
+            gradient = block.gradient(parameter)
+            gradient_data.append(gradient.data)
+
+            samples = np.array(gradient.samples.tolist())
+            # update the "sample" variable in gradient samples
+            samples[:, 0] += 1 + gradient_samples[-1][:, 0].max()
+            gradient_samples.append(samples)
+
+        gradient_data = np.vstack(gradient_data)
+        gradient_samples = np.vstack(gradient_samples)
+
+        gradients_samples = Labels(first_gradient.samples.names, gradient_samples)
+
+        result_block.add_gradient(
+            parameter,
+            gradient_data,
+            gradients_samples,
+            first_gradient.components,
+        )
+
+    return result_block

--- a/python/src/equistore/operations/lstsq.py
+++ b/python/src/equistore/operations/lstsq.py
@@ -5,7 +5,7 @@ import numpy as np
 from ..block import TensorBlock
 from ..tensor import TensorMap
 from . import _dispatch
-from ._utils import _check_same_gradients, _check_same_keys
+from ._utils import _check_blocks, _check_same_keys
 
 
 def lstsq(X: TensorMap, Y: TensorMap, rcond, driver=None) -> TensorMap:
@@ -75,16 +75,15 @@ def _lstsq_block(X: TensorBlock, Y: TensorBlock, rcond, driver) -> TensorBlock:
     Y_n_properties = Y.values.shape[-1]
     Y_values = Y.values.reshape(-1, Y_n_properties)
 
-    if len(X.gradients_list()) > 0:
-        _check_same_gradients(X, Y, "lstsq")
+    _check_blocks(X, Y, ["gradients"], "lstsq")
 
-        for parameter, X_gradient in X.gradients():
-            X_gradient_data = X_gradient.data.reshape(-1, X_n_properties)
-            X_values = _dispatch.vstack((X_values, X_gradient_data))
+    for parameter, X_gradient in X.gradients():
+        X_gradient_data = X_gradient.data.reshape(-1, X_n_properties)
+        X_values = _dispatch.vstack((X_values, X_gradient_data))
 
-            Y_gradient = Y.gradient(parameter)
-            Y_gradient_data = Y_gradient.data.reshape(-1, Y_n_properties)
-            Y_values = _dispatch.vstack((Y_values, Y_gradient_data))
+        Y_gradient = Y.gradient(parameter)
+        Y_gradient_data = Y_gradient.data.reshape(-1, Y_n_properties)
+        Y_values = _dispatch.vstack((Y_values, Y_gradient_data))
 
     weights = _dispatch.lstsq(X_values, Y_values, rcond=rcond, driver=driver)
 

--- a/python/src/equistore/operations/solve.py
+++ b/python/src/equistore/operations/solve.py
@@ -3,7 +3,7 @@ import numpy as np
 from ..block import TensorBlock
 from ..tensor import TensorMap
 from . import _dispatch
-from ._utils import _check_same_gradients, _check_same_keys
+from ._utils import _check_blocks, _check_same_keys
 
 
 def solve(X: TensorMap, Y: TensorMap) -> TensorMap:
@@ -74,16 +74,15 @@ def _solve_block(X: TensorBlock, Y: TensorBlock) -> TensorBlock:
     Y_n_properties = Y.values.shape[-1]
     Y_values = Y.values.reshape(-1, Y_n_properties)
 
-    if len(X.gradients_list()) > 0:
-        _check_same_gradients(X, Y, "solve")
+    _check_blocks(X, Y, ["gradients"], "solve")
 
-        for parameter, X_gradient in X.gradients():
-            X_gradient_data = X_gradient.data.reshape(-1, X_n_properties)
-            X_values = _dispatch.vstack((X_values, X_gradient_data))
+    for parameter, X_gradient in X.gradients():
+        X_gradient_data = X_gradient.data.reshape(-1, X_n_properties)
+        X_values = _dispatch.vstack((X_values, X_gradient_data))
 
-            Y_gradient = Y.gradient(parameter)
-            Y_gradient_data = Y_gradient.data.reshape(-1, Y_n_properties)
-            Y_values = _dispatch.vstack((Y_values, Y_gradient_data))
+        Y_gradient = Y.gradient(parameter)
+        Y_gradient_data = Y_gradient.data.reshape(-1, Y_n_properties)
+        Y_values = _dispatch.vstack((Y_values, Y_gradient_data))
 
     weights = _dispatch.solve(X_values, Y_values)
 

--- a/python/tests/operations/join.py
+++ b/python/tests/operations/join.py
@@ -1,0 +1,280 @@
+import unittest
+from os import path
+
+import numpy as np
+
+import equistore.operations as eop
+from equistore import Labels, TensorBlock, TensorMap
+from equistore.io import load
+
+
+DATA_ROOT = path.join(path.dirname(__file__), "..", "data")
+
+
+class TestJoinTensorMap(unittest.TestCase):
+    def setUp(self):
+        self.ps = load(path.join(DATA_ROOT, "qm7-power-spectrum.npz"), use_numpy=True)
+        self.se = load(
+            path.join(DATA_ROOT, "qm7-spherical-expansion.npz"), use_numpy=True
+        )
+        self.first_block = self.ps.block(0)
+
+        # Test if Tensormaps have at least one gradient. This avoids dropping gradient
+        # tests silently by removing gradients from the reference data
+        self.assertIn("positions", self.ps.block(0).gradients_list())
+        self.assertIn("positions", self.se.block(0).gradients_list())
+
+        keys_first_block = Labels(
+            names=self.ps.keys.names,
+            values=np.array(self.ps.keys[0].tolist()).reshape(1, -1),
+        )
+
+        self.ps_first_block = TensorMap(keys_first_block, [self.first_block.copy()])
+
+        block_extra_grad = self.first_block.copy()
+        gradient = self.ps.block(0).gradient("positions")
+        block_extra_grad.add_gradient(
+            "foo", gradient.data, gradient.samples, gradient.components
+        )
+        self.ps_first_block_extra_grad = TensorMap(keys_first_block, [block_extra_grad])
+
+    def test_single_tensormap(self):
+        """Test error raise if only one tensormap is provided."""
+        with self.assertRaises(ValueError) as err:
+            eop.join(self.ps, axis="properties")
+        self.assertIn("provide at least two", str(err.exception))
+
+        with self.assertRaises(ValueError) as err:
+            eop.join([self.ps], axis="properties")
+        self.assertIn("provide at least two", str(err.exception))
+
+    def test_join_properties(self):
+        """Test public join function with three tensormaps along `properties`.
+
+        We check for the values below."""
+
+        ps_joined = eop.join([self.ps, self.ps, self.ps], axis="properties")
+
+        # test property names
+        names = self.ps.block(0).properties.names
+        self.assertEqual(ps_joined.block(0).properties.names, ("tensor",) + names)
+
+        # test property values
+        tensor_prop = np.unique(ps_joined.block(0).properties["tensor"])
+        self.assertEqual(set(tensor_prop), set((0, 1, 2)))
+
+    def test_join_samples(self):
+        """Test public join function with three tensormaps along `samples`."""
+        ps_joined = eop.join([self.ps, self.ps, self.ps], axis="samples")
+
+        # test sample values
+        self.assertEqual(
+            len(ps_joined.block(0).samples), 3 * len(self.ps.block(0).samples)
+        )
+
+    def test_join_error(self):
+        """Test error with unknown `axis` keyword."""
+        with self.assertRaises(ValueError) as err:
+            eop.join([self.ps, self.ps, self.ps], axis="foo")
+        self.assertIn("values for the `axis` parameter", str(err.exception))
+
+    def test_join_properties_values(self):
+        """Test values for joining along `properties`."""
+        ts_1 = eop.slice(self.ps, properties=self.first_block.properties[:1])
+        ts_2 = eop.slice(self.ps, properties=self.first_block.properties[1:])
+
+        ts_joined = eop.join([ts_1, ts_2], axis="properties")
+        self.assertTrue(eop.allclose(ts_joined, self.ps))
+
+    def test_join_properties_different_samples(self):
+        """Test error raise if `samples` are not the same."""
+        ts = eop.slice(self.ps_first_block, samples=self.first_block.samples[:1])
+
+        with self.assertRaises(ValueError) as err:
+            eop.join([self.ps_first_block, ts], axis="properties")
+        self.assertIn("samples", str(err.exception))
+
+    def test_join_properties_different_components(self):
+        """Test error raise if `components` are not the same."""
+        self.se.components_to_properties(["spherical_harmonics_m"])
+        se = load(path.join(DATA_ROOT, "qm7-spherical-expansion.npz"), use_numpy=True)
+        with self.assertRaises(ValueError) as err:
+            eop.join([self.se, se], axis="properties")
+        self.assertIn("components", str(err.exception))
+
+    def test_join_properties_different_gradients(self):
+        """Test error raise if `gradients` are not the same."""
+        with self.assertRaises(ValueError) as err:
+            eop.join(
+                [self.ps_first_block, self.ps_first_block_extra_grad], axis="properties"
+            )
+        self.assertIn("gradients", str(err.exception))
+
+    def test_join_samples_values(self):
+        """Test values for joining along `samples`."""
+        keys = Labels(
+            names=self.ps.keys.names,
+            values=np.array(self.ps.keys[0].tolist()).reshape(1, -1),
+        )
+
+        ts = TensorMap(keys, [self.first_block.copy()])
+        ts_1 = eop.slice(ts, samples=self.first_block.samples[:1])
+        ts_2 = eop.slice(ts, samples=self.first_block.samples[1:])
+
+        ts_joined = eop.join([ts_1, ts_2], axis="samples")
+        self.assertTrue(eop.allclose(ts, ts_joined))
+
+    def test_join_samples_different_properties(self):
+        """Test error raise if `proprties` are not the same."""
+        ts = eop.slice(self.ps_first_block, properties=self.first_block.properties[:1])
+
+        with self.assertRaises(ValueError) as err:
+            eop.join([self.ps_first_block, ts], axis="samples")
+        self.assertIn("properties", str(err.exception))
+
+    def test_join_samples_different_components(self):
+        """Test error raise if `components` are not the same."""
+        self.se.components_to_properties(["spherical_harmonics_m"])
+        se = load(path.join(DATA_ROOT, "qm7-spherical-expansion.npz"), use_numpy=True)
+        with self.assertRaises(ValueError) as err:
+            eop.join([self.se, se], axis="samples")
+        self.assertIn("components", str(err.exception))
+
+    def test_join_samples_different_gradients(self):
+        """Test error raise if `gradients` are not the same."""
+        with self.assertRaises(ValueError) as err:
+            eop.join(
+                [self.ps_first_block, self.ps_first_block_extra_grad], axis="samples"
+            )
+        self.assertIn("gradients", str(err.exception))
+
+
+class TestJoinLabels(unittest.TestCase):
+    """Test edge cases of label joining."""
+
+    def setUp(self):
+        self.sample_labels = Labels(names=["prop"], values=np.arange(2).reshape(-1, 1))
+        self.keys = Labels(names=["prop"], values=np.arange(1).reshape(-1, 1))
+
+    def test_same_names_same_values(self):
+        """Test Label joining using labels with same names but same values."""
+
+        names = ("structure", "prop_1")
+        property_labels = Labels(names, np.vstack([np.arange(5), np.arange(5)]).T)
+
+        block = TensorBlock(
+            values=np.zeros([2, 5]),
+            samples=self.sample_labels,
+            components=[],
+            properties=property_labels,
+        )
+
+        ts = TensorMap(self.keys, [block])
+        joined_ts = eop.join([ts, ts], axis="properties")
+
+        joined_labels = joined_ts.block(0).properties
+
+        self.assertEqual(joined_labels.names, ("tensor",) + names)
+
+        ref = np.array(
+            [
+                [0, 0, 0],
+                [0, 1, 1],
+                [0, 2, 2],
+                [0, 3, 3],
+                [0, 4, 4],
+                [1, 0, 0],
+                [1, 1, 1],
+                [1, 2, 2],
+                [1, 3, 3],
+                [1, 4, 4],
+            ]
+        )
+
+        self.assertTrue(np.equal(joined_labels.tolist(), ref).all())
+
+    def test_same_names_unique_values(self):
+        """Test Label joining using labels with same names and unique values."""
+        names = ("structure", "prop_1")
+        property_labels_1 = Labels(names, np.vstack([np.arange(5), np.arange(5)]).T)
+        property_labels_2 = Labels(
+            names, np.vstack([np.arange(5, 10), np.arange(5, 10)]).T
+        )
+
+        block_1 = TensorBlock(
+            values=np.zeros([2, 5]),
+            samples=self.sample_labels,
+            components=[],
+            properties=property_labels_1,
+        )
+
+        block_2 = TensorBlock(
+            values=np.zeros([2, 5]),
+            samples=self.sample_labels,
+            components=[],
+            properties=property_labels_2,
+        )
+
+        joined_ts = eop.join(
+            [TensorMap(self.keys, [block_1]), TensorMap(self.keys, [block_2])],
+            axis="properties",
+        )
+
+        joined_labels = joined_ts.block(0).properties
+
+        self.assertEqual(joined_labels.names, ("structure", "prop_1"))
+        self.assertTrue(
+            np.equal(
+                joined_labels.tolist(), np.vstack([np.arange(10), np.arange(10)]).T
+            ).all()
+        )
+
+    def test_different_names(self):
+        """Test Label joining using labels with different names."""
+        values = np.vstack([np.arange(5), np.arange(5)]).T
+        property_labels_1 = Labels(("structure", "prop_1"), -values)
+        property_labels_2 = Labels(("structure", "prop_2"), values)
+
+        block_1 = TensorBlock(
+            values=np.zeros([2, 5]),
+            samples=self.sample_labels,
+            components=[],
+            properties=property_labels_1,
+        )
+
+        block_2 = TensorBlock(
+            values=np.zeros([2, 5]),
+            samples=self.sample_labels,
+            components=[],
+            properties=property_labels_2,
+        )
+
+        joined_ts = eop.join(
+            [TensorMap(self.keys, [block_1]), TensorMap(self.keys, [block_2])],
+            axis="properties",
+        )
+
+        joined_labels = joined_ts.block(0).properties
+
+        self.assertEqual(joined_labels.names, ("tensor", "property"))
+
+        ref = np.array(
+            [
+                [0, 0],
+                [0, 1],
+                [0, 2],
+                [0, 3],
+                [0, 4],
+                [1, 0],
+                [1, 1],
+                [1, 2],
+                [1, 3],
+                [1, 4],
+            ]
+        )
+
+        self.assertTrue(np.equal(joined_labels.tolist(), ref).all())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/blocks.rs
+++ b/src/blocks.rs
@@ -263,8 +263,9 @@ impl TensorBlock {
         }
 
         if samples.size() < 1 || samples.names()[0] != "sample" {
-            return Err(Error::InvalidParameter(
-                "first variable in the gradients samples labels must be 'samples'".into()
+            return Err(Error::InvalidParameter(format!(
+                "'{}' is not valid for the first variable in the gradients \
+                samples labels. It must must be 'sample'", samples.names()[0])
             ))
         }
 


### PR DESCRIPTION
Closes #62

This PR adds two new operations. First `join_along_samples` similar to `vstack`  and second `join_along_properties` similar to `hstack`.

# TODOs
- [x] fix`join_along_samples` with gradients
- [x] Adjust new property and sample names
- [x] Add tests
- [x] Update docs
