### PR TITLE
Split function and more numpy-esque slice

### DIFF
--- a/docs/src/reference/python/operations/manipulation/index.rst
+++ b/docs/src/reference/python/operations/manipulation/index.rst
@@ -6,5 +6,6 @@ Manipulation operations
 
     join() <join>
     slice() <slice>
+    split() <split>
     sum_over_samples() and mean_over_samples() <samples-reduction>
     remove_gradients() <remove-gradients>

--- a/docs/src/reference/python/operations/manipulation/split.rst
+++ b/docs/src/reference/python/operations/manipulation/split.rst
@@ -1,0 +1,6 @@
+split
+======
+
+.. autofunction:: equistore.operations.split
+    
+.. autofunction:: equistore.operations.split_block

--- a/python/src/equistore/operations/__init__.py
+++ b/python/src/equistore/operations/__init__.py
@@ -23,6 +23,7 @@ from .reduce_over_samples import mean_over_samples, sum_over_samples  # noqa
 from .remove_gradients import remove_gradients  # noqa
 from .slice import slice, slice_block  # noqa
 from .solve import solve  # noqa
+from .split import split, split_block  # nopa
 from .zeros_like import zeros_like, zeros_like_block  # noqa
 
 
@@ -43,6 +44,8 @@ __all__ = [
     "slice",
     "slice_block",
     "solve",
+    "split",
+    "split_block",
     "sum_over_samples",
     "zeros_like",
 ]

--- a/python/src/equistore/operations/_utils.py
+++ b/python/src/equistore/operations/_utils.py
@@ -3,6 +3,7 @@ from typing import List
 import numpy as np
 
 from ..block import TensorBlock
+from ..labels import Labels
 from ..tensor import TensorMap
 
 
@@ -111,3 +112,22 @@ def _check_parameters_in_gradient_block(
                 f"The requested parameter '{p}' in {fname} is not a valid parameter"
                 "for the TensorBlock"
             )
+
+
+def _labels_equal(a: Labels, b: Labels, exact_order: bool):
+    """
+    For 2 :py:class:`Labels` objects ``a`` and ``b``, returns true if they are
+    exactly equivalent in names, values, and elemental positions. Assumes that
+    the Labels are already searchable, i.e. they belong to a parent TensorBlock
+    or TensorMap.
+    """
+    # They can only be equivalent if the same length
+    if len(a) != len(b):
+        return False
+    # Check the names
+    if not np.all(a.names == b.names):
+        return False
+    if exact_order:
+        return np.all(np.array(a == b))
+    else:
+        return np.all([a_i in b for a_i in a])

--- a/python/src/equistore/operations/_utils.py
+++ b/python/src/equistore/operations/_utils.py
@@ -190,5 +190,4 @@ def _labels_equal(a: Labels, b: Labels, exact_order: bool):
         return False
     if exact_order:
         return np.all(np.array(a == b))
-    else:
-        return np.all([a_i in b for a_i in a])
+    return np.all([a_i in b for a_i in a])

--- a/python/src/equistore/operations/slice.py
+++ b/python/src/equistore/operations/slice.py
@@ -1,4 +1,4 @@
-import warnings
+from typing import Optional, Union
 
 import numpy as np
 
@@ -7,7 +7,11 @@ from ..labels import Labels
 from ..tensor import TensorMap
 
 
-def slice(tensor: TensorMap, samples=None, properties=None) -> TensorMap:
+def slice(
+    tensor: TensorMap,
+    samples: Optional[Labels] = None,
+    properties: Optional[Labels] = None,
+) -> TensorMap:
     """
     Slices an input :py:class:`TensorMap` along the samples and/or properties
     dimension(s). ``samples`` and ``properties`` are
@@ -74,56 +78,21 @@ def slice(tensor: TensorMap, samples=None, properties=None) -> TensorMap:
     :return: a :py:class:`TensorMap` that corresponds to the sliced input
         tensor.
     """
-
-    # Perform input checks
+    # Check input args
     if not isinstance(tensor, TensorMap):
-        raise TypeError(
-            "the input tensor must be a `TensorMap` object, if you want to "
-            "to slice a `TensorBlock`, use `slice_block()` instead"
-        )
+        raise TypeError("``tensor`` should be an equistore ``TensorMap``")
+    _check_args(tensor, samples=samples, properties=properties)
 
