### PR TITLE
Please B028 linting error

### DIFF
--- a/python/src/equistore/io.py
+++ b/python/src/equistore/io.py
@@ -48,7 +48,10 @@ def save(path: str, tensor: TensorMap, use_numpy=False):
     """
     if not path.endswith(".npz"):
         path += ".npz"
-        warnings.warn(f"adding '.npz' extension, the file will be saved at '{path}'")
+        warnings.warn(
+            msg=f"adding '.npz' extension, the file will be saved at '{path}'",
+            stacklevel=1,
+        )
 
     if use_numpy:
         all_entries = _tensor_map_to_dict(tensor)

--- a/python/src/equistore/operations/lstsq.py
+++ b/python/src/equistore/operations/lstsq.py
@@ -31,9 +31,10 @@ def lstsq(X: TensorMap, Y: TensorMap, rcond, driver=None) -> TensorMap:
     """
     if rcond is None:
         warnings.warn(
-            "WARNING rcond is set to None, which will trigger the default \
-            behavior which is different between numpy and torch lstsq function, \
-            and might depend on the version you are using."
+            "WARNING rcond is set to None, which will trigger the default "
+            "behavior which is different between numpy and torch lstsq function, "
+            "and might depend on the version you are using.",
+            stacklevel=1,
         )
 
     _check_maps(X, Y, "lstsq")

--- a/python/src/equistore/operations/slice.py
+++ b/python/src/equistore/operations/slice.py
@@ -107,14 +107,16 @@ def slice(tensor: TensorMap, samples=None, properties=None) -> TensorMap:
         if np.all(empty_blocks):
             warnings.warn(
                 "All TensorBlocks in the sliced TensorMap are now empty, "
-                "based on your choice of samples and/or properties to slice by. "
+                "based on your choice of samples and/or properties to slice by. ",
+                stacklevel=1,
             )
         else:
             warnings.warn(
                 "Some TensorBlocks in the sliced TensorMap are now empty, "
                 "based on your choice of samples and/or properties to slice by. "
                 "The keys of the empty TensorBlocks are:\n "
-                f"{tensor.keys[empty_blocks]}"
+                f"{tensor.keys[empty_blocks]}",
+                stacklevel=1,
             )
 
     return sliced_tensor
@@ -210,7 +212,8 @@ def slice_block(
     if np.any(np.array(sliced_block.values.shape) == 0):
         warnings.warn(
             "Your input TensorBlock is now empty, based on your choice of samples "
-            + "and/or properties to slice by. "
+            "and/or properties to slice by. ",
+            stacklevel=1,
         )
 
     return sliced_block


### PR DESCRIPTION
This PR explicitly sets the `stacklevel` of warnings since this is required by [flake8](https://github.com/PyCQA/flake8-bugbear):

> B028: No explicit stacklevel keyword argument found. The warn method from the warnings module uses a stacklevel of 1 by default. This will only show a stack trace for the line on which the warn method is called. It is therefore recommended to use a stacklevel of 2 or greater to provide more information to the user.

Here, I set the level to `stacklevel=1` (the default) meaning that no additional backtrace information is given. I think we do not need more information for the user because the warnings are well written and a link and codeblock does not help much. If you disagree we can also set it to `2` or `3`.

