### PR TITLE
Make Tensormap immutable

### DIFF
--- a/include/equistore.h
+++ b/include/equistore.h
@@ -573,18 +573,20 @@ eqs_status_t eqs_tensormap_blocks_matching(const struct eqs_tensormap_t *tensor,
  * lexicographically sorted. Otherwise they are kept in the order in which
  * they appear in the blocks.
  *
+ * The result is a new tensor map, which should be freed with `eqs_tensormap_free`.
+ *
  * @param tensor pointer to an existing tensor map
  * @param keys_to_move description of the keys to move
  * @param sort_samples whether to sort the samples lexicographically after
  *                     merging blocks
  *
- * @returns The status code of this operation. If the status is not
- *          `EQS_SUCCESS`, you can use `eqs_last_error()` to get the full
- *          error message.
+ * @returns A pointer to the newly allocated tensor map, or a `NULL` pointer in
+ *          case of error. In case of error, you can use `eqs_last_error()`
+ *          to get the error message.
  */
-eqs_status_t eqs_tensormap_keys_to_properties(struct eqs_tensormap_t *tensor,
-                                              struct eqs_labels_t keys_to_move,
-                                              bool sort_samples);
+struct eqs_tensormap_t *eqs_tensormap_keys_to_properties(const struct eqs_tensormap_t *tensor,
+                                                         struct eqs_labels_t keys_to_move,
+                                                         bool sort_samples);
 
 /**
  * Move the given variables from the component labels to the property labels
@@ -601,9 +603,9 @@ eqs_status_t eqs_tensormap_keys_to_properties(struct eqs_tensormap_t *tensor,
  *          `EQS_SUCCESS`, you can use `eqs_last_error()` to get the full
  *          error message.
  */
-eqs_status_t eqs_tensormap_components_to_properties(struct eqs_tensormap_t *tensor,
-                                                    const char *const *variables,
-                                                    uintptr_t variables_count);
+struct eqs_tensormap_t *eqs_tensormap_components_to_properties(struct eqs_tensormap_t *tensor,
+                                                               const char *const *variables,
+                                                               uintptr_t variables_count);
 
 /**
  * Merge blocks with the same value for selected keys variables along the
@@ -635,9 +637,9 @@ eqs_status_t eqs_tensormap_components_to_properties(struct eqs_tensormap_t *tens
  *          `EQS_SUCCESS`, you can use `eqs_last_error()` to get the full
  *          error message.
  */
-eqs_status_t eqs_tensormap_keys_to_samples(struct eqs_tensormap_t *tensor,
-                                           struct eqs_labels_t keys_to_move,
-                                           bool sort_samples);
+struct eqs_tensormap_t *eqs_tensormap_keys_to_samples(const struct eqs_tensormap_t *tensor,
+                                                      struct eqs_labels_t keys_to_move,
+                                                      bool sort_samples);
 
 /**
  * Load a tensor map from the file at the given path.

--- a/include/equistore.hpp
+++ b/include/equistore.hpp
@@ -1560,24 +1560,27 @@ public:
     /// @param keys_to_move description of the keys to move
     /// @param sort_samples whether to sort the merged samples or keep them in
     ///                     the order in which they appear in the original blocks
-    void keys_to_properties(const Labels& keys_to_move, bool sort_samples = true) {
-        details::check_status(eqs_tensormap_keys_to_properties(
+    TensorMap keys_to_properties(const Labels& keys_to_move, bool sort_samples = true) const {
+        auto ptr = eqs_tensormap_keys_to_properties(
             tensor_,
             keys_to_move.as_eqs_labels_t(),
             sort_samples
-        ));
+        );
+
+        details::check_pointer(ptr);
+        return TensorMap(ptr);
     }
 
     /// This function calls `keys_to_properties` with an empty set of `Labels`
     /// with the variables defined in `keys_to_move`
-    void keys_to_properties(const std::vector<std::string>& keys_to_move, bool sort_samples = true) {
-        keys_to_properties(Labels(keys_to_move), sort_samples);
+    TensorMap keys_to_properties(const std::vector<std::string>& keys_to_move, bool sort_samples = true) const {
+        return keys_to_properties(Labels(keys_to_move), sort_samples);
     }
 
     /// This function calls `keys_to_properties` with an empty set of `Labels`
     /// with a single variable: `key_to_move`
-    void keys_to_properties(const std::string& key_to_move, bool sort_samples = true) {
-        keys_to_properties(std::vector<std::string>{key_to_move}, sort_samples);
+    TensorMap keys_to_properties(const std::string& key_to_move, bool sort_samples = true) const {
+        return keys_to_properties(std::vector<std::string>{key_to_move}, sort_samples);
     }
 
     /// Merge blocks with the same value for selected keys variables along the
@@ -1602,24 +1605,27 @@ public:
     /// @param keys_to_move description of the keys to move
     /// @param sort_samples whether to sort the merged samples or keep them in
     ///                     the order in which they appear in the original blocks
-    void keys_to_samples(const Labels& keys_to_move, bool sort_samples = true) {
-        details::check_status(eqs_tensormap_keys_to_samples(
+    TensorMap keys_to_samples(const Labels& keys_to_move, bool sort_samples = true) const {
+        auto ptr = eqs_tensormap_keys_to_samples(
             tensor_,
             keys_to_move.as_eqs_labels_t(),
             sort_samples
-        ));
+        );
+
+        details::check_pointer(ptr);
+        return TensorMap(ptr);
     }
 
     /// This function calls `keys_to_properties` with an empty set of `Labels`
     /// with the variables defined in `keys_to_move`
-    void keys_to_samples(const std::vector<std::string>& keys_to_move, bool sort_samples = true) {
-        keys_to_samples(Labels(keys_to_move), sort_samples);
+    TensorMap keys_to_samples(const std::vector<std::string>& keys_to_move, bool sort_samples = true) const {
+        return keys_to_samples(Labels(keys_to_move), sort_samples);
     }
 
     /// This function calls `keys_to_properties` with an empty set of `Labels`
     /// with a single variable: `key_to_move`
-    void keys_to_samples(const std::string& key_to_move, bool sort_samples = true) {
-        keys_to_samples(std::vector<std::string>{key_to_move}, sort_samples);
+    TensorMap keys_to_samples(const std::string& key_to_move, bool sort_samples = true) const {
+        return keys_to_samples(std::vector<std::string>{key_to_move}, sort_samples);
     }
 
     /// Move the given `variables` from the component labels to the property
@@ -1627,27 +1633,31 @@ public:
     ///
     /// @param variables name of the component variables to move to the
     ///                  properties
-    void components_to_properties(const std::vector<std::string>& variables) {
+    TensorMap  components_to_properties(const std::vector<std::string>& variables) const {
         auto c_variables = std::vector<const char*>();
         for (const auto& v: variables) {
             c_variables.push_back(v.c_str());
         }
 
-        details::check_status(eqs_tensormap_components_to_properties(
+        auto ptr = eqs_tensormap_components_to_properties(
             tensor_,
             c_variables.data(),
             c_variables.size()
-        ));
+        );
+        details::check_pointer(ptr);
+        return TensorMap(ptr);
     }
 
     /// Call `components_to_properties` with a single variable
-    void components_to_properties(const std::string& variable) {
+    TensorMap components_to_properties(const std::string& variable) const {
         const char* c_str = variable.c_str();
-        details::check_status(eqs_tensormap_components_to_properties(
+        auto ptr = eqs_tensormap_components_to_properties(
             tensor_,
             &c_str,
             1
-        ));
+        );
+        details::check_pointer(ptr);
+        return TensorMap(ptr);
     }
 
     /// Load a previously saved `TensorMap` from the given path.

--- a/include/equistore.hpp
+++ b/include/equistore.hpp
@@ -516,7 +516,7 @@ private:
         for (size_t i=0; i<labels.size; i++) {
             auto size = std::strlen(labels.names[i]) + 1;
             auto new_name = static_cast<char*>(std::calloc(1, size));
-            std::strncpy(new_name, labels.names[i], size);
+            std::memcpy(new_name, labels.names[i], size);
             names_.push_back(new_name);
         }
     }
@@ -531,7 +531,7 @@ private:
             // allocate 1 extra char to NULL-terminate the string
             auto size = names[i].size() + 1;
             auto new_name = static_cast<char*>(std::calloc(1, size));
-            std::strncpy(new_name, names[i].data(), size);
+            std::memcpy(new_name, names[i].data(), size);
             names_[i] = new_name;
         }
     }

--- a/python/scripts/generate-declarations.py
+++ b/python/scripts/generate-declarations.py
@@ -8,7 +8,9 @@ from pycparser import c_ast, parse_file
 
 ROOT = os.path.dirname(__file__)
 FAKE_INCLUDES = os.path.join(ROOT, "include")
-EQUISTORE_HEADER = os.path.relpath(os.path.join(ROOT, "..", "include", "equistore.h"))
+EQUISTORE_HEADER = os.path.relpath(
+    os.path.join(ROOT, "..", "..", "include", "equistore.h")
+)
 
 
 class Function:
@@ -228,7 +230,7 @@ def generate_functions(file, functions):
 def generate_declarations():
     data = parse(EQUISTORE_HEADER)
 
-    outpath = os.path.join(ROOT, "..", "equistore", "_c_api.py")
+    outpath = os.path.join(ROOT, "..", "src", "equistore", "_c_api.py")
     with open(outpath, "w") as file:
         file.write(
             """# -*- coding: utf-8 -*-

--- a/python/src/equistore/_c_api.py
+++ b/python/src/equistore/_c_api.py
@@ -208,21 +208,21 @@ def setup_functions(lib):
         eqs_labels_t,
         ctypes.c_bool,
     ]
-    lib.eqs_tensormap_keys_to_properties.restype = _check_status
+    lib.eqs_tensormap_keys_to_properties.restype = POINTER(eqs_tensormap_t)
 
     lib.eqs_tensormap_components_to_properties.argtypes = [
         POINTER(eqs_tensormap_t),
         POINTER(ctypes.c_char_p),
         c_uintptr_t,
     ]
-    lib.eqs_tensormap_components_to_properties.restype = _check_status
+    lib.eqs_tensormap_components_to_properties.restype = POINTER(eqs_tensormap_t)
 
     lib.eqs_tensormap_keys_to_samples.argtypes = [
         POINTER(eqs_tensormap_t),
         eqs_labels_t,
         ctypes.c_bool,
     ]
-    lib.eqs_tensormap_keys_to_samples.restype = _check_status
+    lib.eqs_tensormap_keys_to_samples.restype = POINTER(eqs_tensormap_t)
 
     lib.eqs_tensormap_load.argtypes = [
         ctypes.c_char_p,

--- a/python/src/equistore/data/__init__.py
+++ b/python/src/equistore/data/__init__.py
@@ -4,7 +4,6 @@ from .extract import (  # noqa
     data_origin,
     data_origin_name,
     eqs_array_to_python_array,
-    eqs_array_to_python_wrapper,
     eqs_array_was_allocated_by_python,
     register_external_data_wrapper,
 )

--- a/python/src/equistore/data/extract.py
+++ b/python/src/equistore/data/extract.py
@@ -64,20 +64,6 @@ def register_external_data_wrapper(origin, klass):
     _ADDITIONAL_ORIGINS[_register_origin(origin)] = klass
 
 
-def eqs_array_to_python_wrapper(eqs_array):
-    """
-    Convert a raw eqs_array to the corresponding Python ``ArrayWrapper``
-    instance.
-    """
-    origin = data_origin(eqs_array)
-    if _is_python_origin(origin):
-        return _object_from_ptr(eqs_array.ptr)
-    else:
-        raise ValueError(
-            f"unable to handle data coming from '{data_origin_name(origin)}'"
-        )
-
-
 def eqs_array_to_python_array(eqs_array, parent=None):
     """Convert a raw eqs_array to a Python ``Array``.
 

--- a/python/tests/tensor.py
+++ b/python/tests/tensor.py
@@ -165,9 +165,7 @@ keys: ['key_1' 'key_2']
             self.assertTrue(np.all(block.values == expected_values))
 
     def test_keys_to_properties(self):
-        tensor = test_tensor_map()
-
-        tensor.keys_to_properties("key_1")
+        tensor = test_tensor_map().keys_to_properties("key_1")
 
         self.assertEqual(tensor.keys.names, ("key_2",))
         self.assertEqual(tuple(tensor.keys[0]), (0,))
@@ -233,8 +231,7 @@ keys: ['key_1' 'key_2']
         self.assertTrue(np.all(block.values == np.full((4, 3, 1), 4.0)))
 
     def test_keys_to_samples(self):
-        tensor = test_tensor_map()
-        tensor.keys_to_samples("key_2", sort_samples=True)
+        tensor = test_tensor_map().keys_to_samples("key_2", sort_samples=True)
 
         self.assertEqual(tensor.keys.names, ("key_1",))
         self.assertEqual(tuple(tensor.keys[0]), (0,))
@@ -301,8 +298,7 @@ keys: ['key_1' 'key_2']
         self.assertTrue(np.all(gradient.data == expected))
 
         # unsorted samples
-        tensor = test_tensor_map()
-        tensor.keys_to_samples("key_2", sort_samples=False)
+        tensor = test_tensor_map().keys_to_samples("key_2", sort_samples=False)
 
         block = tensor.block(2)
         self.assertEqual(block.samples.names, ("samples", "key_2"))
@@ -316,8 +312,7 @@ keys: ['key_1' 'key_2']
         self.assertEqual(tuple(block.samples[7]), (5, 3))
 
     def test_components_to_properties(self):
-        tensor = test_tensor_map()
-        tensor.components_to_properties("components")
+        tensor = test_tensor_map().components_to_properties("components")
 
         block = tensor.block(0)
         self.assertEqual(block.samples.names, ("samples",))

--- a/src/c_api/tensor.rs
+++ b/src/c_api/tensor.rs
@@ -66,6 +66,7 @@ pub unsafe extern fn eqs_tensormap(
 ) -> *mut eqs_tensormap_t {
     let mut result = std::ptr::null_mut();
     let unwind_wrapper = std::panic::AssertUnwindSafe(&mut result);
+
     let status = catch_unwind(move || {
         let keys = Labels::try_from(&keys)?;
 
@@ -90,7 +91,7 @@ pub unsafe extern fn eqs_tensormap(
         // force the closure to capture the full unwind_wrapper, not just
         // unwind_wrapper.0
         let _ = &unwind_wrapper;
-        *(unwind_wrapper.0) = eqs_tensormap_t::into_boxed_raw(tensor);
+        *unwind_wrapper.0 = eqs_tensormap_t::into_boxed_raw(tensor);
         Ok(())
     });
 
@@ -256,28 +257,43 @@ pub unsafe extern fn eqs_tensormap_blocks_matching(
 /// lexicographically sorted. Otherwise they are kept in the order in which
 /// they appear in the blocks.
 ///
+/// The result is a new tensor map, which should be freed with `eqs_tensormap_free`.
+///
 /// @param tensor pointer to an existing tensor map
 /// @param keys_to_move description of the keys to move
 /// @param sort_samples whether to sort the samples lexicographically after
 ///                     merging blocks
 ///
-/// @returns The status code of this operation. If the status is not
-///          `EQS_SUCCESS`, you can use `eqs_last_error()` to get the full
-///          error message.
+/// @returns A pointer to the newly allocated tensor map, or a `NULL` pointer in
+///          case of error. In case of error, you can use `eqs_last_error()`
+///          to get the error message.
 #[no_mangle]
 pub unsafe extern fn eqs_tensormap_keys_to_properties(
-    tensor: *mut eqs_tensormap_t,
+    tensor: *const eqs_tensormap_t,
     keys_to_move: eqs_labels_t,
     sort_samples: bool,
-) -> eqs_status_t {
-    catch_unwind(|| {
+) -> *mut eqs_tensormap_t {
+    let mut result = std::ptr::null_mut();
+    let unwind_wrapper = std::panic::AssertUnwindSafe(&mut result);
+
+    let status = catch_unwind(move || {
         check_pointers!(tensor);
 
         let keys_to_move = Labels::try_from(&keys_to_move)?;
-        (*tensor).keys_to_properties(&keys_to_move, sort_samples)?;
+        let moved = (*tensor).keys_to_properties(&keys_to_move, sort_samples)?;
 
+        // force the closure to capture the full unwind_wrapper, not just
+        // unwind_wrapper.0
+        let _ = &unwind_wrapper;
+        *unwind_wrapper.0 = eqs_tensormap_t::into_boxed_raw(moved);
         Ok(())
-    })
+    });
+
+    if !status.is_success() {
+        return std::ptr::null_mut();
+    }
+
+    return result;
 }
 
 
@@ -299,8 +315,11 @@ pub unsafe extern fn eqs_tensormap_components_to_properties(
     tensor: *mut eqs_tensormap_t,
     variables: *const *const c_char,
     variables_count: usize,
-) -> eqs_status_t {
-    catch_unwind(|| {
+) -> *mut eqs_tensormap_t {
+    let mut result = std::ptr::null_mut();
+    let unwind_wrapper = std::panic::AssertUnwindSafe(&mut result);
+
+    let status = catch_unwind(move || {
         check_pointers!(tensor, variables);
 
         let mut rust_variables = Vec::new();
@@ -310,10 +329,21 @@ pub unsafe extern fn eqs_tensormap_components_to_properties(
             rust_variables.push(variable);
         }
 
-        (*tensor).components_to_properties(&rust_variables)?;
+        let moved = (*tensor).components_to_properties(&rust_variables)?;
+
+        // force the closure to capture the full unwind_wrapper, not just
+        // unwind_wrapper.0
+        let _ = &unwind_wrapper;
+        *unwind_wrapper.0 = eqs_tensormap_t::into_boxed_raw(moved);
 
         Ok(())
-    })
+    });
+
+    if !status.is_success() {
+        return std::ptr::null_mut();
+    }
+
+    return result;
 }
 
 /// Merge blocks with the same value for selected keys variables along the
@@ -346,16 +376,29 @@ pub unsafe extern fn eqs_tensormap_components_to_properties(
 ///          error message.
 #[no_mangle]
 pub unsafe extern fn eqs_tensormap_keys_to_samples(
-    tensor: *mut eqs_tensormap_t,
+    tensor: *const eqs_tensormap_t,
     keys_to_move: eqs_labels_t,
     sort_samples: bool,
-) -> eqs_status_t {
-    catch_unwind(|| {
+) -> *mut eqs_tensormap_t {
+    let mut result = std::ptr::null_mut();
+    let unwind_wrapper = std::panic::AssertUnwindSafe(&mut result);
+
+    let status = catch_unwind(move || {
         check_pointers!(tensor);
 
         let keys_to_move = Labels::try_from(&keys_to_move)?;
-        (*tensor).keys_to_samples(&keys_to_move, sort_samples)?;
+        let moved = (*tensor).keys_to_samples(&keys_to_move, sort_samples)?;
 
+        // force the closure to capture the full unwind_wrapper, not just
+        // unwind_wrapper.0
+        let _ = &unwind_wrapper;
+        *unwind_wrapper.0 = eqs_tensormap_t::into_boxed_raw(moved);
         Ok(())
-    })
+    });
+
+    if !status.is_success() {
+        return std::ptr::null_mut();
+    }
+
+    return result;
 }

--- a/src/tensor/mod.rs
+++ b/src/tensor/mod.rs
@@ -273,16 +273,18 @@ impl TensorMap {
 
     /// Move the given variables from the component labels to the property labels
     /// for each block in this `TensorMap`.
-    pub fn components_to_properties(&mut self, variables: &[&str]) -> Result<(), Error> {
+    pub fn components_to_properties(&self, variables: &[&str]) -> Result<TensorMap, Error> {
+        let mut clone = self.clone();
+
         if variables.is_empty() {
-            return Ok(());
+            return Ok(clone);
         }
 
-        for block in &mut self.blocks {
+        for block in &mut clone.blocks {
             block.components_to_properties(variables)?;
         }
 
-        Ok(())
+        return Ok(clone);
     }
 }
 

--- a/tests/cpp/tensor.cpp
+++ b/tests/cpp/tensor.cpp
@@ -33,8 +33,7 @@ TEST_CASE("TensorMap") {
     }
 
     SECTION("keys_to_samples") {
-        auto tensor = test_tensor_map();
-        tensor.keys_to_samples("key_2", /* sort_samples */ true);
+        auto tensor = test_tensor_map().keys_to_samples("key_2", /* sort_samples */ true);
 
         CHECK(tensor.keys() == Labels({"key_1"}, {{0}, {1}, {2}}));
 
