### PR TITLE
added the printing of shapes in the print function

### DIFF
--- a/python/src/equistore/block.py
+++ b/python/src/equistore/block.py
@@ -95,19 +95,19 @@ class TensorBlock:
 
     def __repr__(self) -> str:
         s = "TensorBlock\n"
-        s += "    samples: ["
+        s += f"    samples (len: {len(self.samples)}): ["
         for sname in self.samples.names[:-1]:
             s += "'" + sname + "', "
         s += "'" + self.samples.names[-1] + "']"
         s += "\n"
-        s += "    component: ["
+        s += f"    components (len: {[len(c) for c in self.components]}): ["
         for ic in self.components:
             for name in ic.names[:]:
                 s += "'" + name + "', "
         if len(self.components) > 0:
             s = s[:-2]
         s += "]\n"
-        s += "    properties: ["
+        s += f"    properties (len: {len(self.properties)}): ["
         for name in self.properties.names[:-1]:
             s += "'" + name + "', "
         s += "'" + self.properties.names[-1] + "']\n"
@@ -272,19 +272,19 @@ class Gradient:
     def __repr__(self) -> str:
         s = "Gradient TensorBlock \n"
         s += "parameter: '{}'\n".format(self._name)
-        s += "samples: ["
+        s += f"samples (len: {len(self.samples)}): ["
         for sname in self.samples.names[:-1]:
             s += "'" + sname + "', "
         s += "'" + self.samples.names[-1] + "']"
         s += "\n"
-        s += "component: ["
+        s += f"components (len: {[len(c) for c in self.components]}): ["
         for ic in self.components:
             for name in ic.names[:]:
                 s += "'" + name + "', "
         if len(self.components) > 0:
             s = s[:-2]
         s += "]\n"
-        s += "properties: ["
+        s += f"properties (len: {len(self.properties)}): ["
         for name in self.properties.names[:-1]:
             s += "'" + name + "', "
         s += "'" + self.properties.names[-1] + "']"

--- a/python/src/equistore/block.py
+++ b/python/src/equistore/block.py
@@ -101,7 +101,7 @@ class TensorBlock:
         s += "'" + self.samples.names[-1] + "']"
         s += "\n"
         s += "    components ("
-        s += f"{[len(c) for c in self.components]}"[1:-1]
+        s += ", ".join([str(len(c)) for c in self.components])
         s += "): ["
         for ic in self.components:
             for name in ic.names[:]:
@@ -280,7 +280,7 @@ class Gradient:
         s += "'" + self.samples.names[-1] + "']"
         s += "\n"
         s += "components ("
-        s += f"{[len(c) for c in self.components]}"[1:-1]
+        s += ", ".join([str(len(c)) for c in self.components])
         s += "): ["
         for ic in self.components:
             for name in ic.names[:]:

--- a/python/src/equistore/block.py
+++ b/python/src/equistore/block.py
@@ -95,19 +95,21 @@ class TensorBlock:
 
     def __repr__(self) -> str:
         s = "TensorBlock\n"
-        s += f"    samples (len = {len(self.samples)}): ["
+        s += f"    samples ({len(self.samples)}): ["
         for sname in self.samples.names[:-1]:
             s += "'" + sname + "', "
         s += "'" + self.samples.names[-1] + "']"
         s += "\n"
-        s += f"    components (len = {[len(c) for c in self.components]}): ["
+        s += "    components ("
+        s += f"{[len(c) for c in self.components]}"[1:-1]
+        s += "): ["
         for ic in self.components:
             for name in ic.names[:]:
                 s += "'" + name + "', "
         if len(self.components) > 0:
             s = s[:-2]
         s += "]\n"
-        s += f"    properties (len = {len(self.properties)}): ["
+        s += f"    properties ({len(self.properties)}): ["
         for name in self.properties.names[:-1]:
             s += "'" + name + "', "
         s += "'" + self.properties.names[-1] + "']\n"
@@ -272,19 +274,21 @@ class Gradient:
     def __repr__(self) -> str:
         s = "Gradient TensorBlock\n"
         s += "parameter: '{}'\n".format(self._name)
-        s += f"samples (len = {len(self.samples)}): ["
+        s += f"samples ({len(self.samples)}): ["
         for sname in self.samples.names[:-1]:
             s += "'" + sname + "', "
         s += "'" + self.samples.names[-1] + "']"
         s += "\n"
