### PR TITLE
Cleanup tests and fix a bug for slice operation

### DIFF
--- a/python/tests/operations/slice.py
+++ b/python/tests/operations/slice.py
@@ -1,568 +1,318 @@
 import os
 import unittest
+import warnings
 
 import numpy as np
 
 import equistore.io
 import equistore.operations as fn
-from equistore import Labels, TensorBlock, TensorMap
+from equistore import Labels
 
 DATA_ROOT = os.path.join(os.path.dirname(__file__), "..", "data")
 TEST_FILE = "qm7-spherical-expansion.npz"
 
 
-class TestSlice(unittest.TestCase):
-    """
-    Unit tests for the slice functions.
-    Tests are organised into several 'Test Blocks' as follows:
-        1) Slicing samples dimension of tensors without gradients.
-        2) Slicing samples dimension of tensors with gradients.
-        3) Slicing properties dimension of tensors without gradients.
-        4) Slicing properties dimension of tensors with gradients.
-        5) Slicing samples and properties dimensions simultaneously.
-        6) Testing the type handling of the user-facing slice function.
-        7) Checking issuance of user warnings when empty blocks are
-            created.
-    """
+class TestSliceSamples(unittest.TestCase):
+    """Slicing samples dimension of TensorMap and TensorBlock"""
 