@@ -86,8 +85,7 @@ TEST_CASE("TensorMap") {
         CHECK(gradient_3 == expected);
 
         // unsorted samples
-        tensor = test_tensor_map();
-        tensor.keys_to_samples("key_2", /*sort_samples*/ false);
+        tensor = test_tensor_map().keys_to_samples("key_2", /*sort_samples*/ false);
 
         block = tensor.block_by_id(2);
         CHECK(block.samples() == Labels({"samples", "key_2"}, {
@@ -96,8 +94,7 @@ TEST_CASE("TensorMap") {
     }
 
     SECTION("keys_to_properties") {
-        auto tensor = test_tensor_map();
-        tensor.keys_to_properties("key_1");
+        auto tensor = test_tensor_map().keys_to_properties("key_1");
 
         CHECK(tensor.keys() == Labels({"key_2"}, {{0}, {2}, {3}}));
 
@@ -153,8 +150,7 @@ TEST_CASE("TensorMap") {
     }
 
     SECTION("component_to_properties") {
-        auto tensor = test_tensor_map();
-        tensor.components_to_properties("component");
+        auto tensor = test_tensor_map().components_to_properties("component");
 
         auto block = tensor.block_by_id(0);
 


### PR DESCRIPTION
The first commit is extracted from #85, and required to make the second one work.

The second commit fixes #58 and is a API breaking change. It will make #85 easier to implement in full.

```py
# before
tensor = ...
tensor.keys_to_properties("species_neighbor")

# now
tensor = ...
tensor = tensor.keys_to_properties("species_neighbor")
```

TODO before merging:
- [x] update all examples