-    _check_slice_types(
-        samples=samples,
-        properties=properties,
-        sample_names=tensor.sample_names,
-        property_names=tensor.property_names,
+    return TensorMap(
+        keys=tensor.keys,
+        blocks=[_slice_block(tensor[key], samples, properties) for key in tensor.keys],
     )
-
-    # Slice TensorMap
-    sliced_tensor = _slice_tensormap(
-        tensor,
-        samples=samples,
-        properties=properties,
-    )
-
-    # Calculate which blocks have been sliced to now be empty. True if any
-    # dimension of block.values is 0, False otherwise.
-    empty_blocks = np.array(
-        [np.any(np.array(block.values.shape) == 0) for _, block in sliced_tensor]
-    )
-
-    # Issue warnings if some or all of the blocks are now empty.
-    if np.any(empty_blocks):
-        if np.all(empty_blocks):
-            warnings.warn(
-                "All TensorBlocks in the sliced TensorMap are now empty, "
-                "based on your choice of samples and/or properties to slice by. "
-            )
-        else:
-            warnings.warn(
-                "Some TensorBlocks in the sliced TensorMap are now empty, "
-                "based on your choice of samples and/or properties to slice by. "
-                "The keys of the empty TensorBlocks are:\n "
-                f"{tensor.keys[empty_blocks]}"
-            )
-
-    return sliced_tensor
 
 
 def slice_block(
     block: TensorBlock,
-    samples=None,
-    properties=None,
+    samples: Optional[Labels] = None,
+    properties: Optional[Labels] = None,
 ) -> TensorBlock:
     """
     Slices an input :py:class:`TensorBlock` along the samples and/or properties
@@ -186,70 +155,23 @@ def slice_block(
     :return new_block: a :py:class:`TensorBlock` that corresponds to the sliced
         input.
     """
-
-    # Perform input checks
+    # Check input args
     if not isinstance(block, TensorBlock):
-        raise TypeError(
-            "the input tensor must be a `TensorBlock` object, if you want to "
-            "to slice a `TensorMap`, use `slice()` instead"
-        )
+        raise TypeError("``block`` should be an equistore ``TensorBlock``")
+    _check_args(block, samples=samples, properties=properties)
 
-    _check_slice_types(
-        samples=samples,
-        properties=properties,
-        sample_names=block.samples.names,
-        property_names=block.properties.names,
-    )
-
-    # Slice TensorMap and issue warning if the output block is empty
-    sliced_block = _slice_block(
+    return _slice_block(
         block,
         samples=samples,
         properties=properties,
     )
-    if np.any(np.array(sliced_block.values.shape) == 0):
-        warnings.warn(
-            "Your input TensorBlock is now empty, based on your choice of samples "
-            + "and/or properties to slice by. "
-        )
-
-    return sliced_block
 
 
-def _check_slice_types(
-    samples,
-    properties,
-    sample_names,
-    property_names,
-):
-    """Perform checks for samples/properties"""
-
-    if samples is None and properties is None:
-        raise ValueError(
-            "you must specify either samples or properties (or both) to slice by"
-        )
-
-    if samples is not None:
-        if not isinstance(samples, Labels):
-            raise TypeError("samples must be a `Labels` object")
-        for name in samples.names:
-            if name not in sample_names:
-                raise ValueError(
-                    f"invalid sample name '{name}' which is not part of the input"
-                )
-
-    if properties is not None:
-        if not isinstance(properties, Labels):
-            raise TypeError("properties must be a `Labels` object")
-
-        for name in properties.names:
-            if name not in property_names:
-                raise ValueError(
-                    f"invalid property name '{name}' which is not part of the input"
-                )
-
-
-def _slice_block(block: TensorBlock, samples=None, properties=None) -> TensorBlock:
+def _slice_block(
+    block: TensorBlock,
+    samples: Optional[Labels] = None,
+    properties: Optional[Labels] = None,
+) -> TensorBlock:
     """
     Slices an input :py:class:`TensorBlock` along the samples and/or properties
     dimension(s). ``samples`` and ``properties`` are
@@ -273,7 +195,7 @@ def _slice_block(block: TensorBlock, samples=None, properties=None) -> TensorBlo
     :return new_block: a :py:class:`TensorBlock` that corresponds to the sliced
         input.
     """
-
+    # Store current values for later modification
     new_values = block.values
     new_samples = block.samples
     new_properties = block.properties
@@ -358,35 +280,42 @@ def _slice_block(block: TensorBlock, samples=None, properties=None) -> TensorBlo
     return new_block
 
 
-def _slice_tensormap(tensormap: TensorMap, samples=None, properties=None) -> TensorMap:
+def _check_args(
+    tensor: Union[TensorMap, TensorMap],
+    samples: Optional[Labels] = None,
+    properties: Optional[Labels] = None,
+):
     """
-    Slices an input :py:class:`TensorMap` along the samples and/or properties
-    dimension(s). ``samples`` and ``properties`` are
-    :py:class:`Labels` objects that specify the samples/properties
-    (respectively) names and indices that should be sliced, i.e. kept in the
-    output tensor.
-
-    Note that either ``samples`` or ``properties``, or both,
-    should be specified as input.
-
-    :param tensor: the input :py:class:`TensorMap` to be sliced.
-    :param samples: a :py:class:`Labels` object containing the names
-        and indices of samples to keep in the sliced :py:class:`TensorBlock`
-        output, or each of the sliced :py:class:`TensorBlock` objects of the
-        output :py:class:`TensorMap`. Default value of None indicates no slicing
-        along the samples dimension should occur.
-    :param properties: a :py:class:`Labels` object containing the names
-        and indices of properties to keep in the sliced :py:class:`TensorBlock`
-        output, or each of the sliced :py:class:`TensorBlock` objects of the
-        output :py:class:`TensorMap`. Default value of None indicates no slicing
-        along the properties dimension should occur.
-
-    :return: a :py:class:`TensorMap` that corresponds to the sliced input
-        tensor.
+    Checks the arguments passed to :py:func:`slice` and :py:func:`slice_block`.
     """
-
-    # Iterate over, and slice, each block (+ gradients) of the input TensorMap in turn.
-    return TensorMap(
-        keys=tensormap.keys,
-        blocks=[_slice_block(block, samples, properties) for _, block in tensormap],
-    )
+    # Must pass either samples or properties or both
+    if samples is None and properties is None:
+        raise ValueError(
+            "you must specify either samples or properties (or both) to slice by"
+        )
+    # Get a single block
+    block = tensor.block(0) if isinstance(tensor, TensorMap) else tensor
+    # Check samples Labels if passed
+    if samples is not None:
+        # Check type
+        if not isinstance(samples, Labels):
+            raise TypeError("samples must be a `Labels` object")
+        # Check names
+        s_names = block.samples.names
+        for name in samples.names:
+            if name not in s_names:
+                raise ValueError(
+                    f"invalid sample name '{name}' which is not part of the input"
+                )
+    # Check properties Labels if passed
+    if properties is not None:
+        # Check type
+        if not isinstance(properties, Labels):
+            raise TypeError("properties must be a `Labels` object")
+        # Check names
+        p_names = block.properties.names
+        for name in properties.names:
+            if name not in p_names:
+                raise ValueError(
+                    f"invalid property name '{name}' which is not part of the input"
+                )

--- a/python/src/equistore/operations/slice.py
+++ b/python/src/equistore/operations/slice.py
@@ -288,11 +288,6 @@ def _check_args(
     """
     Checks the arguments passed to :py:func:`slice` and :py:func:`slice_block`.
     """
-    # Must pass either samples or properties or both
-    if samples is None and properties is None:
-        raise ValueError(
-            "you must specify either samples or properties (or both) to slice by"
-        )
     # Get a single block
     block = tensor.block(0) if isinstance(tensor, TensorMap) else tensor
     # Check samples Labels if passed

--- a/python/src/equistore/operations/split.py
+++ b/python/src/equistore/operations/split.py
@@ -202,10 +202,10 @@ def _check_args(
     # Check the names in grouped_idxs Labels are contained within the names for
     # the block
     names = block.samples.names if axis == "samples" else block.properties.names
-    for ref_name in ref_names:
+    for ref_i, ref_name in enumerate(ref_names):
         if ref_name not in names:
             raise ValueError(
-                f"a name passed in a Labels object at position {ref_i} of"
-                + f" ``grouped_idxs`` does not appear in the {axis} names"
+                f"the name ``{ref_name}`` passed in a Labels object at position {ref_i}"
+                + f" of ``grouped_idxs`` does not appear in the ``{axis}`` names"
                 + " of the input tensor"
             )

--- a/python/src/equistore/operations/split.py
+++ b/python/src/equistore/operations/split.py
@@ -181,6 +181,9 @@ def _check_args(
         raise TypeError(
             "``grouped_idxs`` should be passed as a ``list`` of equistore ``Labels``"
         )
+    # If passed as an empty list, return now
+    if len(grouped_idxs) == 0:
+        return
     for idxs in grouped_idxs:
         if not isinstance(idxs, Labels):
             raise TypeError(

--- a/python/src/equistore/operations/split.py
+++ b/python/src/equistore/operations/split.py
@@ -179,7 +179,7 @@ def _check_args(
         raise ValueError("must pass ``axis`` as either 'samples' or 'properties'")
     if not isinstance(grouped_idxs, list):
         raise TypeError(
-            "``axis`` should be passed as a ``list`` of equistore ``Labels``"
+            "``grouped_idxs`` should be passed as a ``list`` of equistore ``Labels``"
         )
     for idxs in grouped_idxs:
         if not isinstance(idxs, Labels):

--- a/python/src/equistore/operations/split.py
+++ b/python/src/equistore/operations/split.py
@@ -1,0 +1,211 @@
+from typing import List, Union
+
+from ..block import TensorBlock
+from ..labels import Labels
+from ..tensor import TensorMap
+from .slice import _slice_block
+
+
+def split(
+    tensor: TensorMap,
+    axis: str,
+    grouped_idxs: List[Labels],
+) -> List[TensorMap]:
+    """
+    Splits an input :py:class:`TensorMap` into mutliple :py:class:`TensorMap`
+    objects based on some specified groups of indices, along either the
+    "samples" or "properties" ``axis``. The number of returned
+    :py:class:`TensorMap`s is equal to the number of :py:class:`Labels` objects
+    passed in ``grouped_idxs``. Each returned :py:class`TensorMap` will have the
+    same keys and number of blocks at the input ``tensor``, but with the
+    dimensions of the blocks reduced to only contain the specified indices for
+    the corresponding group.
+
+    For example, to split a tensor along the "samples" axis, according to the
+    "structure" index, where structures 0, 6, and 7 are in the first returned
+    :py:class`TensorMap`; 2, 3, and 4 in the second; and 1, 5, 8, 9, and 10 in
+    the third:
+
+    .. code-block:: python
+
+        split_tensor = split(
+            tensor,
+            axis="samples",
+            grouped_idxs=[
+                Labels(
+                    names=["structure"],
+                    values=np.array([[0], [6], [7]])
+                ),
+                Labels(
+                    names=["structure"],
+                    values=np.array([[2], [3], [4]])
+                ),
+                Labels(
+                    names=["structure"],
+                    values=np.array([[1], [5], [8], [9], [10]])
+                ),
+            ]
+        )
+
+    :param tensor: a :py:class:`TensorMap` to be split
+    :param axis: a str, either "samples" or "properties", that indicates the
+        :py:class:`TensorBlock` axis along which the named index (or indices) in
+        ``grouped_idxs`` belongs. Each :py:class:`TensorBlock` in each returned
+        :py:class:`TensorMap` could have a reduced dimension along this axis,
+        but the other axes will remain the same size.
+    :param grouped_idxs: a list of :py:class:`Labels` containing the names and
+        values of the indices along the specified ``axis`` which should be in
+        each respective output :py:class:`TensorMap`.
+
+    :return: a list of:py:class:`TensorMap` that corresponds to the split input
+        ``tensor``. Each tensor in the returned list contains only the named
+        indices in the respective py:class:`Labels` object of ``grouped_idxs``.
+    """
+    # Check input args
+    if not isinstance(tensor, TensorMap):
+        raise TypeError("``tensor`` should be an equistore ``TensorMap``")
+    _check_args(tensor, axis, grouped_idxs)
+
+    all_new_blocks = {group_i: [] for group_i in range(len(grouped_idxs))}
+    for key in tensor.keys:
+        new_blocks = _split_block(tensor[key], axis, grouped_idxs)
+
+        for group_i, new_block in enumerate(new_blocks):
+            all_new_blocks[group_i].append(new_block)
+
+    return [
+        TensorMap(keys=tensor.keys, blocks=all_new_blocks[group_i])
+        for group_i in range(len(grouped_idxs))
+    ]
+
+
+def split_block(
+    block: TensorBlock,
+    axis: str,
+    grouped_idxs: List[Labels],
+) -> List[TensorBlock]:
+    """
+    Splits an input :py:class:`TensorBlock` into mutliple
+    :py:class:`TensorBlock` objects based on some specified ``grouped_idxs``,
+    along either the "samples" or "properties" ``axis``. The number of returned
+    :py:class:`TensorBlock`s is equal to the number of :py:class:`Labels`
+    objects passed in ``grouped_idxs``. Each returned :py:class`TensorBlock`
+    will have the same keys and number of blocks at the input ``tensor``, but
+    with the dimensions of the blocks reduced to only contain the specified
+    indices for the corresponding group.
+
+    For example, to split a block along the "samples" axis, according to the
+    "structure" index, where structures 0, 6, and 7 are in the first returned
+    :py:class`TensorMap`; 2, 3, and 4 in the second; and 1, 5, 8, 9, and 10 in
+    the third:
+
+    .. code-block:: python
+
+        split_tensorblock = split_block(
+            block,
+            axis="samples",
+            grouped_idxs=[
+                Labels(
+                    names=["structure"],
+                    values=np.array([[0], [6], [7]])
+                ),
+                Labels(
+                    names=["structure"],
+                    values=np.array([[2], [3], [4]])
+                ),
+                Labels(
+                    names=["structure"],
+                    values=np.array([[1], [5], [8], [9], [10]])
+                ),
+            ]
+        )
+
+    :param block: a :py:class:`TensorBlock` to be split
+    :param axis: a str, either "samples" or "properties", that indicates the
+        :py:class:`TensorBlock` axis along which the named index (or indices) in
+        ``grouped_idxs`` belongs. Each :py:class:`TensorBlock` returned could
+        have a reduced dimension along this axis, but the other axes will remain
+        the same size.
+    :param grouped_idxs: a list of :py:class:`Labels` containing the names and
+        values of the indices along the specified ``axis`` which should be in
+        each respective output :py:class:`TensorBlock`.
+
+    :return: a list of:py:class:`TensorBlock` that corresponds to the split
+        input ``block``. Each block in the returned list contains only the named
+        indices in the respective py:class:`Labels` object of ``grouped_idxs``.
+    """
+    # Check input args
+    if not isinstance(block, TensorBlock):
+        raise TypeError("``block`` should be an equistore ``TensorBlock``")
+    _check_args(block, axis, grouped_idxs)
+
+    return _split_block(block, axis, grouped_idxs)
+
+
+def _split_block(
+    block: TensorBlock,
+    axis: str,
+    grouped_idxs: List[Labels],
+) -> List[TensorBlock]:
+    """
+    Splits a TensorBlock into mutliple blocks, as in the public function
+    :py:func:`split_block` but with no input checks. Note that the block is
+    currently split into N new blocks by performing N number of slice
+    operations. There may be a more efficient way of doing it, but this is not
+    yet implemented.
+    """
+    new_blocks = []
+    for indices in grouped_idxs:
+        # Perfom the slice, either along the samples or properties axis
+        if axis == "samples":
+            new_block = _slice_block(block, samples=indices)
+        else:  # properties
+            new_block = _slice_block(block, properties=indices)
+        new_blocks.append(new_block)
+
+    return new_blocks
+
+
+def _check_args(
+    tensor: Union[TensorMap, TensorBlock], axis: str, grouped_idxs: List[Labels]
+):
+    """
+    Checks the arguments passed to :py:func:`split` and :py:func:`split_block`.
+    """
+    # Check types
+    if not isinstance(axis, str):
+        raise TypeError("``axis`` should be passed as a ``str``")
+    if axis not in ["samples", "properties"]:
+        raise ValueError("must pass ``axis`` as either 'samples' or 'properties'")
+    if not isinstance(grouped_idxs, list):
+        raise TypeError(
+            "``axis`` should be passed as a ``list`` of equistore ``Labels``"
+        )
+    for idxs in grouped_idxs:
+        if not isinstance(idxs, Labels):
+            raise TypeError(
+                "each element in ``grouped_idxs`` must"
+                + " be an equistore ``Labels`` object"
+            )
+    # Check the Labels names are equivalent for all Labels in grouped_idxs
+    ref_names = grouped_idxs[0].names
+    if len(grouped_idxs) > 1:
+        for idxs in grouped_idxs[1:]:
+            if idxs.names != ref_names:
+                raise ValueError(
+                    "the names of all ``Labels`` passed in ``grouped_idxs``"
+                    + " must be equivalent"
+                )
+    # Get a single block
+    block = tensor.block(0) if isinstance(tensor, TensorMap) else tensor
+
+    # Check the names in grouped_idxs Labels are contained within the names for
+    # the block
+    names = block.samples.names if axis == "samples" else block.properties.names
+    for ref_i, ref_name in enumerate(ref_names):
+        if ref_name not in names:
+            raise ValueError(
+                f"a name passed in a Labels object at position {ref_i} of"
+                + f" ``grouped_idxs`` does not appear in the {axis} names"
+                + " of the input tensor"
+            )

--- a/python/src/equistore/operations/split.py
+++ b/python/src/equistore/operations/split.py
@@ -202,7 +202,7 @@ def _check_args(
     # Check the names in grouped_idxs Labels are contained within the names for
     # the block
     names = block.samples.names if axis == "samples" else block.properties.names
-    for ref_i, ref_name in enumerate(ref_names):
+    for ref_name in ref_names:
         if ref_name not in names:
             raise ValueError(
                 f"a name passed in a Labels object at position {ref_i} of"

--- a/python/tests/operations/slice.py
+++ b/python/tests/operations/slice.py
@@ -367,7 +367,7 @@ class TestSliceBoth(unittest.TestCase):
         self.assertTrue(np.all(sliced_block.values == expected))
 
 
-class TestSliceErrorsWarnings(unittest.TestCase):
+class TestSliceErrors(unittest.TestCase):
     def setUp(self):
         self.tensor = equistore.io.load(
             os.path.join(DATA_ROOT, TEST_FILE),
@@ -386,8 +386,7 @@ class TestSliceErrorsWarnings(unittest.TestCase):
 
         self.assertEqual(
             str(cm.exception),
-            "the input tensor must be a `TensorMap` object, if you want to "
-            "to slice a `TensorBlock`, use `slice_block()` instead",
+            "``tensor`` should be an equistore ``TensorMap``",
         )
 
         # passing samples=np.array raises TypeError
@@ -425,9 +424,7 @@ class TestSliceErrorsWarnings(unittest.TestCase):
             fn.slice_block(self.tensor, samples=samples),
 
         self.assertEqual(
-            str(cm.exception),
-            "the input tensor must be a `TensorBlock` object, if you want to "
-            "to slice a `TensorMap`, use `slice()` instead",
+            str(cm.exception), "``block`` should be an equistore ``TensorBlock``"
         )
 
         block = self.tensor.block(0)
@@ -453,57 +450,6 @@ class TestSliceErrorsWarnings(unittest.TestCase):
         self.assertEqual(
             str(cm.exception),
             "properties must be a `Labels` object",
-        )
-
-    def test_warnings(self):
-        # ==== warning when some empty blocks produced
-        samples = Labels(
-            names=["structure"],
-            values=np.array([2]).reshape(-1, 1),
-        )
-
-        with self.assertWarns(UserWarning) as cm:
-            fn.slice(
-                self.tensor,
-                samples=samples,
-            )
-
-        self.assertIn(
-            "Some TensorBlocks in the sliced TensorMap are now empty",
-            str(cm.warning),
-        )
-
-        # ==== warning when only empty blocks are produced
-        samples = Labels(
-            names=["structure"],
-            values=np.array([-1]).reshape(-1, 1),
-        )
-
-        with self.assertWarns(UserWarning) as cm:
-            fn.slice(
-                self.tensor,
-                samples=samples,
-            )
-
-        self.assertIn(
-            "All TensorBlocks in the sliced TensorMap are now empty",
-            str(cm.warning),
-        )
-
-        properties = Labels(
-            names=["n"],
-            values=np.array([-1]).reshape(-1, 1),
-        )
-
-        with self.assertWarns(UserWarning) as cm:
-            fn.slice(
-                self.tensor,
-                properties=properties,
-            )
-
-        self.assertIn(
-            "All TensorBlocks in the sliced TensorMap are now empty",
-            str(cm.warning),
         )
 
 

--- a/python/tests/operations/slice.py
+++ b/python/tests/operations/slice.py
@@ -366,6 +366,23 @@ class TestSliceBoth(unittest.TestCase):
         expected = block.values[samples_filter][..., properties_filter]
         self.assertTrue(np.all(sliced_block.values == expected))
 
+    def test_no_slicing(self):
+        tensor = equistore.io.load(
+            os.path.join(DATA_ROOT, TEST_FILE),
+            use_numpy=True,
+        )
+        # Original tensor returned if no samples/properties to slice by are passed
+        self.assertTrue(
+            fn.equal_block(
+                fn.slice_block(tensor.block(0), samples=None, properties=None),
+                tensor.block(0),
+            )
+        )
+        # Original tensor returned if no samples/properties to slice by are passed
+        self.assertTrue(
+            fn.equal(fn.slice(tensor, samples=None, properties=None), tensor)
+        )
+
 
 class TestSliceErrors(unittest.TestCase):
     def setUp(self):

--- a/python/tests/operations/split.py
+++ b/python/tests/operations/split.py
@@ -452,8 +452,9 @@ class TestSplitErrors(unittest.TestCase):
             fn.split(self.tensor, axis="samples", grouped_idxs=grouped_idxs),
         self.assertEqual(
             str(cm.exception),
-            "a name passed in a Labels object at position 0 of ``grouped_idxs`` does"
-            + " not appear in the samples names of the input tensor",
+            "the name ``front and`` passed in a Labels object at position 0 of "
+            "``grouped_idxs`` does not appear in the ``samples`` names "
+            "of the input tensor",
         )
 
     def test_split_block_errors(self):

--- a/python/tests/operations/split.py
+++ b/python/tests/operations/split.py
@@ -44,7 +44,9 @@ class TestSplitSamples(unittest.TestCase):
             # Check samples indices
             target_idxs = _searchable_labels(grouped_idxs[i])
             actual_idxs = _unique_indices(split_block, "samples", target_names)
-            self.assertTrue(_labels_equal(actual_idxs, target_idxs, exact_order=False))
+            self.assertTrue(
+                fn._utils._labels_equal(actual_idxs, target_idxs, exact_order=False)
+            )
             # No properties split
             self.assertEqual(len(split_block.properties), p_size)
             # No components split
@@ -234,7 +236,9 @@ class TestSplitProperties(unittest.TestCase):
             # Check properties indices
             target_idxs = _searchable_labels(grouped_idxs[i])
             actual_idxs = _unique_indices(split_block, "properties", target_names)
-            self.assertTrue(_labels_equal(actual_idxs, target_idxs, exact_order=False))
+            self.assertTrue(
+                fn._utils._labels_equal(actual_idxs, target_idxs, exact_order=False)
+            )
             # No samples split
             self.assertEqual(len(split_block.samples), s_size)
             # No components split
@@ -407,14 +411,15 @@ class TestSplitErrors(unittest.TestCase):
                 grouped_idxs=self.grouped_idxs,
             ),
         self.assertEqual(
-            str(cm.exception), "must pass ``axis`` as either 'samples' or 'properties'"
+            str(cm.exception),
+            "must pass ``axis`` as either 'samples' or 'properties'",
         )
         # grouped_idxs is Labels not list
         with self.assertRaises(TypeError) as cm:
             fn.split(self.tensor, axis="samples", grouped_idxs=self.grouped_idxs[0]),
         self.assertEqual(
             str(cm.exception),
-            "``axis`` should be passed as a ``list`` of equistore ``Labels``",
+            "``grouped_idxs`` should be passed as a ``list`` of equistore ``Labels``",
         )
         # grouped_idxs is list of str
         with self.assertRaises(TypeError) as cm:
@@ -516,22 +521,6 @@ def _searchable_labels(labels: Labels):
         components=[],
         properties=Labels(["p"], np.array([[0]], dtype=np.int32)),
     ).samples
-
-
-def _labels_equal(a: Labels, b: Labels, exact_order: bool):
-    """
-    For 2 :py:class:`Labels` objects ``a`` and ``b``, returns true if they are
-    exactly equivalent in names, values, and elemental positions. Assumes that
-    the Labels are already searchable, i.e. they belogn to a parent TensorBlock
-    or TensorMap.
-    """
-    # They can only be equivalent if the same length
-    if len(a) != len(b):
-        return False
-    if exact_order:
-        return np.all(np.array(a == b))
-    else:
-        return np.all([a_i in b for a_i in a])
 
 
 if __name__ == "__main__":

--- a/python/tests/operations/split.py
+++ b/python/tests/operations/split.py
@@ -189,6 +189,19 @@ class TestSplitSamples(unittest.TestCase):
         self._check_group_sizes_tensors(split_tensors[:2], grouped_idxs[:2])
         self._check_empty_tensor(self.tensor, split_tensors[2])
 
+    def test_split_block_(self):
+        # All indices present - block with key (2, 6, 6)
+        block = self.tensor.block(
+            spherical_harmonics_l=2, species_center=6, species_neighbor=6
+        )  # has structure samples 0 -> 9 (inc.)
+        grouped_idxs = [
+            Labels(names=["structure"], values=np.array([[0], [6], [7]])),
+            Labels(names=["structure"], values=np.array([[2], [6], [4]])),
+            Labels(names=["structure"], values=np.array([[1], [0], [6], [4]])),
+        ]
+        split_blocks = fn.split_block(block, "samples", grouped_idxs)
+        self._check_split_blocks(block, split_blocks, grouped_idxs)
+
 
 class TestSplitProperties(unittest.TestCase):
     """Splitting property dimension of TensorMap and TensorBlock"""

--- a/python/tests/operations/split.py
+++ b/python/tests/operations/split.py
@@ -204,6 +204,15 @@ class TestSplitSamples(unittest.TestCase):
         split_blocks = fn.split_block(block, "samples", grouped_idxs)
         self._check_split_blocks(block, split_blocks, grouped_idxs)
 
+    def test_no_splitting(self):
+        # Passing no groups of indices returns an empty list
+        # Block
+        self.assertEqual(
+            fn.split_block(self.tensor.block(0), axis="samples", grouped_idxs=[]), []
+        )
+        # TensorMap
+        self.assertEqual(fn.split(self.tensor, axis="samples", grouped_idxs=[]), [])
+
 
 class TestSplitProperties(unittest.TestCase):
     """Splitting property dimension of TensorMap and TensorBlock"""
@@ -377,6 +386,15 @@ class TestSplitProperties(unittest.TestCase):
             [split_tensors[0], split_tensors[2]], [grouped_idxs[0], grouped_idxs[2]]
         )
         self._check_empty_tensor(self.tensor, split_tensors[1])
+
+    def test_no_splitting(self):
+        # Passing no groups of indices returns an empty list
+        # Block
+        self.assertEqual(
+            fn.split_block(self.tensor.block(0), axis="properties", grouped_idxs=[]), []
+        )
+        # TensorMap
+        self.assertEqual(fn.split(self.tensor, axis="properties", grouped_idxs=[]), [])
 
 
 class TestSplitErrors(unittest.TestCase):

--- a/python/tests/operations/split.py
+++ b/python/tests/operations/split.py
@@ -1,0 +1,524 @@
+import os
+import unittest
+from typing import List, Union
+
+import numpy as np
+
+import equistore.io
+import equistore.operations as fn
+from equistore import Labels, TensorBlock, TensorMap
+
+
+DATA_ROOT = os.path.join(os.path.dirname(__file__), "..", "data")
+TEST_FILE_1 = "qm7-spherical-expansion.npz"
+TEST_FILE_2 = "qm7-power-spectrum.npz"
+
+
+class TestSplitSamples(unittest.TestCase):
+    """Splitting samples dimension of TensorMap and TensorBlock"""
+
+    def setUp(self):
+        self.tensor = equistore.io.load(
+            # Use the sph. exp. TensorMap - it has components
+            os.path.join(DATA_ROOT, TEST_FILE_1),
+            use_numpy=True,
+        )
+
+    # === TensorBlock checks
+
+    def _check_split_blocks(
+        self,
+        block: TensorBlock,
+        split_blocks: List[TensorBlock],
+        grouped_idxs: List[Labels],
+    ):
+        # Same number of returned blocks as groups of indices
+        self.assertEqual(len(split_blocks), len(grouped_idxs))
+
+        # Define reference values
+        target_names = list(grouped_idxs[0].names)
+        p_size = len(block.properties)
+        c_sizes = [len(c) for c in block.components]
+        # Checks on each split block
+        for i, split_block in enumerate(split_blocks):
+            # Check samples indices
+            target_idxs = _searchable_labels(grouped_idxs[i])
+            actual_idxs = _unique_indices(split_block, "samples", target_names)
+            self.assertTrue(_labels_equal(actual_idxs, target_idxs, exact_order=False))
+            # No properties split
+            self.assertEqual(len(split_block.properties), p_size)
+            # No components split
+            for c_i, c_size in enumerate(c_sizes):
+                self.assertEqual(len(split_block.components[c_i]), c_size)
+            # Equal values tensor
+            samples_filter = np.array(
+                [
+                    s in _searchable_labels(grouped_idxs[i])
+                    for s in block.samples[target_names]
+                ]
+            )
+            self.assertTrue(
+                np.all(split_block.values == block.values[samples_filter, ...])
+            )
+            # Check gradients
+            for parameter, gradient in block.gradients():
+                split_gradient = split_block.gradient(parameter)
+                # No spilt along properties
+                self.assertTrue(
+                    np.all(split_gradient.properties == gradient.properties)
+                )
+                # Samples map to original samples of parent block updated
+                self.assertLess(
+                    np.max(split_gradient.samples["sample"]),
+                    split_block.values.shape[0],
+                )
+                # other columns in the gradient samples have been sliced correctly
+                gradient_sample_filter = samples_filter[gradient.samples["sample"]]
+                if len(gradient.samples.names) > 0:
+                    expected = gradient.samples.asarray()[gradient_sample_filter, 1:]
+                    sliced_gradient_samples = split_gradient.samples.asarray()[:, 1:]
+                    self.assertTrue(np.all(sliced_gradient_samples == expected))
+
+                # No splitting of components
+                self.assertEqual(
+                    len(gradient.components), len(split_gradient.components)
+                )
+                for sliced_c, c in zip(split_gradient.components, gradient.components):
+                    self.assertTrue(np.all(sliced_c == c))
+                expected = gradient.data[gradient_sample_filter]
+                self.assertTrue(np.all(split_gradient.data == expected))
+
+    def _check_empty_block(self, block, split_block):
+        # sliced block has no values
+        self.assertEqual(len(split_block.values.flatten()), 0)
+        # sliced block has dimension zero for samples
+        self.assertEqual(split_block.values.shape[0], 0)
+        # sliced block has original dimension for properties
+        self.assertEqual(split_block.values.shape[-1], block.values.shape[-1])
+        for parameter, gradient in block.gradients():
+            sliced_gradient = split_block.gradient(parameter)
+            # no slicing of properties has occurred
+            self.assertTrue(np.all(sliced_gradient.properties == gradient.properties))
+            # sliced block contains zero samples
+            self.assertEqual(sliced_gradient.data.shape[0], 0)
+
+    # === TensorMap checks
+
+    def _check_num_blocks_tensor(self, split_tensors: List[TensorMap]):
+        # All returned TensorMaps should have the same number of blocks as the
+        # original
+        for tensor in split_tensors:
+            self.assertEqual(len(tensor.keys), len(self.tensor.keys))
+
+    def _check_group_sizes_tensors(
+        self,
+        split_tensors: List[TensorMap],
+        grouped_idxs: List[Labels],
+    ):
+        # Same number of returned tensors as groups of indices
+        self.assertEqual(len(split_tensors), len(grouped_idxs))
+        # Number of unique idxs in each tensor equal to respective group size
+        for i, tensor in enumerate(split_tensors):
+            unique_idxs = _unique_indices(tensor, "samples", grouped_idxs[i].names)
+            self.assertEqual(len(unique_idxs), len(grouped_idxs[i]))
+
+    def _check_empty_tensor(self, tensor, split_tensor):
+        for key in tensor.keys:
+            self._check_empty_block(tensor[key], split_tensor[key])
+
+    # === main unit tests
+
+    def test_split_block(self):
+        # All indices present - block with key (2, 6, 6)
+        block = self.tensor.block(
+            spherical_harmonics_l=2, species_center=6, species_neighbor=6
+        )  # has structure samples 0 -> 9 (inc.)
+        grouped_idxs = [
+            Labels(names=["structure"], values=np.array([[0], [6], [7]])),
+            Labels(names=["structure"], values=np.array([[2], [3], [4]])),
+            Labels(names=["structure"], values=np.array([[1], [5], [8], [9]])),
+        ]
+        split_blocks = fn.split_block(block, "samples", grouped_idxs)
+        self.assertEqual(
+            np.sum([len(b.samples) for b in split_blocks]), len(block.samples)
+        )
+        self._check_split_blocks(block, split_blocks, grouped_idxs)
+        # All indices present - block with key (2, 6, 8)
+        block = self.tensor.block(
+            spherical_harmonics_l=2, species_center=6, species_neighbor=8
+        )  # has structure samples 4 -> 6 (inc.)
+        grouped_idxs = [
+            Labels(names=["structure"], values=np.array([[4], [6]])),
+            Labels(names=["structure"], values=np.array([[5]])),
+        ]
+        split_blocks = fn.split_block(block, "samples", grouped_idxs)
+        self.assertEqual(
+            np.sum([len(b.samples) for b in split_blocks]), len(block.samples)
+        )
+        self._check_split_blocks(block, split_blocks, grouped_idxs)
+        # Indices not present for first group
+        grouped_idxs_empty = [
+            Labels(names=["structure"], values=np.array([[1], [2]])),  # not present
+            Labels(names=["structure"], values=np.array([[4], [6]])),  # present
+            Labels(names=["structure"], values=np.array([[5]])),  # present
+        ]
+        split_blocks = fn.split_block(block, "samples", grouped_idxs_empty)
+        self._check_split_blocks(block, split_blocks[1:], grouped_idxs_empty[1:])
+        self._check_empty_block(block, split_blocks[0])
+
+    def test_split(self):
+        # Normal - all indices present
+        grouped_idxs = [
+            Labels(names=["structure"], values=np.array([[0], [6], [7]])),
+            Labels(names=["structure"], values=np.array([[2], [3], [4]])),
+            Labels(names=["structure"], values=np.array([[1], [5], [8], [9]])),
+        ]
+        split_tensors = fn.split(self.tensor, "samples", grouped_idxs)
+        self._check_num_blocks_tensor(split_tensors)
+        self._check_group_sizes_tensors(split_tensors, grouped_idxs)
+        # Third returned tensor should be empty
+        grouped_idxs = [
+            Labels(names=["structure"], values=np.array([[6], [7]])),  # present
+            Labels(names=["structure"], values=np.array([[2], [3], [4]])),  # present
+            Labels(
+                names=["structure"], values=np.array([[1], [5], [8], [9]]) * -1
+            ),  # not present
+        ]
+        split_tensors = fn.split(self.tensor, "samples", grouped_idxs)
+        self._check_num_blocks_tensor(split_tensors)
+        self._check_group_sizes_tensors(split_tensors[:2], grouped_idxs[:2])
+        self._check_empty_tensor(self.tensor, split_tensors[2])
+
+
+class TestSplitProperties(unittest.TestCase):
+    """Splitting property dimension of TensorMap and TensorBlock"""
+
+    def setUp(self):
+        self.tensor = equistore.io.load(
+            # Use the pow. spectrum TensorMap - it has no components but
+            # mutliple properties
+            os.path.join(DATA_ROOT, TEST_FILE_2),
+            use_numpy=True,
+        )
+
+    # === TensorBlock checks
+
+    def _check_split_blocks(
+        self,
+        block: TensorBlock,
+        split_blocks: List[TensorBlock],
+        grouped_idxs: List[Labels],
+    ):
+        # Same number of returned blocks as groups of indices
+        self.assertEqual(len(split_blocks), len(grouped_idxs))
+
+        # Define reference values
+        target_names = list(grouped_idxs[0].names)
+        s_size = len(block.samples)
+        c_sizes = [len(c) for c in block.components]
+        # Checks on each split block
+        for i, split_block in enumerate(split_blocks):
+            # Check properties indices
+            target_idxs = _searchable_labels(grouped_idxs[i])
+            actual_idxs = _unique_indices(split_block, "properties", target_names)
+            self.assertTrue(_labels_equal(actual_idxs, target_idxs, exact_order=False))
+            # No samples split
+            self.assertEqual(len(split_block.samples), s_size)
+            # No components split
+            for c_i, c_size in enumerate(c_sizes):
+                self.assertEqual(len(split_block.components[c_i]), c_size)
+            # Equal values tensor
+            properties_filter = np.array(
+                [
+                    p in _searchable_labels(grouped_idxs[i])
+                    for p in block.properties[target_names]
+                ]
+            )
+            self.assertTrue(
+                np.all(split_block.values == block.values[..., properties_filter])
+            )
+            # Check gradients
+            for parameter, gradient in block.gradients():
+                split_gradient = split_block.gradient(parameter)
+                # No splitting of samples
+                self.assertTrue(np.all(split_gradient.samples == gradient.samples))
+                # No splitting of components
+                self.assertEqual(
+                    len(gradient.components), len(split_gradient.components)
+                )
+                for sliced_c, c in zip(split_gradient.components, gradient.components):
+                    self.assertTrue(np.all(sliced_c == c))
+                # Properties sliced correctly
+                self.assertEqual(
+                    len(split_gradient.properties),
+                    len(
+                        [
+                            p
+                            for p in gradient.properties[target_names]
+                            if p in target_idxs
+                        ]
+                    ),
+                )
+                # Correct gradient data
+                self.assertTrue(
+                    np.all(split_gradient.data == gradient.data[..., properties_filter])
+                )
+
+    def _check_empty_block(self, block, split_block):
+        # sliced block has no values
+        self.assertEqual(len(split_block.values.flatten()), 0)
+        # sliced block has dimension zero for properties
+        self.assertEqual(split_block.values.shape[-1], 0)
+        # sliced block has original dimension for samples
+        self.assertEqual(split_block.values.shape[0], block.values.shape[0])
+
+        for parameter, gradient in block.gradients():
+            split_gradient = split_block.gradient(parameter)
+            # no slicing of samples has occurred
+            self.assertTrue(np.all(split_gradient.samples == gradient.samples))
+
+            # sliced block contains zero properties
+            self.assertEqual(split_gradient.data.shape[-1], 0)
+
+    # === TensorMap checks
+
+    def _check_num_blocks_tensor(self, split_tensors: List[TensorMap]):
+        # All returned TensorMaps should have the same number of blocks as the
+        # original
+        for tensor in split_tensors:
+            self.assertEqual(len(tensor.keys), len(self.tensor.keys))
+
+    def _check_group_sizes_tensors(
+        self,
+        split_tensors: List[TensorMap],
+        grouped_idxs: List[Labels],
+    ):
+        # Same number of returned tensors as groups of indices
+        self.assertEqual(len(split_tensors), len(grouped_idxs))
+        # Number of unique idxs in each tensor equal to respective group size
+        for i, tensor in enumerate(split_tensors):
+            unique_idxs = _unique_indices(tensor, "properties", grouped_idxs[i].names)
+            self.assertEqual(len(unique_idxs), len(grouped_idxs[i]))
+
+    def _check_empty_tensor(self, tensor, split_tensor):
+        for key in tensor.keys:
+            self._check_empty_block(tensor[key], split_tensor[key])
+
+    # === main unit tests
+
+    def test_split_block(self):
+        # All indices present - block with key (8, 6, 8) for properties "l" and "n2"
+        block = self.tensor.block(
+            species_center=8, species_neighbor_1=6, species_neighbor_2=8
+        )
+        grouped_idxs = [
+            Labels(names=["l", "n2"], values=np.array([[0, 0], [1, 3], [3, 1]])),
+            Labels(names=["l", "n2"], values=np.array([[4, 2], [4, 3], [4, 1]])),
+            Labels(names=["l", "n2"], values=np.array([[3, 2], [1, 1]])),
+        ]
+        split_blocks = fn.split_block(block, "properties", grouped_idxs)
+        self._check_split_blocks(block, split_blocks, grouped_idxs)
+        # Indices not present for last group
+        grouped_idxs_empty = [
+            Labels(
+                names=["l", "n2"], values=np.array([[0, 0], [1, 3], [3, 1]])
+            ),  # present
+            Labels(
+                names=["l", "n2"], values=np.array([[4, 2], [4, 3], [4, 1]])
+            ),  # present
+            Labels(
+                names=["l", "n2"], values=np.array([[3, 2], [1, 1]]) * -1
+            ),  # not present
+        ]
+        split_blocks = fn.split_block(block, "properties", grouped_idxs_empty)
+        self._check_split_blocks(block, split_blocks[:2], grouped_idxs_empty[:2])
+        self._check_empty_block(block, split_blocks[2])
+
+    def test_split(self):
+        # Normal - all indices present
+        grouped_idxs = [
+            Labels(names=["l", "n2"], values=np.array([[0, 0], [1, 3], [3, 1]])),
+            Labels(names=["l", "n2"], values=np.array([[4, 2], [4, 3], [4, 1]])),
+            Labels(names=["l", "n2"], values=np.array([[3, 2], [1, 1]])),
+        ]
+        split_tensors = fn.split(self.tensor, "properties", grouped_idxs)
+        self._check_num_blocks_tensor(split_tensors)
+        self._check_group_sizes_tensors(split_tensors, grouped_idxs)
+        # Second returned tensor should be empty
+        grouped_idxs = [
+            Labels(
+                names=["l", "n2"], values=np.array([[0, 0], [1, 3], [3, 1]])
+            ),  # present
+            Labels(
+                names=["l", "n2"], values=np.array([[4, 2], [4, 3], [4, 1]]) * -1
+            ),  # not present
+            Labels(names=["l", "n2"], values=np.array([[3, 2], [1, 1]])),  # present
+        ]
+        split_tensors = fn.split(self.tensor, "properties", grouped_idxs)
+        self._check_num_blocks_tensor(split_tensors)
+        self._check_group_sizes_tensors(
+            [split_tensors[0], split_tensors[2]], [grouped_idxs[0], grouped_idxs[2]]
+        )
+        self._check_empty_tensor(self.tensor, split_tensors[1])
+
+
+class TestSplitErrors(unittest.TestCase):
+    def setUp(self):
+        self.tensor = equistore.io.load(
+            os.path.join(DATA_ROOT, TEST_FILE_1),
+            use_numpy=True,
+        )
+        self.block = self.tensor.block(0)
+        self.grouped_idxs = [
+            Labels(names=["structure"], values=np.array([[0], [6], [7]])),
+            Labels(names=["structure"], values=np.array([[2], [3], [4]])),
+            Labels(names=["structure"], values=np.array([[1], [5], [8], [9]])),
+        ]
+
+    def test_split_errors(self):
+        # TypeError not TM
+        with self.assertRaises(TypeError) as cm:
+            fn.split(self.block, axis="samples", grouped_idxs=self.grouped_idxs),
+        self.assertEqual(
+            str(cm.exception), "``tensor`` should be an equistore ``TensorMap``"
+        )
+        # axis not str
+        with self.assertRaises(TypeError) as cm:
+            fn.split(self.tensor, axis=3.14, grouped_idxs=self.grouped_idxs),
+        self.assertEqual(str(cm.exception), "``axis`` should be passed as a ``str``")
+        # axis not "samples" or "properties"
+        with self.assertRaises(ValueError) as cm:
+            fn.split(
+                self.tensor,
+                axis="buongiorno!",
+                grouped_idxs=self.grouped_idxs,
+            ),
+        self.assertEqual(
+            str(cm.exception), "must pass ``axis`` as either 'samples' or 'properties'"
+        )
+        # grouped_idxs is Labels not list
+        with self.assertRaises(TypeError) as cm:
+            fn.split(self.tensor, axis="samples", grouped_idxs=self.grouped_idxs[0]),
+        self.assertEqual(
+            str(cm.exception),
+            "``axis`` should be passed as a ``list`` of equistore ``Labels``",
+        )
+        # grouped_idxs is list of str
+        with self.assertRaises(TypeError) as cm:
+            fn.split(self.tensor, axis="samples", grouped_idxs=["a", "b", "c"]),
+        self.assertEqual(
+            str(cm.exception),
+            "each element in ``grouped_idxs`` must be an equistore ``Labels`` object",
+        )
+        # different names in labels of grouped_idxs
+        grouped_idxs = [
+            Labels(names=["red"], values=np.array([[0], [6], [7]])),
+            Labels(names=["red"], values=np.array([[2], [3], [4]])),
+            Labels(names=["wine"], values=np.array([[1], [5], [8], [9]])),
+        ]
+        with self.assertRaises(ValueError) as cm:
+            fn.split(self.tensor, axis="samples", grouped_idxs=grouped_idxs),
+        self.assertEqual(
+            str(cm.exception),
+            "the names of all ``Labels`` passed in ``grouped_idxs`` must be equivalent",
+        )
+        # a name in grouped_idxs not in the tensor
+        grouped_idxs = [
+            Labels(
+                names=["front and", "center"], values=np.array([[0, 1], [6, 7], [7, 4]])
+            ),
+            Labels(
+                names=["front and", "center"], values=np.array([[2, 4], [3, 3], [4, 7]])
+            ),
+            Labels(
+                names=["front and", "center"],
+                values=np.array([[1, 5], [5, 3], [8, 10]]),
+            ),
+        ]
+        with self.assertRaises(ValueError) as cm:
+            fn.split(self.tensor, axis="samples", grouped_idxs=grouped_idxs),
+        self.assertEqual(
+            str(cm.exception),
+            "a name passed in a Labels object at position 0 of ``grouped_idxs`` does"
+            + " not appear in the samples names of the input tensor",
+        )
+
+    def test_split_block_errors(self):
+        # TypeError not TB
+        with self.assertRaises(TypeError) as cm:
+            fn.split_block(self.tensor, axis="samples", grouped_idxs=self.grouped_idxs),
+        self.assertEqual(
+            str(cm.exception), "``block`` should be an equistore ``TensorBlock``"
+        )
+
+
+def _unique_indices(
+    tensor: Union[TensorMap, TensorBlock],
+    axis: str,
+    names: Union[List[str], str],
+):
+    """
+    For a given ``axis`` (either "samples" or "properties"), and for the given
+    samples/proeprties ``names``, returns a :py:class:`Labels` object of the
+    unique indices in the input ``tensor``, which can be either a
+    :py:class:`TensorMap` or :py:class:`TensorBlock` object.
+    """
+    # Parse tensor into a list of blocks
+    if isinstance(tensor, TensorMap):
+        blocks = tensor.blocks()
+    else:  # TensorBlock
+        blocks = [tensor]
+
+    # Parse the names into a list
+    names = [names] if isinstance(names, str) else names
+    names = list(names) if isinstance(names, tuple) else names
+
+    # Extract indices from each block
+    all_idxs = []
+    for block in blocks:
+        block_idxs = (
+            block.samples[names] if axis == "samples" else block.properties[names]
+        )
+        for idx in block_idxs:
+            all_idxs.append(idx)
+    if len(all_idxs) == 0:  # return an empty Labels, with the correct name
+        return Labels(names=names, values=np.array([[i for i in range(len(names))]]))[
+            :0
+        ]
+
+    # Define the unique indices, convert to a Labels obj, and return
+    unique_idxs = np.unique(all_idxs, axis=0)  # this also sorts the idxs
+    return Labels(names=names, values=np.array([[j for j in i] for i in unique_idxs]))
+
+
+def _searchable_labels(labels: Labels):
+    """
+    Returns the input Labels object but after being used to construct a
+    TensorBlock, so that look-ups can be performed.
+    """
+    return TensorBlock(
+        values=np.full((len(labels), 1), 0.0),
+        samples=labels,
+        components=[],
+        properties=Labels(["p"], np.array([[0]], dtype=np.int32)),
+    ).samples
+
+
+def _labels_equal(a: Labels, b: Labels, exact_order: bool):
+    """
+    For 2 :py:class:`Labels` objects ``a`` and ``b``, returns true if they are
+    exactly equivalent in names, values, and elemental positions. Assumes that
+    the Labels are already searchable, i.e. they belogn to a parent TensorBlock
+    or TensorMap.
+    """
+    # They can only be equivalent if the same length
+    if len(a) != len(b):
+        return False
+    if exact_order:
+        return np.all(np.array(a == b))
+    else:
+        return np.all([a_i in b for a_i in a])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**1. Split**

This PR introduces the ``split`` and ``split_block`` functions, which are essentially wrappers for the private function ``_slice_block`` found in operations/slice.py. They allow tensors (TensorMap or TensorBlock, respectively) to be split into multiple tensors according to a specified index name along either the "samples" or "properties" axis, and returned in a list.

How they work:
```py
import numpy as np
from equistore import io, Labels
from equistore.operations import split

# Load a tensor - i.e. SOAP for 11 training structures (idxs 0 -> 11 inc.)
tensor = io.load("path/to/tensor.npz")

split_tensor = split(
    tensor,
    axis="samples",
    grouped_idxs=[
        Labels(
            names=["structure"],
            values=np.array([[0], [6], [7]])
        ),
        Labels(
            names=["structure"],
            values=np.array([[2], [3], [4]])
        ),
        Labels(
            names=["structure"],
            values=np.array([[1], [5], [8], [9], [10]])
        ),
    ]
)
```
In this case, there are 3 groups of structure indices passed as a list of Labels. Inclusion of the ``axis`` argument means that splitting can only occur along one axis with a single function call, in contrast to the slice function where one can specify both the ``samples`` and ``properties`` Labels to slice with. This is intended, so as to mirror the ``join`` function, for which this operation is essentially the inverse.

The ``split*`` functions wrap the private ``_slice_block`` fxn as opposed to the public ``slice*`` fxns as all appropriate input checks are performed in ``split*`` and so would be run twice by calling ``slice*``. To split a tensor into N tensors, N slice operations have to be performed. This is not the ideal under-the-hood implementation, but no better solution could be found at present.

The ``split`` function provides a basis for a ``split_tensors`` function in equisolve that can be used to perform splitting of multiple TensorMaps at once, i.e. for a train-test(-validation) split.

**2. Slice**

Also included in the same PR are changes to slice and appropriate updates to unit tests. The ``numpy.slice`` function does not raise warnings when slicing arrays to emptiness, so after a discussion with @PicoCentauri it was decided that such warnings should be removed from ``equistore.slice`` too. Checks for the arguments to ``slice`` and ``slice_block`` functions were unified, and the ``_slice_tensormap`` function was removed. Unit tests related to error messages were updated with new messages, and those related to warnings were removed.