-    # TEST BLOCK 1: SLICING SAMPLES WITHOUT GRADIENTS
-
-    def test_slice_samples_block_no_gradients(self):
-        tensor = equistore.io.load(
+    def setUp(self):
+        self.tensor = equistore.io.load(
             os.path.join(DATA_ROOT, TEST_FILE),
             use_numpy=True,
         )
-        # Remove the gradients to simplify test
-        tensor = fn.remove_gradients(tensor)
-        # Define a single block to test
-        block = tensor.block(0)
-        # Slice only 'structures' 2, 4, 6, 8
-        structures_to_keep = np.arange(2, 10, 2).reshape(-1, 1)
-        samples_to_slice = Labels(
-            names=["structure"],
-            values=structures_to_keep,
-        )
-        sliced_block = fn.slice_block(
-            block,
-            samples_to_slice=samples_to_slice,
-        )
-        # Check 1: no slicing of properties has occurred
-        self.assertTrue(
-            block.properties.asarray().shape,
-            sliced_block.properties.asarray().shape,
-        )
-        # Check 2: samples have been sliced to the correct dimension
+
+    def _check_sliced_block(self, block, sliced_block, structures_to_keep):
+        # no slicing of properties has occurred
+        self.assertTrue(np.all(block.properties == sliced_block.properties))
+
+        # samples have been sliced to the correct dimension
         self.assertEqual(
             len(sliced_block.samples),
-            len(
-                [
-                    struct_i
-                    for struct_i in block.samples["structure"]
-                    if struct_i in structures_to_keep
-                ]
-            ),
+            len([s for s in block.samples["structure"] if s in structures_to_keep]),
         )
-        # Check 3: samples in sliced block only feature desired strutcure indices
+
+        # samples in sliced block only feature desired structure indices
         self.assertTrue(
-            np.all(
-                [
-                    struct_i in structures_to_keep
-                    for struct_i in sliced_block.samples["structure"]
-                ]
-            )
+            np.all([s in structures_to_keep for s in sliced_block.samples["structure"]])
         )
-        # Check 4: no components have been sliced
-        for i, comp in enumerate(sliced_block.components):
-            self.assertEqual(len(comp), len(block.components[i]))
 
-    def test_slice_samples_tensormap_no_gradients(self):
-        tensor = equistore.io.load(
-            os.path.join(DATA_ROOT, TEST_FILE),
-            use_numpy=True,
-        )
-        # Remove the gradients to simplify test
-        tensor = fn.remove_gradients(tensor)
-        # Slice only 'structures' 2, 4, 6, 8
-        structures_to_keep = np.arange(2, 10, 2).reshape(-1, 1)
-        samples_to_slice = Labels(
-            names=["structure"],
-            values=structures_to_keep,
-        )
-        sliced_tensor = fn.slice(
-            tensor,
-            samples_to_slice=samples_to_slice,
-        )
-        for i, (key, block) in enumerate(tensor):
-            # Check 1: no slicing of properties has occurred
-            self.assertEqual(
-                sliced_tensor.block(i).properties.asarray().shape,
-                block.properties.asarray().shape,
-            )
-            # Check 2: samples have been sliced to the correct dimension
-            self.assertEqual(
-                len(sliced_tensor.block(i).samples),
-                len(
-                    [
-                        struct_i
-                        for struct_i in block.samples["structure"]
-                        if struct_i in structures_to_keep
-                    ]
-                ),
-            )
-            # Check 3: samples in sliced block only feature desired structure indices
-            self.assertTrue(
-                np.all(
-                    [
-                        struct_i in structures_to_keep
-                        for struct_i in sliced_tensor.block(i).samples["structure"]
-                    ]
-                )
-            )
-            # Check 4: no components have been sliced
-            for j, comp in enumerate(block.components):
-                self.assertEqual(len(comp), len(sliced_tensor.block(i).components[j]))
+        # no components have been sliced
+        self.assertEqual(len(sliced_block.components), len(block.components))
+        for sliced_c, c in zip(sliced_block.components, block.components):
+            self.assertTrue(np.all(sliced_c == c))
 
-        # Check 5: all the keys in the sliced tensor are in the original
-        self.assertTrue(np.all([key in tensor.keys for key in sliced_tensor.keys]))
-
-    def test_slice_samples_block_empty_no_gradients(self):
-        tensor = equistore.io.load(
-            os.path.join(DATA_ROOT, TEST_FILE),
-            use_numpy=True,
+        # we have the right values
+        samples_filter = [
+            sample["structure"] in structures_to_keep for sample in block.samples
+        ]
+        self.assertTrue(
+            np.all(sliced_block.values == block.values[samples_filter, ...])
         )
-        # Remove the gradients to simplify test
-        tensor = fn.remove_gradients(tensor)
-        # Define a single block to test
-        block = tensor.block(0)
-        # Slice only 'structures' -1 (i.e. a sample that doesn't exist in the data)
-        structures_to_keep = np.array([-1]).reshape(-1, 1)
-        samples_to_slice = Labels(
-            names=["structure"],
-            values=structures_to_keep,
-        )
-        sliced_block = fn.slice_block(
-            block,
-            samples_to_slice=samples_to_slice,
-        )
-        # Check 1: returned block has no values
-        self.assertTrue(len(sliced_block.values.flatten()) == 0)
 
-        # Check 2: returned block has dimension zero for samples
-        self.assertTrue(sliced_block.values.shape[0] == 0)
+        for parameter, gradient in block.gradients():
+            sliced_gradient = sliced_block.gradient(parameter)
+            # no slicing of properties has occurred
+            self.assertTrue(np.all(sliced_gradient.properties == gradient.properties))
 
-        # Check 3: returned block has original dimension for properties
+            # samples have been sliced to the correct dimension
+
+            # FIXME: this only works for position gradients
+            # self.assertEqual(
+            #     len(sliced_block.samples),
+            #     len(
+            #         [
+            #             s
+            #             for s in gradient.samples["structure"]
+            #             if s in structures_to_keep
+            #         ]
+            #     ),
+            # )
+
+            # same components as the original
+            self.assertEqual(len(gradient.components), len(sliced_gradient.components))
+            for sliced_c, c in zip(sliced_gradient.components, gradient.components):
+                self.assertTrue(np.all(sliced_c == c))
+
+            # TODO: check values
+
+    def _check_empty_block(self, block, sliced_block):
+        # sliced block has no values
+        self.assertEqual(len(sliced_block.values.flatten()), 0)
+        # sliced block has dimension zero for samples
+        self.assertEqual(sliced_block.values.shape[0], 0)
+        # sliced block has original dimension for properties
         self.assertEqual(sliced_block.values.shape[-1], block.values.shape[-1])
 
-    def test_slice_samples_tensormap_empty_no_gradients(self):
-        tensor = equistore.io.load(
-            os.path.join(DATA_ROOT, TEST_FILE),
-            use_numpy=True,
-        )
-        # Remove the gradients to simplify test
-        tensor = fn.remove_gradients(tensor)
-        # Slice only 'structures' -1 (i.e. a sample that doesn't exist in the data)
-        structures_to_keep = np.array([-1]).reshape(-1, 1)
-        samples_to_slice = Labels(
-            names=["structure"],
-            values=structures_to_keep,
-        )
-        sliced_tensor = fn.slice(
-            tensor,
-            samples_to_slice=samples_to_slice,
-        )
-        for _, block in sliced_tensor:
-            # Check 1: all blocks are empty
-            self.assertEqual(len(block.values.flatten()), 0)
+        for parameter, gradient in block.gradients():
+            sliced_gradient = sliced_block.gradient(parameter)
+            # no slicing of properties has occurred
+            self.assertTrue(np.all(sliced_gradient.properties == gradient.properties))
 
-        # Check 2: all the original keys are kept in the output tensor
-        self.assertTrue(np.all([key in sliced_tensor.keys for key in tensor.keys]))
+            # sliced block contains zero samples
+            self.assertEqual(sliced_gradient.data.shape[0], 0)
 
-    # TEST BLOCK 2: SLICING SAMPLES WITH GRADIENTS
-
-    def test_slice_samples_block_gradients(self):
-        tensor = equistore.io.load(
-            os.path.join(DATA_ROOT, TEST_FILE),
-            use_numpy=True,
-        )
-        # Define a single block to test
-        block = tensor.block(0)
+    def test_slice_block(self):
         # Slice only 'structures' 2, 4, 6, 8
         structures_to_keep = np.arange(2, 10, 2).reshape(-1, 1)
         samples_to_slice = Labels(
             names=["structure"],
             values=structures_to_keep,
         )
+        block = self.tensor.block(0)
         sliced_block = fn.slice_block(
             block,
             samples_to_slice=samples_to_slice,
         )
-        for i, (parameter, gradient) in enumerate(sliced_block.gradients()):
-            # Check 1: no slicing of properties has occurred
-            self.assertEqual(
-                list(block.gradients())[i][1].properties.asarray().shape,
-                gradient.properties.asarray().shape,
-            )
-            # Check 2: samples have been sliced to the correct dimension
-            self.assertEqual(
-                len(sliced_block.samples),
-                len(
-                    [
-                        struct_i
-                        for struct_i in block.samples["structure"]
-                        if struct_i in structures_to_keep
-                    ]
-                ),
-            )
-            # Check 3: samples in sliced block only feature desired structure indices
-            self.assertTrue(
-                np.all(
-                    [
-                        struct_i in structures_to_keep
-                        for struct_i in sliced_block.samples["structure"]
-                    ]
-                )
-            )
-            # Check 4: same number of components as original
-            self.assertEqual(
-                len(gradient.components),
-                len(list(block.gradients())[i][1].components),
-            )
+        self._check_sliced_block(block, sliced_block, structures_to_keep)
 
-    def test_slice_samples_block_empty_gradients(self):
-        tensor = equistore.io.load(
-            os.path.join(DATA_ROOT, TEST_FILE),
-            use_numpy=True,
-        )
-        # Define a single block to test
-        block = tensor.block(0)
+        # ===== Slice to an empty block =====
         # Slice only 'structures' -1 (i.e. a sample that doesn't exist in the data)
-        structures_to_keep = np.array([-1]).reshape(-1, 1)
         samples_to_slice = Labels(
             names=["structure"],
-            values=structures_to_keep,
+            values=np.array([-1]).reshape(-1, 1),
         )
-        sliced_block = fn.slice_block(
-            block,
-            samples_to_slice=samples_to_slice,
-        )
-        # Check 1: returned block has no values
-        self.assertEqual(len(sliced_block.values.flatten()), 0)
 
-        for i, (_, gradient) in enumerate(sliced_block.gradients()):
-            # Check 2: all gradients have no values
-            self.assertEqual(len(gradient.data), 0)
-
-            # Check 3: the shape of the Gradient values is equivalent to the
-            # original in all but the samples (i.e. 1st) dimension
-            self.assertEqual(
-                gradient.data.shape[1:],
-                list(block.gradients())[i][1].data.shape[1:],
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            sliced_block = fn.slice_block(
+                block,
+                samples_to_slice=samples_to_slice,
             )
 
-    def test_slice_samples_tensormap_empty_gradients(self):
-        tensor = equistore.io.load(
-            os.path.join(DATA_ROOT, TEST_FILE),
-            use_numpy=True,
-        )
-        # Slice only 'structures' -1 (i.e. a sample that doesn't exist in the data)
-        structures_to_keep = np.array([-1]).reshape(-1, 1)
+        self._check_empty_block(block, sliced_block)
+
+    def test_slice(self):
+        # Slice only 'structures' 2, 4, 6, 8
+        structures_to_keep = np.arange(2, 10, 2).reshape(-1, 1)
         samples_to_slice = Labels(
             names=["structure"],
             values=structures_to_keep,
         )
         sliced_tensor = fn.slice(
-            tensor,
+            self.tensor,
             samples_to_slice=samples_to_slice,
         )
-        for i, (_, block) in enumerate(sliced_tensor):
-            for j, (_, gradient) in enumerate(block.gradients()):
-                # Check 1: all gradient blocks are empty
-                self.assertEqual(len(gradient.data.flatten()), 0)
 
-                # Check 2: the shape of the Gradient values is equivalent to the
-                # original in all but the samples (i.e. 1st) dimension
-                self.assertEqual(
-                    gradient.data.shape[1:],
-                    list(tensor.block(i).gradients())[j][1].data.shape[1:],
-                )
+        for key, block in self.tensor:
+            sliced_block = sliced_tensor.block(key)
+            self._check_sliced_block(block, sliced_block, structures_to_keep)
 
-        # Check 3: all the original keys are kept in the output tensor
-        self.assertTrue(np.all([key in sliced_tensor.keys for key in tensor.keys]))
+        # all the keys in the sliced tensor are in the original
+        self.assertTrue(np.all(self.tensor.keys == sliced_tensor.keys))
 
-    # TEST BLOCK 3: SLICING PROPERTIES WITHOUT GRADIENTS
+        # ===== Slice to all empty blocks =====
+        # Slice only 'structures' -1 (i.e. a sample that doesn't exist in the data)
+        samples_to_slice = Labels(
+            names=["structure"],
+            values=np.array([-1]).reshape(-1, 1),
+        )
 
-    def test_slice_properties_block_no_gradients(self):
-        tensor = equistore.io.load(
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            sliced_tensor = fn.slice(
+                self.tensor,
+                samples_to_slice=samples_to_slice,
+            )
+
+        for _, block in sliced_tensor:
+            # all blocks are empty
+            self._check_empty_block(block, sliced_tensor.block(key))
+
+
+class TestSliceProperties(unittest.TestCase):
+    """Slicing property dimension of TensorMap and TensorBlock"""
+
+    def setUp(self):
+        self.tensor = equistore.io.load(
             os.path.join(DATA_ROOT, TEST_FILE),
             use_numpy=True,
         )
-        # Remove the gradients to simplify test
-        tensor = fn.remove_gradients(tensor)
-        # Define a single block to test
-        block = tensor.block(0)
-        # Slice only 'n' (i.e. radial channels) 1, 3
-        channels_to_keep = np.arange(1, 5, 2).reshape(-1, 1)
-        properties_to_slice = Labels(
-            names=["n"],
-            values=channels_to_keep,
-        )
-        sliced_block = fn.slice_block(
-            block,
-            properties_to_slice=properties_to_slice,
-        )
-        # Check 1: no slicing of samples has occurred
-        self.assertEqual(
-            block.samples.asarray().shape,
-            sliced_block.samples.asarray().shape,
-        )
-        # Check 2: properties have been sliced to the correct dimension
+
+    def _check_sliced_block(self, block, sliced_block, radial_to_keep):
+        # no slicing of samples has occurred
+        self.assertTrue(np.all(block.samples == sliced_block.samples))
+
+        # properties have been sliced to the correct dimension
         self.assertEqual(
             len(sliced_block.properties),
-            len(
-                [
-                    channel_i
-                    for channel_i in block.properties["n"]
-                    if channel_i in channels_to_keep
-                ]
-            ),
+            len([n for n in block.properties["n"] if n in radial_to_keep]),
         )
-        # Check 3: properties in sliced block only feature desired channel indices
+        # properties in sliced block only feature desired radial indices
         self.assertTrue(
-            np.all(
-                [
-                    channel_i in channels_to_keep
-                    for channel_i in sliced_block.properties["n"]
-                ]
-            )
+            np.all([n in radial_to_keep for n in sliced_block.properties["n"]])
         )
-        # Check 4: no components have been sliced
-        for i, comp in enumerate(sliced_block.components):
-            self.assertEqual(len(comp), len(block.components[i]))
 
-    def test_slice_properties_tensormap_no_gradients(self):
-        tensor = equistore.io.load(
-            os.path.join(DATA_ROOT, TEST_FILE),
-            use_numpy=True,
+        # no components have been sliced
+        self.assertEqual(len(sliced_block.components), len(block.components))
+        for sliced_c, c in zip(sliced_block.components, block.components):
+            self.assertTrue(np.all(sliced_c == c))
+
+        # we have the right values
+        property_filter = [
+            property["n"] in radial_to_keep for property in block.properties
+        ]
+        self.assertTrue(
+            np.all(sliced_block.values == block.values[..., property_filter])
         )
-        # Remove the gradients to simplify test
-        tensor = fn.remove_gradients(tensor)
-        # Slice only 'n' (i.e. radial channels) 1, 3
-        channels_to_keep = np.arange(1, 5, 2).reshape(-1, 1)
-        properties_to_slice = Labels(
-            names=["n"],
-            values=channels_to_keep,
-        )
-        sliced_tensor = fn.slice(
-            tensor,
-            properties_to_slice=properties_to_slice,
-        )
-        for i, (key, block) in enumerate(tensor):
-            # Check 1: no slicing of samples has occurred
+
+        for parameter, gradient in block.gradients():
+            sliced_gradient = sliced_block.gradient(parameter)
+            # no slicing of samples has occurred
+            self.assertTrue(np.all(sliced_gradient.samples == gradient.samples))
+
+            # properties have been sliced to the correct dimension
             self.assertEqual(
-                sliced_tensor.block(i).samples.asarray().shape,
-                block.samples.asarray().shape,
+                len(sliced_gradient.properties),
+                len([n for n in gradient.properties["n"] if n in radial_to_keep]),
             )
-            # Check 2: properties have been sliced to the correct dimension
-            self.assertEqual(
-                len(sliced_tensor.block(i).properties),
-                len(
-                    [
-                        channel_i
-                        for channel_i in block.properties["n"]
-                        if channel_i in channels_to_keep
-                    ]
-                ),
-            )
-            # Check 3: properties in sliced block only feature desired channel indices
+            # properties in sliced block only feature desired radial indices
             self.assertTrue(
-                np.all(
-                    [
-                        channel_i in channels_to_keep
-                        for channel_i in sliced_tensor.block(i).properties["n"]
-                    ]
-                )
+                np.all([n in radial_to_keep for n in sliced_gradient.properties["n"]])
             )
-            # Check 4: no components have been sliced
-            for j, comp in enumerate(block.components):
-                self.assertEqual(len(comp), len(sliced_tensor.block(i).components[j]))
 
-        # Check 5: all the keys in the sliced tensor are in the original
-        self.assertTrue(np.all([key in tensor.keys for key in sliced_tensor.keys]))
+            # same components as the original
+            self.assertEqual(len(gradient.components), len(sliced_gradient.components))
+            for sliced_c, c in zip(sliced_gradient.components, gradient.components):
+                self.assertTrue(np.all(sliced_c == c))
 
-    def test_slice_properties_block_empty_no_gradients(self):
-        tensor = equistore.io.load(
-            os.path.join(DATA_ROOT, TEST_FILE),
-            use_numpy=True,
-        )
-        # Remove the gradients to simplify test
-        tensor = fn.remove_gradients(tensor)
-        # Define a single block to test
-        block = tensor.block(0)
-        # Slice only 'n' (i.e. radial channels) -1 (i.e. non-existent channel)
-        channels_to_keep = np.array([-1]).reshape(-1, 1)
-        properties_to_slice = Labels(
-            names=["n"],
-            values=channels_to_keep,
-        )
-        sliced_block = fn.slice_block(
-            block,
-            properties_to_slice=properties_to_slice,
-        )
-        # Check 1: returned block has no values
+            # we have the right values
+            self.assertTrue(
+                np.all(sliced_gradient.data == gradient.data[..., property_filter])
+            )
+
+    def _check_empty_block(self, block, sliced_block):
+        # sliced block has no values
         self.assertEqual(len(sliced_block.values.flatten()), 0)
-
-        # Check 2: returned block has dimension zero for properties
+        # sliced block has dimension zero for properties
         self.assertEqual(sliced_block.values.shape[-1], 0)
-
-        # Check 3: returned block has original dimension for samples
+        # sliced block has original dimension for samples
         self.assertEqual(sliced_block.values.shape[0], block.values.shape[0])
 
-    def test_slice_properties_tensormap_empty_no_gradients(self):
-        tensor = equistore.io.load(
-            os.path.join(DATA_ROOT, TEST_FILE),
-            use_numpy=True,
-        )
-        # Remove the gradients to simplify test
-        tensor = fn.remove_gradients(tensor)
-        # Slice only 'n' (i.e. radial channels) -1 (i.e. non-existent channel)
-        channels_to_keep = np.array([-1]).reshape(-1, 1)
-        properties_to_slice = Labels(
-            names=["n"],
-            values=channels_to_keep,
-        )
-        sliced_tensor = fn.slice(
-            tensor,
-            properties_to_slice=properties_to_slice,
-        )
-        for _, block in sliced_tensor:
-            # Check 1: all blocks are empty
-            self.assertEqual(len(block.values.flatten()), 0)
+        for parameter, gradient in block.gradients():
+            sliced_gradient = sliced_block.gradient(parameter)
+            # no slicing of samples has occurred
+            self.assertTrue(np.all(sliced_gradient.samples == gradient.samples))
 
-            # Check 2: the properties dimension is zero
-            self.assertEqual(block.values.shape[-1], 0)
+            # sliced block contains zero properties
+            self.assertEqual(sliced_gradient.data.shape[-1], 0)
 
-        # Check 2: all the original keys are kept in the output tensor
-        self.assertTrue(np.all([key in sliced_tensor.keys for key in tensor.keys]))
-
-    # TEST BLOCK 4: SLICING PROPERTIES WITH GRADIENTS
-
-    def test_slice_properties_block_gradients(self):
-        tensor = equistore.io.load(
-            os.path.join(DATA_ROOT, TEST_FILE),
-            use_numpy=True,
-        )
-        # Define a single block to test
-        block = tensor.block(0)
+    def test_slice_block(self):
         # Slice only 'n' (i.e. radial channels) 1, 3
-        channels_to_keep = np.arange(1, 5, 2).reshape(-1, 1)
+        radial_to_keep = np.arange(1, 5, 2).reshape(-1, 1)
         properties_to_slice = Labels(
             names=["n"],
-            values=channels_to_keep,
+            values=radial_to_keep,
         )
+
+        block = self.tensor.block(0)
         sliced_block = fn.slice_block(
             block,
             properties_to_slice=properties_to_slice,
         )
-        for i, (parameter, gradient) in enumerate(sliced_block.gradients()):
-            # Check 1: no slicing of samples has occurred
-            self.assertEqual(
-                list(block.gradients())[i][1].samples.asarray().shape,
-                gradient.samples.asarray().shape,
-            )
-            # Check 2: properties have been sliced to the correct dimension
-            self.assertEqual(
-                len(sliced_block.properties),
-                len(
-                    [
-                        channel_i
-                        for channel_i in block.properties["n"]
-                        if channel_i in channels_to_keep
-                    ]
-                ),
-            )
-            # Check 3: properties in sliced block only feature desired channel indices
-            self.assertTrue(
-                np.all(
-                    [
-                        channel_i in channels_to_keep
-                        for channel_i in sliced_block.properties["n"]
-                    ]
-                )
-            )
-            # Check 4: same number of components as original
-            self.assertEqual(
-                len(gradient.components),
-                len(list(block.gradients())[i][1].components),
-            )
+        self._check_sliced_block(block, sliced_block, radial_to_keep)
 
-    def test_slice_properties_block_empty_gradients(self):
-        tensor = equistore.io.load(
-            os.path.join(DATA_ROOT, TEST_FILE),
-            use_numpy=True,
-        )
-        # Define a single block to test
-        block = tensor.block(0)
+        # ===== Slice to an empty block =====
         # Slice only 'n' (i.e. radial channels) -1 (i.e. non-existent channel)
-        channels_to_keep = np.array([-1]).reshape(-1, 1)
         properties_to_slice = Labels(
             names=["n"],
-            values=channels_to_keep,
+            values=np.array([-1]).reshape(-1, 1),
         )
-        sliced_block = fn.slice_block(
-            block,
-            properties_to_slice=properties_to_slice,
-        )
-        # Check 1: returned block has no values
-        self.assertEqual(len(sliced_block.values.flatten()), 0)
 
-        for i, (_, gradient) in enumerate(sliced_block.gradients()):
-            # Check 2: all gradients have no values
-            self.assertEqual(len(gradient.data.flatten()), 0)
-
-            # Check 3: the shape of the Gradient values is equivalent to the
-            # original in all but the properties (i.e. last) dimension
-            self.assertEqual(
-                gradient.data.shape[:-1],
-                list(block.gradients())[i][1].data.shape[:-1],
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            sliced_block = fn.slice_block(
+                block,
+                properties_to_slice=properties_to_slice,
             )
 
-    def test_slice_properties_tensormap_empty_gradients(self):
-        tensor = equistore.io.load(
-            os.path.join(DATA_ROOT, TEST_FILE),
-            use_numpy=True,
-        )
-        # Slice only 'n' (i.e. radial channels) -1 (i.e. non-existent channel)
-        channels_to_keep = np.array([-1]).reshape(-1, 1)
+        self._check_empty_block(block, sliced_block)
+
+    def test_slice(self):
+        # Slice only 'n' (i.e. radial channels) 1, 3
+        radial_to_keep = np.arange(1, 5, 2).reshape(-1, 1)
         properties_to_slice = Labels(
             names=["n"],
-            values=channels_to_keep,
+            values=radial_to_keep,
         )
+
         sliced_tensor = fn.slice(
-            tensor,
+            self.tensor,
             properties_to_slice=properties_to_slice,
         )
-        for i, (_, block) in enumerate(sliced_tensor):
-            for j, (_, gradient) in enumerate(block.gradients()):
-                # Check 1: all gradient blocks are empty
-                self.assertEqual(len(gradient.data.flatten()), 0)
 
-                # Check 2: the shape of the Gradient values is equivalent to the
-                # original in all but the properties (i.e. last) dimension
-                self.assertEqual(
-                    gradient.data.shape[:-1],
-                    list(tensor.block(i).gradients())[j][1].data.shape[:-1],
-                )
+        for key, block in self.tensor:
+            sliced_block = sliced_tensor.block(key)
+            self._check_sliced_block(block, sliced_block, radial_to_keep)
 
-        # Check 3: all the original keys are kept in the output tensor
-        self.assertTrue(np.all([key in sliced_tensor.keys for key in tensor.keys]))
+        # Check 5: all the keys in the sliced tensor are in the original
+        self.assertTrue(np.all(self.tensor.keys == sliced_tensor.keys))
 
-    # TEST BLOCK 5: SLICING SAMPLES AND PROPERTIES SIMULTANEOUSLY
+        # ===== Slice to all empty blocks =====
+        # Slice only 'n' (i.e. radial channels) -1 (i.e. non-existent channel)
+        properties_to_slice = Labels(
+            names=["n"],
+            values=np.array([-1]).reshape(-1, 1),
+        )
 
-    def test_slice_samples_properties_block(self):
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            sliced_tensor = fn.slice(
+                self.tensor,
+                properties_to_slice=properties_to_slice,
+            )
+
+        for key, block in self.tensor:
+            sliced_block = sliced_tensor.block(key)
+            self._check_empty_block(block, sliced_block)
+
+
+class TestSliceBoth(unittest.TestCase):
+    def test_slice_block(self):
         tensor = equistore.io.load(
             os.path.join(DATA_ROOT, TEST_FILE),
             use_numpy=True,
         )
+
         block = tensor.block(5)
         # Slice 'center' 1, 3, 5
         centers_to_keep = np.arange(1, 7, 2).reshape(-1, 1)
@@ -576,209 +326,183 @@ class TestSlice(unittest.TestCase):
             names=["n"],
             values=channels_to_keep,
         )
+
         sliced_block = fn.slice_block(
             block,
             samples_to_slice=samples_to_slice,
             properties_to_slice=properties_to_slice,
         )
-        # Check 1: only desired centers indices are in the output.
+
+        # only desired samples are in the output.
         self.assertTrue(
-            np.all(
-                [
-                    center_i in centers_to_keep
-                    for center_i in sliced_block.samples["center"]
-                ]
-            )
+            np.all([c in centers_to_keep for c in sliced_block.samples["center"]])
         )
-        # Check 2: only desired centers indices are in the output.
+
+        # only desired properties are in the output
         self.assertTrue(
-            np.all(
-                [
-                    channel_i in channels_to_keep
-                    for channel_i in sliced_block.properties["n"]
-                ]
-            )
+            np.all([n in channels_to_keep for n in sliced_block.properties["n"]])
         )
-        # Check 3: There are the correct number of samples
+
+        # There are the correct number of samples
         self.assertEqual(
             sliced_block.values.shape[0],
-            len(
-                [
-                    sample
-                    for sample in block.samples
-                    if sample["center"] in centers_to_keep
-                ]
-            ),
+            len([s for s in block.samples if s["center"] in centers_to_keep]),
         )
-        # Check 4: There are the correct number of properties
+
+        # There are the correct number of properties
         self.assertEqual(
             sliced_block.values.shape[-1],
-            len([prop for prop in block.properties if prop["n"] in channels_to_keep]),
+            len([p for p in block.properties if p["n"] in channels_to_keep]),
         )
-        # Check 6: actual values are what they should be
+
+        # we have the right values
         samples_filter = [
             sample["center"] in centers_to_keep for sample in block.samples
         ]
-        properties_filter = [prop["n"] in channels_to_keep for prop in block.properties]
-        self.assertTrue(
-            np.array_equal(
-                block.values[samples_filter][..., properties_filter],
-                sliced_block.values,
-            )
-        )
+        properties_filter = [
+            property["n"] in channels_to_keep for property in block.properties
+        ]
+        expected = block.values[samples_filter][..., properties_filter]
+        self.assertTrue(np.all(sliced_block.values == expected))
 
-    # TEST BLOCK 6: TESTING TYPE HANDLING OF USER-FACING SLICE FUNCTION
 
-    def test_slice_type_handling(self):
-        tensor = equistore.io.load(
+class TestSliceErrorsWarnings(unittest.TestCase):
+    def setUp(self):
+        self.tensor = equistore.io.load(
             os.path.join(DATA_ROOT, TEST_FILE),
             use_numpy=True,
         )
-        # Define a single block to test
-        block = tensor.block(0)
-        # Slice 'center' 1, 3, 5
-        structures_to_keep = np.arange(1, 7, 2).reshape(-1, 1)
+
+    def test_slice_errors(self):
+        centers_to_keep = np.arange(1, 7, 2).reshape(-1, 1)
         samples_to_slice = Labels(
             names=["center"],
-            values=structures_to_keep,
+            values=centers_to_keep,
         )
-        # Check 1: TensorBlock -> TypeError
-        with self.assertRaises(TypeError):
-            fn.slice(block, samples_to_slice=samples_to_slice),
-        # Check 2: TensorMap -> TensorMap
-        self.assertTrue(
-            isinstance(fn.slice(tensor, samples_to_slice=samples_to_slice), TensorMap)
+
+        with self.assertRaises(TypeError) as cm:
+            fn.slice(self.tensor.block(0), samples_to_slice=samples_to_slice),
+
+        self.assertEqual(
+            str(cm.exception),
+            "the input tensor must be a `TensorMap` object, if you want to "
+            "to slice a `TensorBlock`, use `slice_block()` instead",
         )
-        # Check 3: passing tensor=float raises TypeError
-        with self.assertRaises(TypeError):
-            fn.slice(5.0, samples_to_slice=samples_to_slice)
-        # Check 4: passing samples_to_slice=np.array raises TypeError
-        with self.assertRaises(TypeError):
+
+        # passing samples_to_slice=np.array raises TypeError
+        with self.assertRaises(TypeError) as cm:
             fn.slice(
-                tensor,
-                samples_to_slice=np.array(
-                    [
-                        [
-                            5,
-                        ],
-                        [
-                            6,
-                        ],
-                    ]
-                ),
+                self.tensor,
+                samples_to_slice=np.array([[5], [6]]),
             )
 
-    def test_slice_block_type_handling(self):
-        tensor = equistore.io.load(
-            os.path.join(DATA_ROOT, TEST_FILE),
-            use_numpy=True,
+        self.assertEqual(
+            str(cm.exception),
+            "samples_to_slice must be a `Labels` object",
         )
-        # Define a single block to test
-        block = tensor.block(0)
-        # Slice 'center' 1, 3, 5
-        structures_to_keep = np.arange(1, 7, 2).reshape(-1, 1)
+
+        # passing properties_to_slice=np.array raises TypeError
+        with self.assertRaises(TypeError) as cm:
+            fn.slice(
+                self.tensor,
+                properties_to_slice=np.array([[5], [6]]),
+            )
+
+        self.assertEqual(
+            str(cm.exception),
+            "properties_to_slice must be a `Labels` object",
+        )
+
+    def test_slice_block_errors(self):
+        centers_to_keep = np.arange(1, 7, 2).reshape(-1, 1)
         samples_to_slice = Labels(
             names=["center"],
-            values=structures_to_keep,
+            values=centers_to_keep,
         )
-        # Check 1: TensorMap -> TypeError
-        with self.assertRaises(TypeError):
-            fn.slice_block(tensor, samples_to_slice=samples_to_slice),
-        # Check 2: TensorBlock -> TensorBlock
-        self.assertTrue(
-            isinstance(
-                fn.slice_block(block, samples_to_slice=samples_to_slice),
-                TensorBlock,
-            )
+
+        with self.assertRaises(TypeError) as cm:
+            fn.slice_block(self.tensor, samples_to_slice=samples_to_slice),
+
+        self.assertEqual(
+            str(cm.exception),
+            "the input tensor must be a `TensorBlock` object, if you want to "
+            "to slice a `TensorMap`, use `slice()` instead",
         )
-        # Check 3: passing tensor=float raises TypeError
-        with self.assertRaises(TypeError):
-            fn.slice_block(5.0, samples_to_slice=samples_to_slice)
-        # Check 4: passing samples_to_slice=np.array raises TypeError
-        with self.assertRaises(TypeError):
+
+        block = self.tensor.block(0)
+        # passing samples_to_slice=np.array raises TypeError
+        with self.assertRaises(TypeError) as cm:
             fn.slice_block(
                 block,
-                samples_to_slice=np.array(
-                    [
-                        [
-                            5,
-                        ],
-                        [
-                            6,
-                        ],
-                    ]
-                ),
+                samples_to_slice=np.array([[5], [6]]),
             )
 
-    # TEST BLOCK 7: TESTING WARNINGS OF THE SLICE FUNCTION
-
-    def test_slice_samples_tensormap_partially_empty_warning(self):
-        tensor = equistore.io.load(
-            os.path.join(DATA_ROOT, TEST_FILE),
-            use_numpy=True,
+        self.assertEqual(
+            str(cm.exception),
+            "samples_to_slice must be a `Labels` object",
         )
-        # Remove the gradients to simplify test
-        tensor = fn.remove_gradients(tensor)
-        # Slice only 'structures' 2
-        structures_to_keep = np.array([2]).reshape(-1, 1)
+
+        # passing properties_to_slice=np.array raises TypeError
+        with self.assertRaises(TypeError) as cm:
+            fn.slice_block(
+                block,
+                properties_to_slice=np.array([[5], [6]]),
+            )
+
+        self.assertEqual(
+            str(cm.exception),
+            "properties_to_slice must be a `Labels` object",
+        )
+
+    def test_warnings(self):
+        # ==== warning when some empty blocks produced
         samples_to_slice = Labels(
             names=["structure"],
-            values=structures_to_keep,
-        )
-        with self.assertWarns(UserWarning) as cm:
-            # Check 1: warning raised as some empty blocks produced
-            fn.slice(
-                tensor,
-                samples_to_slice=samples_to_slice,
-            )
-        self.assertTrue(
-            "Some TensorBlocks in the sliced TensorMap are now empty" in str(cm.warning)
+            values=np.array([2]).reshape(-1, 1),
         )
 
-    def test_slice_samples_tensormap_completely_empty_warning(self):
-        tensor = equistore.io.load(
-            os.path.join(DATA_ROOT, TEST_FILE),
-            use_numpy=True,
+        with self.assertWarns(UserWarning) as cm:
+            fn.slice(
+                self.tensor,
+                samples_to_slice=samples_to_slice,
+            )
+
+        self.assertIn(
+            "Some TensorBlocks in the sliced TensorMap are now empty",
+            str(cm.warning),
         )
-        # Remove the gradients to simplify test
-        tensor = fn.remove_gradients(tensor)
-        # Slice only 'structures' -1 (i.e. a sample that doesn't exist in the data)
-        structures_to_keep = np.array([-1]).reshape(-1, 1)
+
+        # ==== warning when only empty blocks are produced
         samples_to_slice = Labels(
             names=["structure"],
-            values=structures_to_keep,
-        )
-        with self.assertWarns(UserWarning) as cm:
-            # Check 1: warning raised as all empty blocks produced
-            fn.slice(
-                tensor,
-                samples_to_slice=samples_to_slice,
-            )
-        self.assertTrue(
-            "All TensorBlocks in the sliced TensorMap are now empty" in str(cm.warning)
+            values=np.array([-1]).reshape(-1, 1),
         )
 
-    def test_slice_properties_tensormap_completely_empty_warning(self):
-        tensor = equistore.io.load(
-            os.path.join(DATA_ROOT, TEST_FILE),
-            use_numpy=True,
+        with self.assertWarns(UserWarning) as cm:
+            fn.slice(
+                self.tensor,
+                samples_to_slice=samples_to_slice,
+            )
+
+        self.assertIn(
+            "All TensorBlocks in the sliced TensorMap are now empty",
+            str(cm.warning),
         )
-        # Remove the gradients to simplify test
-        tensor = fn.remove_gradients(tensor)
-        # Slice only 'n' (i.e. radial channels) -1 (i.e. non-existent channel)
-        channels_to_keep = np.array([-1]).reshape(-1, 1)
+
         properties_to_slice = Labels(
             names=["n"],
-            values=channels_to_keep,
+            values=np.array([-1]).reshape(-1, 1),
         )
+
         with self.assertWarns(UserWarning) as cm:
-            # Check 1: warning raised as all empty blocks produced
             fn.slice(
-                tensor,
+                self.tensor,
                 properties_to_slice=properties_to_slice,
             )
-        self.assertTrue(
-            "All TensorBlocks in the sliced TensorMap are now empty" in str(cm.warning)
+
+        self.assertIn(
+            "All TensorBlocks in the sliced TensorMap are now empty",
+            str(cm.warning),
         )
 
 


### PR DESCRIPTION
The issue was that the new gradient samples where just picked out of the old ones, but they need to be updated to refer to the new samples. For example, a block with gradient samples `[0, 1, 1, 2, 2, 3]` where samples 1 and 3 where picked need to be updated to read `[0, 0, 1]`. This only applies to the first column (`name = "sample"`) of the  gradient samples.