### PR TITLE
Fix bug in io.save of torch-based tensormaps

### DIFF
--- a/python/src/equistore/data/array.py
+++ b/python/src/equistore/data/array.py
@@ -114,8 +114,8 @@ def _eqs_array_data(this, data):
     elif _is_torch_array(storage.array):
         array = storage.array
 
-        if array.device.type == "cpu":
-            raise ValueError("can not get data pointer for tensors not on CPU")
+        if array.device.type != "cpu":
+            raise ValueError("can only get data pointer for tensors on CPU")
 
         # `.numpy()` will fail if the data is on GPU or requires gradient
         # tracking, and the resulting array is sharing data storage with the


### PR DESCRIPTION
When writing a `TensorMap` to file, where the `TensorBlock.values` tensors are of type `torch.tensor`, the `equistore.io.save` function fails with a `ValueError`.

```python
ValueError                                Traceback (most recent call last)
File /opt/miniforge3/envs/qml/lib/python3.10/site-packages/equistore/utils.py:31, in catch_exceptions.<locals>.inner(*args, **kwargs)
     30 try:
---> 31     function(*args, **kwargs)
     32 except Exception as e:

File /opt/miniforge3/envs/qml/lib/python3.10/site-packages/equistore/data/array.py:118, in _eqs_array_data(this, data)
    117 if array.device.type == "cpu":
--> 118     raise ValueError("can not get data pointer for tensors not on CPU")
    120 # `.numpy()` will fail if the data is on GPU or requires gradient
    121 # tracking, and the resulting array is sharing data storage with the
    122 # tensor, meaning we can take a pointer to it without the array being
    123 # freed immediately.

ValueError: can not get data pointer for tensors not on CPU
```

This is because there is a bug in _equistore/data/array.py_ code of the Python API, where a ValueError is raised if the device type of the machine running the operation is a 'cpu', where instead it should raise an error if the device type **isn't** 'cpu' - i.e. for GPUs, where converting the values tensor from torch to numpy using the `tensor.numpy()` method wouldn't work.

This pull request simply changes the conditional check on the device type and changes the error message to be more clear.