-        s += f"components (len = {[len(c) for c in self.components]}): ["
+        s += "components ("
+        s += f"{[len(c) for c in self.components]}"[1:-1]
+        s += "): ["
         for ic in self.components:
             for name in ic.names[:]:
                 s += "'" + name + "', "
         if len(self.components) > 0:
             s = s[:-2]
         s += "]\n"
-        s += f"properties (len = {len(self.properties)}): ["
+        s += f"properties ({len(self.properties)}): ["
         for name in self.properties.names[:-1]:
             s += "'" + name + "', "
         s += "'" + self.properties.names[-1] + "']"

--- a/python/src/equistore/block.py
+++ b/python/src/equistore/block.py
@@ -95,19 +95,19 @@ class TensorBlock:
 
     def __repr__(self) -> str:
         s = "TensorBlock\n"
-        s += f"    samples (len: {len(self.samples)}): ["
+        s += f"    samples (len = {len(self.samples)}): ["
         for sname in self.samples.names[:-1]:
             s += "'" + sname + "', "
         s += "'" + self.samples.names[-1] + "']"
         s += "\n"
-        s += f"    components (len: {[len(c) for c in self.components]}): ["
+        s += f"    components (len = {[len(c) for c in self.components]}): ["
         for ic in self.components:
             for name in ic.names[:]:
                 s += "'" + name + "', "
         if len(self.components) > 0:
             s = s[:-2]
         s += "]\n"
-        s += f"    properties (len: {len(self.properties)}): ["
+        s += f"    properties (len = {len(self.properties)}): ["
         for name in self.properties.names[:-1]:
             s += "'" + name + "', "
         s += "'" + self.properties.names[-1] + "']\n"
@@ -272,19 +272,19 @@ class Gradient:
     def __repr__(self) -> str:
         s = "Gradient TensorBlock\n"
         s += "parameter: '{}'\n".format(self._name)
-        s += f"samples (len: {len(self.samples)}): ["
+        s += f"samples (len = {len(self.samples)}): ["
         for sname in self.samples.names[:-1]:
             s += "'" + sname + "', "
         s += "'" + self.samples.names[-1] + "']"
         s += "\n"
-        s += f"components (len: {[len(c) for c in self.components]}): ["
+        s += f"components (len = {[len(c) for c in self.components]}): ["
         for ic in self.components:
             for name in ic.names[:]:
                 s += "'" + name + "', "
         if len(self.components) > 0:
             s = s[:-2]
         s += "]\n"
-        s += f"properties (len: {len(self.properties)}): ["
+        s += f"properties (len = {len(self.properties)}): ["
         for name in self.properties.names[:-1]:
             s += "'" + name + "', "
         s += "'" + self.properties.names[-1] + "']"

--- a/python/src/equistore/block.py
+++ b/python/src/equistore/block.py
@@ -270,7 +270,7 @@ class Gradient:
         self._name = name
 
     def __repr__(self) -> str:
-        s = "Gradient TensorBlock \n"
+        s = "Gradient TensorBlock\n"
         s += "parameter: '{}'\n".format(self._name)
         s += f"samples (len: {len(self.samples)}): ["
         for sname in self.samples.names[:-1]:

