### PR TITLE
Added more Python versions to the build test

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -89,16 +89,17 @@ jobs:
     name: check examples / benchmarks / Python build
     strategy:
       matrix:
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11']
         include:
           - rust-version: stable
             rust-target: x86_64-unknown-linux-gnu
     steps:
       - uses: actions/checkout@v3
 
-      - name: setup Python
+      - name: set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:
-          python-version: "3.10"
+          python-version: ${{ matrix.python-version }}
 
       - name: setup rust
         uses: actions-rs/toolchain@v1


### PR DESCRIPTION
As discussed in #88 before we move to more modern package/build infrastructure we have to test that this still works on all supported versions. This PR adds a matrix to the build test ranging from Python 3.6 up to 3.11.