### PR TITLE
Use glibc==2.28 and rust==1.59

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -39,16 +39,16 @@ jobs:
           default: true
           target: ${{ matrix.rust-target }}
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: "3.10"
       - name: build wheel
         env:
           RUST_BUILD_TARGET: ${{ matrix.rust-target }}
         run: |
           python -m pip install wheel
           python setup.py bdist_wheel --plat-name ${{ matrix.platform-name }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: wheels
           path: dist/*.whl
@@ -63,20 +63,20 @@ jobs:
   build-manylinux-wheels:
     runs-on: ubuntu-20.04
     # TODO: add other arch for linux?
-    name: x86_64 manylinux2010
+    name: x86_64 manylinux
     steps:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: build manylinux2010 with rust docker image
-        run: docker build -t manylinux2010-with-rust python/scripts/build-wheels
+      - name: build manylinux with rust docker image
+        run: docker build -t manylinux-with-rust python/scripts/build-wheels
       - name: build wheel in docker
-        run: docker run --rm -v $(pwd):/code manylinux2010-with-rust bash -c "cd /code && /opt/python/cp38-cp38/bin/python setup.py bdist_wheel"
+        run: docker run --rm -v $(pwd):/code manylinux-with-rust bash -c "cd /code && /opt/python/cp38-cp38/bin/python setup.py bdist_wheel"
       - name: run auditwheel in docker
-        run: docker run --rm -v $(pwd):/code manylinux2010-with-rust bash -c "auditwheel repair /code/dist/*.whl -w /code/dist"
+        run: docker run --rm -v $(pwd):/code manylinux-with-rust bash -c "auditwheel repair /code/dist/*.whl -w /code/dist"
       - name: remove wheel with wrong tag
         run: sudo rm dist/*linux_x86_64.whl
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: wheels
           path: dist/*.whl
@@ -96,14 +96,14 @@ jobs:
         with:
           fetch-depth: 0
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: "3.10"
       - name: build sdist
         run: |
           python -m pip install wheel
           python setup.py sdist
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: wheels
           path: dist/*.tar.gz

--- a/.github/workflows/comment-wheels-pr.yml
+++ b/.github/workflows/comment-wheels-pr.yml
@@ -9,7 +9,7 @@ jobs:
     if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v5
+      - uses: actions/github-script@v6
         with:
           script: |
             async function insertUpdateComment(owner, repo, issue_number, purpose, body) {

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,7 +18,7 @@ jobs:
           profile: minimal
           toolchain: stable
       - name: setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: "3.10"
       - name: install dependencies
@@ -53,7 +53,7 @@ jobs:
 
       - name: post link to RTD
         if: github.event_name == 'pull_request'
-        uses: actions/github-script@v5
+        uses: actions/github-script@v6
         with:
           script: |
             async function insertUpdateComment(owner, repo, issue_number, purpose, body) {

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,7 @@ jobs:
 
           # MSRV (Minimally Supported Rust Version)
           - os: ubuntu-20.04
-            rust-version: 1.56
+            rust-version: 1.59
             rust-target: x86_64-unknown-linux-gnu
             build-type: debug
             cargo-build-flags: --all-features
@@ -61,7 +61,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         if: "!matrix.container"
         with:
           python-version: "3.10"
@@ -97,7 +97,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -11,7 +11,7 @@ build:
   apt_packages:
     - cmake
   tools:
-    python: "3.8"
+    python: "3.10"
     rust: "1.61"
 
 # Build documentation in the docs/ directory with Sphinx

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -56,7 +56,7 @@ on equistore:
 - **the rust compiler**: you will need both ``rustc`` (the compiler) and
   ``cargo`` (associated build tool). You can install both using `rustup`_, or
   use a version provided by your operating system. We need at least Rust version
-  1.56 to build equistore.
+  1.59 to build equistore.
 - **Python**: you can install ``Python`` and ``pip`` from your operating system.
   We require a Python version of at least 3.6.
 - **tox**: a Python test runner, cf https://tox.readthedocs.io/en/latest/. You

--- a/python/scripts/build-wheels/Dockerfile
+++ b/python/scripts/build-wheels/Dockerfile
@@ -1,9 +1,11 @@
-FROM quay.io/pypa/manylinux2010_x86_64
+# Use a many linux with a specification
+# manylinux_${GLIBCMAJOR}_${GLIBCMINOR}_${ARCH}
+FROM quay.io/pypa/manylinux_2_28_x86_64
 
 RUN yum install git -y
 RUN git config --global --add safe.directory /code
 
-RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --profile minimal --default-toolchain 1.63
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --profile minimal --default-toolchain stable
 
 ENV PATH="/root/.cargo/bin:${PATH}"
 ENV RUST_BUILD_TARGET="x86_64-unknown-linux-gnu"

--- a/python/src/equistore/operations/join.py
+++ b/python/src/equistore/operations/join.py
@@ -146,7 +146,6 @@ def _join_blocks_along_properties(blocks: List[TensorBlock]) -> TensorBlock:
     )
 
     for parameter, first_gradient in first_block.gradients():
-
         # Different blocks might contain different gradient samples
         gradient_sample_values = np.unique(
             np.hstack([block.gradient(parameter).samples for block in blocks])

--- a/python/src/equistore/operations/slice.py
+++ b/python/src/equistore/operations/slice.py
@@ -320,7 +320,6 @@ def _slice_block(block: TensorBlock, samples=None, properties=None) -> TensorBlo
 
     # Slice each Gradient TensorBlock and add to the new_block.
     for parameter, gradient in block.gradients():
-
         new_grad_data = gradient.data
         new_grad_samples = gradient.samples
 


### PR DESCRIPTION
This PRs updates a number of dependencies to allow building the equistore.

1. All Github actions are upgraded to the latest version
2. Use glibc with version 2.28 of the python wheels. Required by rustup
3. Update the mininal rust version to 1.59. Required by zip.