--- a/python/src/equistore/operations/reduce_over_samples.py
+++ b/python/src/equistore/operations/reduce_over_samples.py
@@ -196,9 +196,9 @@ def sum_over_samples(
     >>> # only 'structure' is left as a sample
     >>> print(tensor_sum.block(0))
     TensorBlock
-        samples (len = 2): ['structure']
-        components (len = []): []
-        properties (len = 3): ['properties']
+        samples (2): ['structure']
+        components (): []
+        properties (3): ['properties']
         gradients: no
     >>> print(tensor_sum.block(0).samples)
     [(0,) (1,)]

--- a/python/src/equistore/operations/reduce_over_samples.py
+++ b/python/src/equistore/operations/reduce_over_samples.py
@@ -196,9 +196,9 @@ def sum_over_samples(
     >>> # only structure is left as a sample
     >>> print(tensor_sum.block(0))
     TensorBlock
-        samples: ['structure']
-        component: []
-        properties: ['properties']
+        samples (len = 2): ['structure']
+        components (len = []): []
+        properties (len = 3): ['properties']
         gradients: no
     >>> print(tensor_sum.block(0).samples)
     [(0,) (1,)]

--- a/python/src/equistore/operations/reduce_over_samples.py
+++ b/python/src/equistore/operations/reduce_over_samples.py
@@ -193,7 +193,7 @@ def sum_over_samples(
     ...
     >>> tensor_sum = sum_over_samples(tensor, samples_names="center")
     ...
-    >>> # only structure is left as a sample
+    >>> # only 'structure' is left as a sample
     >>> print(tensor_sum.block(0))
     TensorBlock
         samples (len = 2): ['structure']

--- a/python/tests/blocks.py
+++ b/python/tests/blocks.py
@@ -14,9 +14,9 @@ class TestBlocks(unittest.TestCase):
             properties=Labels(["properties"], np.array([[5], [3]], dtype=np.int32)),
         )
         expected = """TensorBlock
-    samples (len = 3): ['samples']
-    components (len = []): []
-    properties (len = 2): ['properties']
+    samples (3): ['samples']
+    components (): []
+    properties (2): ['properties']
     gradients: no"""
         self.assertTrue(block.__repr__() == expected)
 
@@ -54,9 +54,9 @@ class TestBlocks(unittest.TestCase):
             properties=Labels(["properties"], np.array([[5], [3]], dtype=np.int32)),
         )
         expected = """TensorBlock
-    samples (len = 3): ['samples']
-    components (len = [3, 2]): ['component_1', 'component_2']
-    properties (len = 2): ['properties']
+    samples (3): ['samples']
+    components (3, 2): ['component_1', 'component_2']
+    properties (2): ['properties']
     gradients: no"""
         self.assertTrue(block.__repr__() == expected)
 
@@ -111,9 +111,9 @@ class TestBlocks(unittest.TestCase):
         )
 
         expected = """TensorBlock
-    samples (len = 3): ['samples']
-    components (len = [3, 2]): ['component_1', 'component_2']
-    properties (len = 2): ['properties']
+    samples (3): ['samples']
+    components (3, 2): ['component_1', 'component_2']
+    properties (2): ['properties']
     gradients: ['parameter']"""
         self.assertTrue(block.__repr__() == expected)
 
@@ -126,9 +126,9 @@ class TestBlocks(unittest.TestCase):
 
         expected_grad = """Gradient TensorBlock
 parameter: 'parameter'
-samples (len = 2): ['sample', 'parameter']
-components (len = [3, 2]): ['component_1', 'component_2']
-properties (len = 2): ['properties']"""
+samples (2): ['sample', 'parameter']
+components (3, 2): ['component_1', 'component_2']
+properties (2): ['properties']"""
         self.assertTrue(gradient.__repr__() == expected_grad)
 
         self.assertEqual(gradient.samples.names, ("sample", "parameter"))

--- a/python/tests/blocks.py
+++ b/python/tests/blocks.py
@@ -14,9 +14,9 @@ class TestBlocks(unittest.TestCase):
             properties=Labels(["properties"], np.array([[5], [3]], dtype=np.int32)),
         )
         expected = """TensorBlock
-    samples: ['samples']
-    component: []
-    properties: ['properties']
+    samples (len: 3): ['samples']
+    components (len: []): []
+    properties (len: 2): ['properties']
     gradients: no"""
         self.assertTrue(block.__repr__() == expected)
 
@@ -53,6 +53,12 @@ class TestBlocks(unittest.TestCase):
             ],
             properties=Labels(["properties"], np.array([[5], [3]], dtype=np.int32)),
         )
+        expected = """TensorBlock
+    samples (len: 3): ['samples']
+    components (len: [3, 2]): ['component_1', 'component_2']
+    properties (len: 2): ['properties']
+    gradients: no"""
+        self.assertTrue(block.__repr__() == expected)
 
         self.assertTrue(np.all(block.values == np.full((3, 3, 2, 2), -1.0)))
 
@@ -104,12 +110,26 @@ class TestBlocks(unittest.TestCase):
             ],
         )
 
+        expected = """TensorBlock
+    samples (len: 3): ['samples']
+    components (len: [3, 2]): ['component_1', 'component_2']
+    properties (len: 2): ['properties']
+    gradients: ['parameter']"""
+        self.assertTrue(block.__repr__() == expected)
+
         self.assertTrue(block.has_gradient("parameter"))
         self.assertFalse(block.has_gradient("something else"))
 
         self.assertEqual(block.gradients_list(), ["parameter"])
 
         gradient = block.gradient("parameter")
+
+        expected_grad = """Gradient TensorBlock
+parameter: 'parameter'
+samples (len: 2): ['sample', 'parameter']
+components (len: [3, 2]): ['component_1', 'component_2']
+properties (len: 2): ['properties']"""
+        self.assertTrue(gradient.__repr__() == expected_grad)
 
         self.assertEqual(gradient.samples.names, ("sample", "parameter"))
         self.assertEqual(len(gradient.samples), 2)

--- a/python/tests/blocks.py
+++ b/python/tests/blocks.py
@@ -14,9 +14,9 @@ class TestBlocks(unittest.TestCase):
             properties=Labels(["properties"], np.array([[5], [3]], dtype=np.int32)),
         )
         expected = """TensorBlock
