### PR TITLE
rewrite of _utils._check_blocks _utils._check_same_gradients,

### DIFF
--- a/docs/src/reference/python/operations/logic/equal.rst
+++ b/docs/src/reference/python/operations/logic/equal.rst
@@ -1,0 +1,10 @@
+equal
+=====
+
+.. autofunction:: equistore.operations.equal
+
+.. autofunction:: equistore.operations.equal_raise
+
+.. autofunction:: equistore.operations.equal_block
+
+.. autofunction:: equistore.operations.equal_block_raise

--- a/docs/src/reference/python/operations/logic/index.rst
+++ b/docs/src/reference/python/operations/logic/index.rst
@@ -5,3 +5,4 @@ Logic function
     :maxdepth: 1
 
     allclose() <allclose>
+    equal() <equal>

--- a/python/src/equistore/operations/__init__.py
+++ b/python/src/equistore/operations/__init__.py
@@ -16,6 +16,7 @@ from .allclose import (  # noqa
 from .divide import divide  # noqa
 from .dot import dot  # noqa
 from .empty_like import empty_like, empty_like_block  # noqa
+from .equal import equal, equal_block, equal_block_raise, equal_raise  # noqa
 from .join import join  # noqa
 from .lstsq import lstsq  # noqa
 from .multiply import multiply  # noqa
@@ -35,9 +36,13 @@ __all__ = [
     "allclose_raise",
     "allclose_block",
     "allclose_block_raise",
-    "empty_like",
     "divide",
     "dot",
+    "empty_like",
+    "equal",
+    "equal_raise",
+    "equal_block",
+    "equal_block_raise",
     "join",
     "lstsq",
     "mean_over_samples",

--- a/python/src/equistore/operations/_dispatch.py
+++ b/python/src/equistore/operations/_dispatch.py
@@ -23,6 +23,20 @@ def _check_all_same_type(arrays, expected_type):
             )
 
 
+def all(a, axis=None):
+    """Test whether all array elements along a given axis evaluate to True.
+
+    This function has the same behavior as
+    ``np.all(array,axis=axis)``.
+    """
+    if isinstance(a, np.ndarray):
+        return np.all(a=a, axis=axis)
+    elif isinstance(a, TorchTensor):
+        return torch.all(input=a, dim=axis)
+    else:
+        raise TypeError(UNKNOWN_ARRAY_TYPE)
+
+
 def allclose(a, b, rtol, atol, equal_nan=False):
     """Compare two arrays using ``allclose``
 

--- a/python/src/equistore/operations/_utils.py
+++ b/python/src/equistore/operations/_utils.py
@@ -89,7 +89,7 @@ def _check_same_gradients(a: TensorBlock, b: TensorBlock, props: List[str], fnam
      for an operation.
 
     The functions verifies that the metadata of the given props is the same
-    (length, names, values).
+    (length, names, values) and in the same order.
 
     If props is None it only checks if the ``'parameters'`` are consistent.
 

--- a/python/src/equistore/operations/_utils.py
+++ b/python/src/equistore/operations/_utils.py
@@ -48,58 +48,121 @@ def _check_blocks(a: TensorBlock, b: TensorBlock, props: List[str], fname: str):
                  ``'components'`` and ``'gradients'``.
     """
     for prop in props:
-        err_msg = f"Inputs to {fname} should have the same {prop}."
+        err_msg = f"Inputs to '{fname}' should have the same {prop}:\n"
+        err_msg_len = f"{prop} of the two `TensorBlock` have not the same lenght."
+        err_msg_1 = f"{prop} are not the same or not in the same order."
+        err_msg_names = f"{prop} names are not the same or not in the same order."
         if prop == "samples":
+            if not len(a.samples) == len(b.samples):
+                raise ValueError(err_msg + err_msg_len)
             if not a.samples.names == b.samples.names:
-                raise ValueError(err_msg)
+                raise ValueError(err_msg + err_msg_names)
             if not np.all(a.samples == b.samples):
-                raise ValueError(err_msg)
+                raise ValueError(err_msg + err_msg_1)
         elif prop == "properties":
+            if not len(a.properties) == len(b.properties):
+                raise ValueError(err_msg + err_msg_len)
             if not a.properties.names == b.properties.names:
-                raise ValueError(err_msg)
+                raise ValueError(err_msg + err_msg_names)
             if not np.all(a.properties == b.properties):
-                raise ValueError(err_msg)
+                raise ValueError(err_msg + err_msg_1)
         elif prop == "components":
             if len(a.components) != len(b.components):
-                raise ValueError(err_msg)
+                raise ValueError(err_msg + err_msg_len)
 
-            for ca in a.components:
-                flag = False
-                for cb in b.components:
-                    if ca.names == cb.names:
-                        flag = True
-                        if not np.all(ca == cb):
-                            raise ValueError(err_msg)
-                # if flag is False ca.names == cb.names has never been satisfied
-                if not flag:
-                    raise ValueError(err_msg)
+            for c1, c2 in zip(a.components, b.components):
+                if not (c1.names == c2.names):
+                    raise ValueError(err_msg + err_msg_names)
 
-        elif prop == "gradients":
-            grads_a = a.gradients_list()
-            grads_b = b.gradients_list()
+                if not np.all(c1 == c2):
+                    raise ValueError(err_msg + err_msg_1)
 
-            if len(grads_a) != len(grads_b) or (
-                not np.all([parameter in grads_b for parameter in grads_a])
-            ):
-                raise ValueError(err_msg)
         else:
             raise ValueError(
                 f"{prop} is not a valid property to check. "
-                "Choose from 'samples', 'properties', 'components' "
-                "or 'gradients'."
+                "Choose from 'samples', 'properties', 'components'."
             )
 
 
-def _check_same_gradients_components(a: TensorBlock, b: TensorBlock, fname: str):
-    for parameter, grad_a in a.gradients():
-        grad_b = b.gradient(parameter)
-        grad_comps_a = np.array(grad_a.components, dtype=object)
-        grad_comps_b = np.array(grad_b.components, dtype=object)
+def _check_same_gradients(a: TensorBlock, b: TensorBlock, props: List[str], fname: str):
+    """Check if metadata between two gradients's TensorBlocks is consistent
+     for an operation.
 
-        if not np.all(grad_comps_a == grad_comps_b):
-            raise ValueError(
-                f"input to {fname} should habe the same gradient components"
-            )
+    The functions verifies that that the metadata of the given props is the same
+    (length, names, values).
+
+    If props is None it only checks if the ``'parameters'`` are consistent.
+
+    :param a: first :py:class:`TensorBlock` for check
+    :param b: second :py:class:`TensorBlock` for check
+    :param props: A list of strings containing the property to check.
+                 Allowed values are ``'samples'`` or ``'properties'``,
+                 ``'components'``. To check only if the ``'parameters'`` are consistent
+                 use ``props=None``, using ``'parameters'`` is allowed
+                  even though deprecated.
+    """
+    err_msg = f"Inputs to {fname} should have the same gradient:\n"
+    grads_a = a.gradients_list()
+    grads_b = b.gradients_list()
+
+    if len(grads_a) != len(grads_b) or (
+        not np.all([parameter in grads_b for parameter in grads_a])
+    ):
+        raise ValueError(f"Inputs to {fname} should have the same gradient parameters.")
+
+    if props is not None:
+        for parameter, grad_a in a.gradients():
+            grad_b = b.gradient(parameter)
+            for prop in props:
+                err_msg_len = (
+                    f'gradient ("{parameter}") {prop} of the two `TensorBlock` '
+                    "have not the same lenght."
+                )
+
+                err_msg_1 = (
+                    f'gradient ("{parameter}") {prop} are not the same or not in the '
+                    "same order."
+                )
+
+                err_msg_names = (
+                    f'gradient ("{parameter}") {prop} names are not the same '
+                    "or not in the same order."
+                )
+
+                if prop == "samples":
+                    if not len(grad_a.samples) == len(grad_b.samples):
+                        raise ValueError(err_msg + err_msg_len)
+                    if not grad_a.samples.names == grad_b.samples.names:
+                        raise ValueError(err_msg + err_msg_names)
+                    if not np.all(grad_a.samples == grad_b.samples):
+                        raise ValueError(err_msg + err_msg_1)
+                elif prop == "properties":
+                    if not len(grad_a.properties) == len(grad_b.properties):
+                        raise ValueError(err_msg + err_msg_len)
+                    if not grad_a.properties.names == grad_b.properties.names:
+                        raise ValueError(err_msg + err_msg_names)
+                    if not np.all(grad_a.properties == grad_b.properties):
+                        raise ValueError(err_msg + err_msg_1)
+                elif prop == "components":
+                    if len(grad_a.components) != len(grad_b.components):
+                        raise ValueError(err_msg + err_msg_len)
+
+                    for c1, c2 in zip(grad_a.components, grad_b.components):
+                        if not (c1.names == c2.names):
+                            raise ValueError(err_msg + err_msg_names)
+
+                        if not np.all(c1 == c2):
+                            raise ValueError(err_msg + err_msg_1)
+                elif prop == "parameters":
+                    # parameters are already checked at the begining but i want to give
+                    # the opportunity to the 'user' to use it, without problems
+                    continue
+                else:
+                    raise ValueError(
+                        f"{prop} is not a valid property of the gradients to check. "
+                        "Choose from 'parameters', 'samples', "
+                        "'properties', 'components'."
+                    )
 
 
 def _check_parameters_in_gradient_block(

--- a/python/src/equistore/operations/_utils.py
+++ b/python/src/equistore/operations/_utils.py
@@ -88,7 +88,7 @@ def _check_same_gradients(a: TensorBlock, b: TensorBlock, props: List[str], fnam
     """Check if metadata between two gradients's TensorBlocks is consistent
      for an operation.
 
-    The functions verifies that that the metadata of the given props is the same
+    The functions verifies that the metadata of the given props is the same
     (length, names, values).
 
     If props is None it only checks if the ``'parameters'`` are consistent.

--- a/python/src/equistore/operations/_utils.py
+++ b/python/src/equistore/operations/_utils.py
@@ -153,11 +153,9 @@ def _check_same_gradients(a: TensorBlock, b: TensorBlock, props: List[str], fnam
 
                         if not np.all(c1 == c2):
                             raise ValueError(err_msg + err_msg_1)
-                elif prop == "parameters":
+                elif prop != "parameters":
                     # parameters are already checked at the begining but i want to give
                     # the opportunity to the 'user' to use it, without problems
-                    continue
-                else:
                     raise ValueError(
                         f"{prop} is not a valid property of the gradients to check. "
                         "Choose from 'parameters', 'samples', "

--- a/python/src/equistore/operations/add.py
+++ b/python/src/equistore/operations/add.py
@@ -2,7 +2,7 @@ from typing import Union
 
 from ..block import TensorBlock
 from ..tensor import TensorMap
-from ._utils import _check_blocks, _check_maps, _check_same_gradients_components
+from ._utils import _check_blocks, _check_maps, _check_same_gradients
 
 
 def add(A: TensorMap, B: Union[float, TensorMap]) -> TensorMap:
@@ -39,10 +39,15 @@ def add(A: TensorMap, B: Union[float, TensorMap]) -> TensorMap:
             _check_blocks(
                 blockA,
                 blockB,
-                props=["samples", "components", "properties", "gradients"],
+                props=["samples", "components", "properties"],
                 fname="add",
             )
-            _check_same_gradients_components(blockA, blockB, "add")
+            _check_same_gradients(
+                blockA,
+                blockB,
+                props=["samples", "components", "properties"],
+                fname="add",
+            )
             blocks.append(_add_block_block(block1=blockA, block2=blockB))
     else:
         # check if can be converted in float (so if it is a constant value)

--- a/python/src/equistore/operations/allclose.py
+++ b/python/src/equistore/operations/allclose.py
@@ -99,9 +99,9 @@ def allclose_block(
     numpy-like ``allclose`` test with the provided ``rtol``, and ``atol``.
 
     If the :py:class:`TensorBlock` contains gradients, then the gradient must
-    also have same samples, components, properties and their data matrices must
-    pass the numpy-like ``allclose`` test with the provided ``rtol``, and
-    ``atol``.
+    also have same (and in the same order) samples, components, properties
+    and their data matrices must pass the numpy-like ``allclose`` test with the
+    provided ``rtol``, and ``atol``.
 
     In practice this function calls :py:func:`allclose_block_raise`, returning
     ``True`` if no exception is rased, `False` otherwise.

--- a/python/src/equistore/operations/allclose.py
+++ b/python/src/equistore/operations/allclose.py
@@ -3,7 +3,7 @@ import numpy as np
 from equistore import TensorBlock, TensorMap
 
 from . import _dispatch
-from ._utils import _check_blocks, _check_maps
+from ._utils import _check_blocks, _check_maps, _check_same_gradients
 
 
 def allclose(
@@ -158,74 +158,15 @@ def allclose_block_raise(
         equal_nan=equal_nan,
     ):
         raise ValueError("values are not allclose")
-
-    if not block1.samples.names == block2.samples.names:
-        raise ValueError("samples names are not the same or not in the same order")
-
-    if not np.all(block1.samples == block2.samples):
-        raise ValueError("samples not the same or not in the same order")
-
-    if not len(block1.properties) == len(block2.properties):
-        raise ValueError("properties not the same or not in the same order")
-    elif not block1.properties.names == block2.properties.names:
-        raise ValueError("properties names are not the same or not in the same order")
-    else:
-        for p1, p2 in zip(block1.properties, block2.properties):
-            if not np.all(p1 == p2):
-                raise ValueError("properties not the same or not in the same order")
-
-    if not (len(block1.components) == len(block2.components)):
-        raise ValueError("different number of components")
-    else:
-        for c1, c2 in zip(block1.components, block2.components):
-            if not (c1.names == c2.names):
-                raise ValueError(
-                    "components names are not the same or not in the same order"
-                )
-
-            if not np.all(c1 == c2):
-                raise ValueError("components not the same or not in the same order")
-
-    _check_blocks(block1, block2, ["gradients"], "allclose")
+    _check_blocks(
+        block1, block2, props=["samples", "properties", "components"], fname="allclose"
+    )
+    _check_same_gradients(
+        block1, block2, props=["samples", "properties", "components"], fname="allclose"
+    )
 
     for parameter, gradient1 in block1.gradients():
         gradient2 = block2.gradient(parameter)
-        if not (gradient1.samples.names == gradient2.samples.names):
-            raise ValueError(
-                f'gradient ("{parameter}") samples names are not the same or '
-                "not in the same order"
-            )
-
-        if len(gradient1.components) != len(gradient2.components):
-            raise ValueError(f'different number of gradient ("{parameter}") components')
-
-        for c1, c2 in zip(gradient1.components, gradient2.components):
-            if not (c1.names == c2.names):
-                raise ValueError(
-                    f'gradient ("{parameter}") components names '
-                    "are not the same or not in the same order"
-                )
-
-            if not np.all(c1 == c2):
-                raise ValueError(
-                    f'gradient ("{parameter}") components not the same or '
-                    "not in the same order"
-                )
-
-        if len(gradient1.properties) != len(gradient2.properties):
-            raise ValueError(f'different number of gradient ("{parameter}") properties')
-        elif not (gradient1.properties.names == gradient2.properties.names):
-            raise ValueError(
-                f'gradient ("{parameter}") properties names are '
-                "not the same or not in the same order"
-            )
-        else:
-            for p1, p2 in zip(gradient1.properties, gradient2.properties):
-                if not np.all(p1 == p2):
-                    raise ValueError(
-                        f'gradient ("{parameter}") properties not the same '
-                        "or not in the same order"
-                    )
 
         if not _dispatch.allclose(
             gradient1.data,

--- a/python/src/equistore/operations/allclose.py
+++ b/python/src/equistore/operations/allclose.py
@@ -17,8 +17,9 @@ def allclose(
 
     This function returns ``True`` if the two tensors have the same keys
     (potentially in different order) and all the :py:class:`TensorBlock` have
-    the same samples, components, properties, and their values matrices pass the
-    numpy-like ``allclose`` test with the provided ``rtol``, and ``atol``.
+    the same (and in the same order) samples, components, properties,
+    and their values matrices pass the numpy-like ``allclose`` test with the provided
+    ``rtol``, and ``atol``.
 
     The :py:class:`TensorMap` contains gradient data, then this function only
     returns ``True`` if all the gradients also have the same samples,

--- a/python/src/equistore/operations/divide.py
+++ b/python/src/equistore/operations/divide.py
@@ -5,7 +5,7 @@ import numpy as np
 from ..block import TensorBlock
 from ..tensor import TensorMap
 from . import _dispatch
-from ._utils import _check_blocks, _check_maps, _check_same_gradients_components
+from ._utils import _check_blocks, _check_maps, _check_same_gradients
 
 
 def divide(A: TensorMap, B: Union[float, TensorMap]) -> TensorMap:
@@ -43,10 +43,15 @@ def divide(A: TensorMap, B: Union[float, TensorMap]) -> TensorMap:
             _check_blocks(
                 blockA,
                 blockB,
-                props=["samples", "components", "properties", "gradients"],
+                props=["samples", "components", "properties"],
                 fname="divide",
             )
-            _check_same_gradients_components(blockA, blockB, "divide")
+            _check_same_gradients(
+                blockA,
+                blockB,
+                props=["samples", "components", "properties"],
+                fname="divide",
+            )
             blocks.append(_divide_block_block(block1=blockA, block2=blockB))
     else:
         # check if can be converted in float (so if it is a constant value)

--- a/python/src/equistore/operations/equal.py
+++ b/python/src/equistore/operations/equal.py
@@ -1,0 +1,122 @@
+import numpy as np
+
+from equistore import TensorBlock, TensorMap
+
+from . import _dispatch
+from ._utils import _check_blocks, _check_maps, _check_same_gradients
+
+
+def equal(tensor1: TensorMap, tensor2: TensorMap) -> bool:
+    """Compare two :py:class:`TensorMap`.
+
+    This function returns ``True`` if the two tensors have the same keys
+    (potentially in different order) and all the :py:class:`TensorBlock` have
+    the same (and in the same order) samples, components, properties,
+    and their values matrices pass the == test with the provided
+    ``rtol``, and ``atol``.
+
+    The :py:class:`TensorMap` contains gradient data, then this function only
+    returns ``True`` if all the gradients also have the same samples,
+    components, properties and their data matrices pass == test.
+
+    In practice this function calls :py:func:`equal_raise`, returning
+    ``True`` if no exception is rased, `False` otherwise.
+
+    :param tensor1: first :py:class:`TensorMap`.
+    :param tensor2: second :py:class:`TensorMap`.
+    """
+    try:
+        equal_raise(
+            tensor1=tensor1,
+            tensor2=tensor2,
+        )
+        return True
+    except ValueError:
+        return False
+
+
+def equal_raise(
+    tensor1: TensorMap,
+    tensor2: TensorMap,
+    rtol=1e-13,
+    atol=1e-12,
+    equal_nan=False,
+):
+    """
+    Compare two :py:class:`TensorMap`, raising a ``ValueError`` if they are not
+    the same.
+
+    The message associated with the ``ValueError`` will contain more information
+    on where the two :py:class:`TensorMap` differ. See :py:func:`equal` for
+    more information on which :py:class:`TensorMap` are considered equal.
+
+    :param tensor1: first :py:class:`TensorMap`.
+    :param tensor2: second :py:class:`TensorMap`.
+    """
+    _check_maps(tensor1, tensor2, "equal")
+
+    for key, block1 in tensor1:
+        try:
+            equal_block_raise(block1, tensor2.block(key))
+        except ValueError as e:
+            raise ValueError(f"The TensorBlocks with key = {key} are different") from e
+
+
+def equal_block(
+    block1: TensorBlock,
+    block2: TensorBlock,
+) -> bool:
+    """
+    Compare two :py:class:`TensorBlock`.
+
+    This function returns ``True`` if the two :py:class:`TensorBlock` have the
+    same samples, components, properties and their values matrices must pass == test.
+
+    If the :py:class:`TensorBlock` contains gradients, then the gradient must
+    also have same (and in the same order) samples, components, properties
+    and their data matrices must pass the == test.
+
+    In practice this function calls :py:func:`equal_block_raise`, returning
+    ``True`` if no exception is rased, `False` otherwise.
+
+    :param block1: first :py:class:`TensorBlock`.
+    :param block2: second :py:class:`TensorBlock`.
+    """
+    try:
+        equal_block_raise(block1=block1, block2=block2)
+        return True
+    except ValueError:
+        return False
+
+
+def equal_block_raise(block1: TensorBlock, block2: TensorBlock):
+    """
+    Compare two :py:class:`TensorBlock`, raising a ``ValueError`` if they are
+    not the same.
+
+    The message associated with the ``ValueError`` will contain more information
+    on where the two :py:class:`TensorBlock` differ. See
+    :py:func:`equal_block` for more information on which
+    :py:class:`TensorBlock` are considered equal.
+
+    :param block1: first :py:class:`TensorBlock`.
+    :param block2: second :py:class:`TensorBlock`.
+    """
+
+    if not np.all(block1.values.shape == block2.values.shape):
+        raise ValueError("values shapes are different")
+
+    if not _dispatch.all(block1.values == block2.values):
+        raise ValueError("values are not equal")
+    _check_blocks(
+        block1, block2, props=["samples", "properties", "components"], fname="equal"
+    )
+    _check_same_gradients(
+        block1, block2, props=["samples", "properties", "components"], fname="equal"
+    )
+
+    for parameter, gradient1 in block1.gradients():
+        gradient2 = block2.gradient(parameter)
+
+        if not _dispatch.all(gradient1.data == gradient2.data):
+            raise ValueError(f'gradient ("{parameter}") data are not equal')

--- a/python/src/equistore/operations/join.py
+++ b/python/src/equistore/operations/join.py
@@ -8,7 +8,7 @@ from ..block import TensorBlock
 from ..labels import Labels
 from ..tensor import TensorMap
 from . import _dispatch
-from ._utils import _check_blocks, _check_maps, _check_same_gradients_components
+from ._utils import _check_blocks, _check_maps, _check_same_gradients
 
 
 def join(tensor_maps: List[TensorMap], axis: str):
@@ -134,8 +134,8 @@ def _join_blocks_along_properties(blocks: List[TensorBlock]) -> TensorBlock:
 
     fname = "_join_blocks_along_properties"
     for block in blocks[1:]:
-        _check_blocks(first_block, block, ["components", "samples", "gradients"], fname)
-        _check_same_gradients_components(first_block, block, fname)
+        _check_blocks(first_block, block, ["components", "samples"], fname)
+        _check_same_gradients(first_block, block, ["components", "samples"], fname)
 
     properties = _join_labels([block.properties for block in blocks])
     result_block = TensorBlock(
@@ -190,10 +190,8 @@ def _join_blocks_along_samples(blocks: List[TensorBlock]) -> TensorBlock:
 
     fname = "_join_blocks_along_samples"
     for block in blocks[1:]:
-        _check_blocks(
-            first_block, block, ["components", "properties", "gradients"], fname
-        )
-        _check_same_gradients_components(first_block, block, fname)
+        _check_blocks(first_block, block, ["components", "properties"], fname)
+        _check_same_gradients(first_block, block, ["components", "properties"], fname)
 
     result_block = TensorBlock(
         values=_dispatch.vstack([block.values for block in blocks]),

--- a/python/src/equistore/operations/lstsq.py
+++ b/python/src/equistore/operations/lstsq.py
@@ -5,7 +5,7 @@ import numpy as np
 from ..block import TensorBlock
 from ..tensor import TensorMap
 from . import _dispatch
-from ._utils import _check_blocks, _check_maps
+from ._utils import _check_maps, _check_same_gradients
 
 
 def lstsq(X: TensorMap, Y: TensorMap, rcond, driver=None) -> TensorMap:
@@ -76,7 +76,7 @@ def _lstsq_block(X: TensorBlock, Y: TensorBlock, rcond, driver) -> TensorBlock:
     Y_n_properties = Y.values.shape[-1]
     Y_values = Y.values.reshape(-1, Y_n_properties)
 
-    _check_blocks(X, Y, ["gradients"], "lstsq")
+    _check_same_gradients(X, Y, props=None, fname="lstsq")
 
     for parameter, X_gradient in X.gradients():
         X_gradient_data = X_gradient.data.reshape(-1, X_n_properties)

--- a/python/src/equistore/operations/multiply.py
+++ b/python/src/equistore/operations/multiply.py
@@ -5,7 +5,7 @@ import numpy as np
 from ..block import TensorBlock
 from ..tensor import TensorMap
 from . import _dispatch
-from ._utils import _check_blocks, _check_maps, _check_same_gradients_components
+from ._utils import _check_blocks, _check_maps, _check_same_gradients
 
 
 def multiply(A: TensorMap, B: Union[float, TensorMap]) -> TensorMap:
@@ -43,10 +43,15 @@ def multiply(A: TensorMap, B: Union[float, TensorMap]) -> TensorMap:
             _check_blocks(
                 blockA,
                 blockB,
-                props=["samples", "components", "properties", "gradients"],
+                props=["samples", "components", "properties"],
+                fname="add",
+            )
+            _check_same_gradients(
+                blockA,
+                blockB,
+                props=["samples", "components", "properties"],
                 fname="multiply",
             )
-            _check_same_gradients_components(blockA, blockB, "multiply")
             blocks.append(_multiply_block_block(block1=blockA, block2=blockB))
     else:
         # check if can be converted in float (so if it is a constant value)

--- a/python/src/equistore/operations/multiply.py
+++ b/python/src/equistore/operations/multiply.py
@@ -44,7 +44,7 @@ def multiply(A: TensorMap, B: Union[float, TensorMap]) -> TensorMap:
                 blockA,
                 blockB,
                 props=["samples", "components", "properties"],
-                fname="add",
+                fname="multiply",
             )
             _check_same_gradients(
                 blockA,

--- a/python/src/equistore/operations/solve.py
+++ b/python/src/equistore/operations/solve.py
@@ -3,7 +3,7 @@ import numpy as np
 from ..block import TensorBlock
 from ..tensor import TensorMap
 from . import _dispatch
-from ._utils import _check_blocks, _check_maps
+from ._utils import _check_maps, _check_same_gradients
 
 
 def solve(X: TensorMap, Y: TensorMap) -> TensorMap:
@@ -74,7 +74,7 @@ def _solve_block(X: TensorBlock, Y: TensorBlock) -> TensorBlock:
     Y_n_properties = Y.values.shape[-1]
     Y_values = Y.values.reshape(-1, Y_n_properties)
 
-    _check_blocks(X, Y, ["gradients"], "solve")
+    _check_same_gradients(X, Y, props=None, fname="solve")
 
     for parameter, X_gradient in X.gradients():
         X_gradient_data = X_gradient.data.reshape(-1, X_n_properties)

--- a/python/tests/operations/allclose.py
+++ b/python/tests/operations/allclose.py
@@ -211,14 +211,18 @@ class Testallclose(unittest.TestCase):
             fn.allclose_block_raise(block_1, block_2)
 
         self.assertEqual(
-            str(cm.exception), "samples names are not the same or not in the same order"
+            str(cm.exception),
+            "Inputs to 'allclose' should have the same samples:\n"
+            "samples names are not the same or not in the same order.",
         )
 
         with self.assertRaises(ValueError) as cm:
             fn.allclose_block_raise(block_1, block_3)
 
         self.assertEqual(
-            str(cm.exception), "samples not the same or not in the same order"
+            str(cm.exception),
+            "Inputs to 'allclose' should have the same samples:\n"
+            "samples are not the same or not in the same order.",
         )
 
         with self.assertRaises(ValueError) as cm:
@@ -231,7 +235,8 @@ class Testallclose(unittest.TestCase):
 
         self.assertEqual(
             str(cm.exception),
-            "components names are not the same or not in the same order",
+            "Inputs to 'allclose' should have the same components:\n"
+            "components names are not the same or not in the same order.",
         )
 
         with self.assertRaises(ValueError) as cm:
@@ -239,7 +244,8 @@ class Testallclose(unittest.TestCase):
 
         self.assertEqual(
             str(cm.exception),
-            "samples not the same or not in the same order",
+            "Inputs to 'allclose' should have the same samples:\n"
+            "samples are not the same or not in the same order.",
         )
 
     def test_self_allclose_exceptions_gradient(self):
@@ -280,8 +286,9 @@ class Testallclose(unittest.TestCase):
 
         self.assertEqual(
             str(cm.exception),
-            'gradient ("parameter") samples names \
-are not the same or not in the same order',
+            "Inputs to allclose should have the same gradient:\n"
+            'gradient ("parameter") samples names are not the same'
+            " or not in the same order.",
         )
 
         block_3 = TensorBlock(
@@ -349,8 +356,9 @@ are not the same or not in the same order',
 
         self.assertEqual(
             str(cm.exception),
-            'gradient ("parameter") components \
-not the same or not in the same order',
+            "Inputs to allclose should have the same gradient:\n"
+            'gradient ("parameter") components are not the same'
+            " or not in the same order.",
         )
 
 

--- a/python/tests/operations/equal.py
+++ b/python/tests/operations/equal.py
@@ -1,0 +1,392 @@
+import os
+import unittest
+
+import numpy as np
+
+import equistore.io
+import equistore.operations as fn
+from equistore import Labels, TensorBlock, TensorMap
+
+
+DATA_ROOT = os.path.join(os.path.dirname(__file__), "..", "data")
+
+
+class TestEqual(unittest.TestCase):
+    def test_equal_nograd(self):
+        block_1 = TensorBlock(
+            values=np.array([[1, 2], [3, 5]], dtype=np.float64),
+            samples=Labels(["samples"], np.array([[0], [2]], dtype=np.int32)),
+            components=[],
+            properties=Labels(["properties"], np.array([[0], [1]], dtype=np.int32)),
+        )
+        block_2 = TensorBlock(
+            values=np.array([[1, 2], [3, 4], [5, 6], [1, 2], [3, 4], [5, 6]]),
+            samples=Labels(
+                ["samples"],
+                np.array([[0], [1], [2], [3], [4], [5]], dtype=np.int32),
+            ),
+            components=[],
+            properties=Labels(["properties"], np.array([[0], [1]], dtype=np.int32)),
+        )
+
+        block_3 = TensorBlock(
+            values=np.array([[1], [2]]),
+            samples=Labels(["samples"], np.array([[0], [2]], dtype=np.int32)),
+            components=[],
+            properties=Labels(["properties"], np.array([[0]], dtype=np.int32)),
+        )
+        block_4 = TensorBlock(
+            values=np.array([[23], [53], [83]]),
+            samples=Labels(["samples"], np.array([[0], [2], [7]], dtype=np.int32)),
+            components=[],
+            properties=Labels(["properties"], np.array([[6]], dtype=np.int32)),
+        )
+        keys = Labels(
+            names=["key_1", "key_2"], values=np.array([[0, 0], [1, 0]], dtype=np.int32)
+        )
+        X = TensorMap(keys, [block_1, block_2])
+        self.assertTrue(fn.equal(X, X))
+        Y = TensorMap(keys, [block_3, block_4])
+        self.assertFalse(fn.equal(X, Y))
+        with self.assertRaises(ValueError) as cm:
+            fn.equal_raise(X, Y)
+
+        self.assertEqual(
+            str(cm.exception), "The TensorBlocks with key = (0, 0) are different"
+        )
+
+        block_1_c = TensorBlock(
+            values=np.array(
+                [
+                    [
+                        [[1, 0.5], [4, 2], [1.5, 6.5]],
+                        [[2, 1], [6, 3], [6.1, 3.5]],
+                        [[9, 9], [9, 9.8], [10, 10.5]],
+                    ],
+                    [
+                        [[3, 1.5], [7, 3.5], [3.7, 1.5]],
+                        [[5, 2.5], [8, 4], [6.3, 1.5]],
+                        [[5, 7.1], [8, 4.8], [6.3, 14.466]],
+                    ],
+                ],
+                dtype=np.float64,
+            ),
+            samples=Labels(["samples"], np.array([[0], [2]], dtype=np.int32)),
+            components=[
+                Labels(["c1"], np.array([[0], [1], [2]], dtype=np.int32)),
+                Labels(["c2"], np.array([[0], [1], [2]], dtype=np.int32)),
+            ],
+            properties=Labels(["properties"], np.array([[0], [1]], dtype=np.int32)),
+        )
+        block_1_c_copy = TensorBlock(
+            values=block_1_c.values + 0.1e-6,
+            samples=Labels(["samples"], np.array([[0], [2]], dtype=np.int32)),
+            components=[
+                Labels(["c1"], np.array([[0], [1], [2]], dtype=np.int32)),
+                Labels(["c2"], np.array([[0], [1], [2]], dtype=np.int32)),
+            ],
+            properties=Labels(["properties"], np.array([[0], [1]], dtype=np.int32)),
+        )
+
+        block_2_c = TensorBlock(
+            values=np.array(
+                [
+                    [[[1, 2], [6.8, 2.8]], [[4.1, 6.2], [66.8, 62.8]]],
+                    [[[3, 4], [36, 6.4]], [[83, 84], [73.76, 76.74]]],
+                    [[[5, 6], [58, 68]], [[23.4, 5643.3], [234.5, 3247.6]]],
+                    [[[5.6, 6.6], [5.68, 668]], [[55.6, 676.76], [775.68, 0.668]]],
+                    [[[1, 2], [17.7, 27.7]], [[77.1, 22.2], [1.11, 3.42]]],
+                ]
+            ),
+            samples=Labels(
+                ["samples"],
+                np.array([[0], [1], [2], [3], [4]], dtype=np.int32),
+            ),
+            components=[
+                Labels(["c1"], np.array([[3], [5]], dtype=np.int32)),
+                Labels(["c2"], np.array([[6], [8]], dtype=np.int32)),
+            ],
+            properties=Labels(["properties"], np.array([[0], [1]], dtype=np.int32)),
+        )
+        block_2_c_copy = TensorBlock(
+            values=block_2_c.values + 0.1e-6,
+            samples=Labels(
+                ["samples"],
+                np.array([[0], [1], [2], [3], [4]], dtype=np.int32),
+            ),
+            components=[
+                Labels(["c1"], np.array([[3], [5]], dtype=np.int32)),
+                Labels(["c2"], np.array([[6], [8]], dtype=np.int32)),
+            ],
+            properties=Labels(["properties"], np.array([[0], [1]], dtype=np.int32)),
+        )
+        X_c = TensorMap(keys, [block_1_c, block_2_c])
+        X_c_copy = TensorMap(keys, [block_1_c_copy, block_2_c_copy])
+        self.assertFalse(fn.equal(X, X_c))
+
+        self.assertTrue(fn.equal(X_c, X_c))
+        self.assertFalse(fn.equal(X_c, X_c_copy))
+
+    def test_self_equal_grad(self):
+        tensor1 = equistore.io.load(
+            os.path.join(DATA_ROOT, "qm7-spherical-expansion.npz"),
+            use_numpy=True,
+        )
+        blocks = []
+        blocks_e6 = []
+        for _, block in tensor1:
+            blocks.append(block.copy())
+            be6 = block.copy()
+            be6.values[:] += 1e-6
+            blocks_e6.append(be6)
+
+        tensor1_copy = TensorMap(tensor1.keys, blocks)
+        tensor1_e6 = TensorMap(tensor1.keys, blocks_e6)
+        self.assertTrue(fn.equal(tensor1, tensor1_copy))
+        self.assertFalse(fn.equal(tensor1, tensor1_e6))
+
+        with self.assertRaises(ValueError) as cm:
+            fn.equal_raise(tensor1, tensor1_e6)
+
+        self.assertEqual(
+            str(cm.exception), "The TensorBlocks with key = (0, 1, 1) are different"
+        )
+
+        with self.assertRaises(ValueError) as cm:
+            fn.equal_block_raise(tensor1.block(0), tensor1_e6.block(0))
+        self.assertEqual(str(cm.exception), "values are not equal")
+
+    def test_self_equal_exceptions(self):
+        block_1 = TensorBlock(
+            values=np.array([[1], [2]]),
+            samples=Labels(["samples"], np.array([[0], [2]], dtype=np.int32)),
+            components=[],
+            properties=Labels(["properties"], np.array([[0]], dtype=np.int32)),
+        )
+        block_2 = TensorBlock(
+            values=np.array([[1], [2]]),
+            samples=Labels(["samples_5"], np.array([[0], [2]], dtype=np.int32)),
+            components=[],
+            properties=Labels(["properties"], np.array([[0]], dtype=np.int32)),
+        )
+        block_3 = TensorBlock(
+            values=np.array([[1], [2]]),
+            samples=Labels(["samples"], np.array([[0], [6]], dtype=np.int32)),
+            components=[],
+            properties=Labels(["properties"], np.array([[0]], dtype=np.int32)),
+        )
+
+        block_4 = TensorBlock(
+            values=np.array([[[1], [4]], [[44], [2]]]),
+            samples=Labels(["samples"], np.array([[0], [2]], dtype=np.int32)),
+            components=[
+                Labels(["component"], np.array([[0], [6]], dtype=np.int32)),
+            ],
+            properties=Labels(["properties"], np.array([[0]], dtype=np.int32)),
+        )
+        block_5 = TensorBlock(
+            values=np.array([[[1], [4]], [[44], [2]]]),
+            samples=Labels(["samples"], np.array([[0], [2]], dtype=np.int32)),
+            components=[
+                Labels(["component1"], np.array([[0], [6]], dtype=np.int32)),
+            ],
+            properties=Labels(["properties"], np.array([[0]], dtype=np.int32)),
+        )
+
+        block_6 = TensorBlock(
+            values=np.array([[[1], [4]], [[44], [2]]]),
+            samples=Labels(["samples"], np.array([[2], [0]], dtype=np.int32)),
+            components=[
+                Labels(["component"], np.array([[0], [6]], dtype=np.int32)),
+            ],
+            properties=Labels(["properties"], np.array([[0]], dtype=np.int32)),
+        )
+
+        self.assertFalse(fn.equal_block(block_1, block_2))
+
+        with self.assertRaises(ValueError) as cm:
+            fn.equal_block_raise(block_1, block_2)
+
+        self.assertEqual(
+            str(cm.exception),
+            "Inputs to 'equal' should have the same samples:\n"
+            "samples names are not the same or not in the same order.",
+        )
+
+        with self.assertRaises(ValueError) as cm:
+            fn.equal_block_raise(block_1, block_3)
+
+        self.assertEqual(
+            str(cm.exception),
+            "Inputs to 'equal' should have the same samples:\n"
+            "samples are not the same or not in the same order.",
+        )
+
+        with self.assertRaises(ValueError) as cm:
+            fn.equal_block_raise(block_1, block_4)
+
+        self.assertEqual(str(cm.exception), "values shapes are different")
+
+        with self.assertRaises(ValueError) as cm:
+            fn.equal_block_raise(block_5, block_4)
+
+        self.assertEqual(
+            str(cm.exception),
+            "Inputs to 'equal' should have the same components:\n"
+            "components names are not the same or not in the same order.",
+        )
+
+        with self.assertRaises(ValueError) as cm:
+            fn.equal_block_raise(block_6, block_4)
+
+        self.assertEqual(
+            str(cm.exception),
+            "Inputs to 'equal' should have the same samples:\n"
+            "samples are not the same or not in the same order.",
+        )
+
+    def test_self_equal_exceptions_gradient(self):
+        block_1 = TensorBlock(
+            values=np.array([[1], [2]]),
+            samples=Labels(["samples"], np.array([[0], [2]], dtype=np.int32)),
+            components=[],
+            properties=Labels(["properties"], np.array([[0]], dtype=np.int32)),
+        )
+
+        block_1.add_gradient(
+            "parameter",
+            data=np.full((2, 1), 11.0),
+            samples=Labels(
+                ["sample", "parameter"], np.array([[0, -2], [2, 3]], dtype=np.int32)
+            ),
+            components=[],
+        )
+
+        block_2 = TensorBlock(
+            values=np.array([[1], [2]]),
+            samples=Labels(["samples"], np.array([[0], [2]], dtype=np.int32)),
+            components=[],
+            properties=Labels(["properties"], np.array([[0]], dtype=np.int32)),
+        )
+
+        block_2.add_gradient(
+            "parameter",
+            data=np.full((2, 1), 11.0),
+            samples=Labels(
+                ["sample", "parameter1"], np.array([[0, -2], [2, 3]], dtype=np.int32)
+            ),
+            components=[],
+        )
+
+        with self.assertRaises(ValueError) as cm:
+            fn.equal_block_raise(block_1, block_2)
+
+        self.assertEqual(
+            str(cm.exception),
+            "Inputs to equal should have the same gradient:\n"
+            'gradient ("parameter") samples names are not the same'
+            " or not in the same order.",
+        )
+
+        block_3 = TensorBlock(
+            values=np.array([[1], [2]]),
+            samples=Labels(["samples"], np.array([[0], [2]], dtype=np.int32)),
+            components=[],
+            properties=Labels(["properties"], np.array([[0]], dtype=np.int32)),
+        )
+
+        block_3.add_gradient(
+            "parameter",
+            data=np.full((2, 1), 1.0),
+            samples=Labels(
+                ["sample", "parameter"], np.array([[0, -2], [2, 3]], dtype=np.int32)
+            ),
+            components=[],
+        )
+
+        with self.assertRaises(ValueError) as cm:
+            fn.equal_block_raise(block_1, block_3)
+
+        self.assertEqual(
+            str(cm.exception),
+            'gradient ("parameter") data are not equal',
+        )
+
+        block_4 = TensorBlock(
+            values=np.array([[1], [2]]),
+            samples=Labels(["samples"], np.array([[0], [2]], dtype=np.int32)),
+            components=[],
+            properties=Labels(["properties"], np.array([[0]], dtype=np.int32)),
+        )
+
+        block_4.add_gradient(
+            "parameter",
+            data=np.full((2, 3, 1), 1.0),
+            samples=Labels(
+                ["sample", "parameter"], np.array([[0, -2], [2, 3]], dtype=np.int32)
+            ),
+            components=[
+                Labels(["component_1"], np.array([[-1], [0], [1]], dtype=np.int32))
+            ],
+        )
+
+        block_5 = TensorBlock(
+            values=np.array([[1], [2]]),
+            samples=Labels(["samples"], np.array([[0], [2]], dtype=np.int32)),
+            components=[],
+            properties=Labels(["properties"], np.array([[0]], dtype=np.int32)),
+        )
+
+        block_5.add_gradient(
+            "parameter",
+            data=np.full((2, 3, 1), 1.0),
+            samples=Labels(
+                ["sample", "parameter"], np.array([[0, -2], [2, 3]], dtype=np.int32)
+            ),
+            components=[
+                Labels(["component_1"], np.array([[-1], [6], [1]], dtype=np.int32))
+            ],
+        )
+
+        with self.assertRaises(ValueError) as cm:
+            fn.equal_block_raise(block_5, block_4)
+
+        self.assertEqual(
+            str(cm.exception),
+            "Inputs to equal should have the same gradient:\n"
+            'gradient ("parameter") components are not the same'
+            " or not in the same order.",
+        )
+
+        block_6 = TensorBlock(
+            values=np.array([[1], [2]]),
+            samples=Labels(["samples"], np.array([[0], [2]], dtype=np.int32)),
+            components=[],
+            properties=Labels(["properties"], np.array([[0]], dtype=np.int32)),
+        )
+
+        block_6.add_gradient(
+            "parameter",
+            data=np.full((2, 3, 1), 1.0),
+            samples=Labels(
+                ["sample", "parameter_1"], np.array([[0, -2], [2, 3]], dtype=np.int32)
+            ),
+            components=[
+                Labels(["component_1"], np.array([[-1], [6], [1]], dtype=np.int32))
+            ],
+        )
+        with self.assertRaises(ValueError) as cm:
+            fn.equal_block_raise(block_5, block_6)
+
+        self.assertEqual(
+            str(cm.exception),
+            "Inputs to equal should have the same gradient:\n"
+            'gradient ("parameter") samples names are not the same'
+            " or not in the same order.",
+        )
+
+
+# TODO: add tests with torch & torch scripting/tracing
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/tests/operations/join.py
+++ b/python/tests/operations/join.py
@@ -106,10 +106,10 @@ class TestJoinTensorMap(unittest.TestCase):
 
     def test_join_properties_different_components(self):
         """Test error raise if `components` are not the same."""
-        self.se.components_to_properties(["spherical_harmonics_m"])
+        se_c2p = self.se.components_to_properties(["spherical_harmonics_m"])
         se = load(path.join(DATA_ROOT, "qm7-spherical-expansion.npz"), use_numpy=True)
         with self.assertRaises(ValueError) as err:
-            equistore.operations.join([self.se, se], axis="properties")
+            equistore.operations.join([se_c2p, se], axis="properties")
         self.assertIn("components", str(err.exception))
 
     def test_join_properties_different_gradients(self):
@@ -118,7 +118,7 @@ class TestJoinTensorMap(unittest.TestCase):
             equistore.operations.join(
                 [self.ps_first_block, self.ps_first_block_extra_grad], axis="properties"
             )
-        self.assertIn("gradients", str(err.exception))
+        self.assertIn("gradient", str(err.exception))
 
     def test_join_samples_values(self):
         """Test values for joining along `samples`."""
@@ -146,10 +146,10 @@ class TestJoinTensorMap(unittest.TestCase):
 
     def test_join_samples_different_components(self):
         """Test error raise if `components` are not the same."""
-        self.se.components_to_properties(["spherical_harmonics_m"])
+        se_c2p = self.se.components_to_properties(["spherical_harmonics_m"])
         se = load(path.join(DATA_ROOT, "qm7-spherical-expansion.npz"), use_numpy=True)
         with self.assertRaises(ValueError) as err:
-            equistore.operations.join([self.se, se], axis="samples")
+            equistore.operations.join([se_c2p, se], axis="samples")
         self.assertIn("components", str(err.exception))
 
     def test_join_samples_different_gradients(self):
@@ -158,7 +158,7 @@ class TestJoinTensorMap(unittest.TestCase):
             equistore.operations.join(
                 [self.ps_first_block, self.ps_first_block_extra_grad], axis="samples"
             )
-        self.assertIn("gradients", str(err.exception))
+        self.assertIn("gradient", str(err.exception))
 
 
 class TestJoinLabels(unittest.TestCase):


### PR DESCRIPTION
In the spirit of #119  I rewrote them in a more stringent way and allclose now use them to do all the checks for the metadata . This implies that all the test of allclose now are on these functions. I think everything has a test (maybe not all the gradient possibilities).

What do you think? 
I, of course, can create the equal functions, being the same as allclose except for the more stringent numerical checks, but I do not know if it really usefull.