-    samples (len: 3): ['samples']
-    components (len: []): []
-    properties (len: 2): ['properties']
+    samples (len = 3): ['samples']
+    components (len = []): []
+    properties (len = 2): ['properties']
     gradients: no"""
         self.assertTrue(block.__repr__() == expected)
 
@@ -54,9 +54,9 @@ class TestBlocks(unittest.TestCase):
             properties=Labels(["properties"], np.array([[5], [3]], dtype=np.int32)),
         )
         expected = """TensorBlock
-    samples (len: 3): ['samples']
-    components (len: [3, 2]): ['component_1', 'component_2']
-    properties (len: 2): ['properties']
+    samples (len = 3): ['samples']
+    components (len = [3, 2]): ['component_1', 'component_2']
+    properties (len = 2): ['properties']
     gradients: no"""
         self.assertTrue(block.__repr__() == expected)
 
@@ -111,9 +111,9 @@ class TestBlocks(unittest.TestCase):
         )
 
         expected = """TensorBlock
-    samples (len: 3): ['samples']
-    components (len: [3, 2]): ['component_1', 'component_2']
-    properties (len: 2): ['properties']
+    samples (len = 3): ['samples']
+    components (len = [3, 2]): ['component_1', 'component_2']
+    properties (len = 2): ['properties']
     gradients: ['parameter']"""
         self.assertTrue(block.__repr__() == expected)
 
@@ -126,9 +126,9 @@ class TestBlocks(unittest.TestCase):
 
         expected_grad = """Gradient TensorBlock
 parameter: 'parameter'
-samples (len: 2): ['sample', 'parameter']
-components (len: [3, 2]): ['component_1', 'component_2']
-properties (len: 2): ['properties']"""
+samples (len = 2): ['sample', 'parameter']
+components (len = [3, 2]): ['component_1', 'component_2']
+properties (len = 2): ['properties']"""
         self.assertTrue(gradient.__repr__() == expected_grad)
 
         self.assertEqual(gradient.samples.names, ("sample", "parameter"))


### PR DESCRIPTION
following @ceriottm suggestion, now the print fuction prints also the shapes of the different direction of the tensorblock, basically the block.value.shape .

This first commit is a draft ( do not pass the test becouse i haven't modified them).

i think that there are different possible ways to show the shapes. The codes I have here does that:

```
>> tensor[1]
TensorBlock
     samples (len: 52): ['structure', 'center']
     components (len: [3]): ['spherical_harmonics_m']
     properties (len: 4): ['n']
     gradients: ['cell', 'positions']

>>tensor[1].gradient('positions')
Gradient TensorBlock 
 parameter: 'positions'
 samples (len: 128): ['sample', 'structure', 'atom']
 components (len: [3, 3]): ['direction', 'spherical_harmonics_m']
 properties (len: 4): ['n']
```

Now at each different dimension (sample, components, properties) it has in () the lenght of that dimension in the block.value array. The components is a list of all the lengths (if the are no components it is an empy array like the one after the :)

For the gradient it writes nothing in the TensorBlock (no idea what to write), but when you print one specific gradient it prints all the shapes, with the same spirit.

One other idea is just to add one line that prints the values.shape like:

```
>> tensor[1]
TensorBlock
     values.shape : (52, 3, 4)
     samples: ['structure', 'center']
     components: ['spherical_harmonics_m']
     properties: ['n']
     gradients: ['cell', 'positions']

>>tensor[1].gradient('positions')
Gradient TensorBlock 
 data.shape: (128, 3, 3, 4)
 parameter: 'positions'
 samples: ['sample', 'structure', 'atom']
 components: ['direction', 'spherical_harmonics_m']
 properties: ['n']
```
I think that putting the lenght next to each axis name is clearer. 

What do you think?


