### PR TITLE
New operation ``unique_metadata``

### DIFF
--- a/docs/src/reference/python/operations/index.rst
+++ b/docs/src/reference/python/operations/index.rst
@@ -16,3 +16,4 @@ Operations
     logic/index
     manipulation/index
     math/index
+    set/index

--- a/docs/src/reference/python/operations/set/index.rst
+++ b/docs/src/reference/python/operations/set/index.rst
@@ -1,0 +1,7 @@
+Set operations
+==============
+
+.. toctree::
+    :maxdepth: 1
+
+    unique_metadata() <unique_metadata>

--- a/docs/src/reference/python/operations/set/unique_metadata.rst
+++ b/docs/src/reference/python/operations/set/unique_metadata.rst
@@ -1,0 +1,6 @@
+unique_metadata
+===============
+
+.. autofunction:: equistore.operations.unique_metadata
+    
+.. autofunction:: equistore.operations.unique_metadata_block

--- a/python/src/equistore/operations/__init__.py
+++ b/python/src/equistore/operations/__init__.py
@@ -28,6 +28,7 @@ from .slice import slice, slice_block  # noqa
 from .solve import solve  # noqa
 from .split import split, split_block  # nopa
 from .subtract import subtract  # noqa
+from .unique_metadata import unique_metadata, unique_metadata_block  # noqa
 from .zeros_like import zeros_like, zeros_like_block  # noqa
 
 
@@ -58,5 +59,7 @@ __all__ = [
     "split_block",
     "subtract",
     "sum_over_samples",
+    "unique_metadata",
+    "unique_metadata_block",
     "zeros_like",
 ]

--- a/python/src/equistore/operations/unique_metadata.py
+++ b/python/src/equistore/operations/unique_metadata.py
@@ -42,8 +42,8 @@ def unique_metadata(
             tensor, axis="samples", names=["structure"],
         )
 
-    To find the unique "atom" indices in the ``"samples"`` metadata present in
-    the ``"positions"`` gradient blocks of a given :py:class:`TensorMap`:
+    To find the unique ``"atom"`` indices in the ``"samples"`` metadata present
+    in the ``"positions"`` gradient blocks of a given :py:class:`TensorMap`:
 
     .. code-block:: python
 
@@ -117,8 +117,8 @@ def unique_metadata_block(
             block, axis="samples", names=["structure"],
         )
 
-    To find the unique ``"atom"`` indices along the "samples" axis present in
-    the ``"positions"`` gradient block of a given :py:class:`TensorBlock`:
+    To find the unique ``"atom"`` indices along the ``"samples"`` axis present
+    in the ``"positions"`` gradient block of a given :py:class:`TensorBlock`:
 
     .. code-block:: python
 

--- a/python/src/equistore/operations/unique_metadata.py
+++ b/python/src/equistore/operations/unique_metadata.py
@@ -18,22 +18,23 @@ def unique_metadata(
 ) -> Labels:
     """
     Returns a :py:class:`Labels` object containing the unique metadata across
-    all blocks of the input :py:class:`TensorMap`  ``tensor``, for the specified
-    ``axis`` (either "samples" or "properties") and metatdata ``names``.
+    all blocks of the input :py:class:`TensorMap`  ``tensor``. Unique Labels are
+    returned for the specified ``axis`` (either ``"samples"`` or
+    ``"properties"``) and metatdata ``names``.
 
-    Passing ``gradient_param`` as a str corresponding to a gradient parameter
-    (for instance "cell" or "positions") returns the unique indices only for the
-    gradient blocks associated with each block in the input ``tensor``,
-    according to the specified ``axis`` and ``names``. Note that gradient blocks
-    by definition have the same properties metadata as their parent
+    Passing ``gradient_param`` as a ``str`` corresponding to a gradient
+    parameter (for instance ``"cell"`` or ``"positions"``) returns the unique
+    indices only for the gradient blocks. Note that gradient blocks by
+    definition have the same properties metadata as their parent
     :py:class:`TensorBlock`.
 
-    If there are no indices in the (gradient) blocks of ``tensor`` corresponding
-    to the specified ``axis`` and ``names``, an empty Labels object with the
-    correct names as in the passed ``names`` is returned.
+    An empty :py:class:`Labels` object is returned if there are no indices in
+    the (gradient) blocks of ``tensor`` corresponding to the specified ``axis``
+    and ``names``. This will have length zero but the names will be the same as
+    passed in ``names``.
 
-    For example, to find the unique "structure" indices in the "samples"
-    metadata present in a given TensorMap:
+    For example, to find the unique ``"structure"`` indices in the ``"samples"``
+    metadata present in a given :py:class:`TensorMap`:
 
     .. code-block:: python
 
@@ -41,8 +42,8 @@ def unique_metadata(
             tensor, axis="samples", names=["structure"],
         )
 
-    To find the unique "atom" indices in the "samples" metadata present in the
-    "positions" gradient blocks of a given TensorMap:
+    To find the unique "atom" indices in the ``"samples"`` metadata present in
+    the ``"positions"`` gradient blocks of a given :py:class:`TensorMap`:
 
     .. code-block:: python
 
@@ -51,15 +52,16 @@ def unique_metadata(
         )
 
     :param tensor: the :py:class:`TensorMap` to find unique indices for.
-    :param axis: a str, either "samples" or "properties", corresponding to the
-        axis along which the named unique indices should be found.
-    :param names: a str, list of str, or tuple of str corresponding to the
-        name(s) of the indices along the specified ``axis`` for which the unique
-        values should be found.
-    :param gradient_param: a str corresponding to the gradient parameter name
-        for the gradient blocks to find the unique indices for. If none
-        (default), the unique indices of the regular TensorBlocks will be
-        calculated.
+    :param axis: a ``str``, either ``"samples"`` or ``"properties"``,
+        corresponding to the ``axis`` along which the named unique indices
+        should be found.
+    :param names: a ``str``, ``list`` of ``str``, or ``tuple`` of ``str``
+        corresponding to the name(s) of the indices along the specified ``axis``
+        for which the unique values should be found.
+    :param gradient_param: a ``str`` corresponding to the gradient parameter
+        name for the gradient blocks to find the unique indices for. If none
+        (default), the unique indices of the regular :py:class:`TensorBlock`s
+        will be calculated.
 
     :return: a sorted :py:class:`Labels` object containing the unique metadata
         for the blocks of the input ``tensor`` or its gradient blocks for the
@@ -68,7 +70,7 @@ def unique_metadata(
     """
     # Parse input args
     if not isinstance(tensor, TensorMap):
-        raise TypeError("``tensor`` must be an equistore TensorMap")
+        raise TypeError("`tensor` must be an equistore `TensorMap`")
     names = (
         [names]
         if isinstance(names, str)
@@ -93,20 +95,21 @@ def unique_metadata_block(
     """
     Returns a :py:class:`Labels` object containing the unique metadata in the
     input :py:class:`TensorBlock`  ``block``, for the specified ``axis`` (either
-    "samples" or "properties") and metatdata ``names``.
+    ``"samples"`` or ``"properties"``) and metatdata ``names``.
 
-    Passing ``gradient_param`` as a str corresponding to a gradient parameter
-    (for instance "cell" or "positions") returns the unique indices only for the
-    gradient block associated with the input ``block`` , according to the
-    specified ``axis`` and ``names``. Note that gradient blocks by definition
-    have the same properties metadata as their parent :py:class:`TensorBlock`.
+    Passing ``gradient_param`` as a ``str`` corresponding to a gradient
+    parameter (for instance ``"cell"`` or ``"positions"``) returns the unique
+    indices only for the gradient block associated with ``block``. Note that
+    gradient blocks by definition have the same properties metadata as their
+    parent :py:class:`TensorBlock`.
 
-    If there are no indices in the ``block`` (or its gradient) corresponding to
-    the specified ``axis`` and ``names``, an empty Labels object with the
-    correct names as in the passed ``names`` is returned.
+    An empty :py:class:`Labels` object is returned if there are no indices in
+    the (gradient) blocks of ``tensor`` corresponding to the specified ``axis``
+    and ``names``. This will have length zero but the names will be the same as
+    passed in ``names``.
 
-    For example, to find the unique "structure" indices in the "samples"
-    metadata present in a given TensorBlock:
+    For example, to find the unique ``"structure"`` indices in the ``"samples"``
+    metadata present in a given :py:class:`TensorBlock`:
 
     .. code-block:: python
 
@@ -114,8 +117,8 @@ def unique_metadata_block(
             block, axis="samples", names=["structure"],
         )
 
-    To find the unique "atom" indices along the "samples" axis present in the
-    "positions" gradient block of a given TensorBlock:
+    To find the unique ``"atom"`` indices along the "samples" axis present in
+    the ``"positions"`` gradient block of a given :py:class:`TensorBlock`:
 
     .. code-block:: python
 
@@ -124,24 +127,24 @@ def unique_metadata_block(
         )
 
     :param block: the :py:class:`TensorBlock` to find unique indices for.
-    :param axis: a str, either "samples" or "properties", corresponding to the
-        axis along which the named unique metadata should be found.
-    :param names: a str, list of str, or tuple of str corresponding to the
-        name(s) of the metadata along the specified ``axis`` for which the
-        unique indices should be found.
-    :param gradient_param: a str corresponding to the gradient parameter name
-        for the gradient blocks to find the unique metadata for. If none
-        (default), the unique metadata of the regular TensorBlocks will be
-        calculated.
+    :param axis: a str, either ``"samples"`` or ``"properties"``, corresponding
+        to the ``axis`` along which the named unique metadata should be found.
+    :param names: a ``str``, ``list`` of ``str``, or ``tuple`` of ``str``
+        corresponding to the name(s) of the metadata along the specified
+        ``axis`` for which the unique indices should be found.
+    :param gradient_param: a ``str`` corresponding to the gradient parameter
+        name for the gradient blocks to find the unique metadata for. If none
+        (default), the unique metadata of the regular :py:class:`TensorBlock`s
+        will be calculated.
 
     :return: a sorted :py:class:`Labels` object containing the unique metadata
         for the input ``block`` or its gradient for the specified parameter.
-        Each element in the returned :py:class:`Labels` object has len(names)
-        entries.
+        Each element in the returned :py:class:`Labels` object has
+        len(``names``) entries.
     """
     # Parse input args
     if not isinstance(block, TensorBlock):
-        raise TypeError("``block`` must be an equistore TensorBlock")
+        raise TypeError("`block` must be an equistore `TensorBlock`")
     names = (
         [names]
         if isinstance(names, str)
@@ -171,17 +174,18 @@ def _unique_from_blocks(
     # Extract indices from each block
     all_idxs = []
     for block in blocks:
-        idxs = block.samples[names] if axis == "samples" else block.properties[names]
-        for idx in idxs:
-            all_idxs.append(idx)
+        if axis == "samples":
+            idxs = block.samples[names]
+        else:  # "properties"
+            idxs = block.properties[names]
+        all_idxs += idxs.tolist()
 
     # If no matching indices across all blocks return a empty Labels w/ the
     # correct names
     if len(all_idxs) == 0:
         # Create Labels with single entry
-        labels = Labels(names=names, values=np.array([[i for i in range(len(names))]]))
-        # rslice to zero length
-        return labels[:0]
+        labels = Labels(names=names, values=np.arange(len(names)).reshape(-1, 1))
+        return labels[:0]  # Slice to zero length
 
     # Define the unique and sorted indices
     unique_idxs = np.unique(all_idxs, axis=0)
@@ -196,20 +200,22 @@ def _check_args(
     names: List[str],
     gradient_param: Optional[str] = None,
 ):
-    """Checks input args for :py:func:`unique_metadata` and
-    :py:func:`unique_metadata_block`."""
+    """
+    Checks input args for :py:func:`unique_metadata` and
+    :py:func:`unique_metadata_block`.
+    """
     # Check tensors
     if isinstance(tensor, TensorMap):
         blocks = tensor.blocks()
         # Check gradients
         if gradient_param is not None:
             if not isinstance(gradient_param, str):
-                raise TypeError("``gradient_param`` must be a str")
+                raise TypeError("`gradient_param` must be a `str`")
             # Check all blocks have a gradient under the passed param
             if not np.all([block.has_gradient(gradient_param) for block in blocks]):
                 raise ValueError(
                     "not all input blocks have a gradient under the"
-                    + f" passed ``gradient_param`` {gradient_param}"
+                    + f" passed `gradient_param` {gradient_param}"
                 )
             blocks = [
                 block.gradient(gradient_param) for block in blocks
@@ -219,27 +225,29 @@ def _check_args(
         # Check gradients
         if gradient_param is not None:
             if not isinstance(gradient_param, str):
-                raise TypeError("``gradient_param`` must be a str")
+                raise TypeError("`gradient_param` must be a `str`")
             # Check block has a gradient under the passed param
             if not tensor.has_gradient(gradient_param):
                 raise ValueError(
                     "input block does not have a gradient under the"
-                    + f" passed ``gradient_param`` {gradient_param}"
+                    + f" passed `gradient_param` {gradient_param}"
                 )
             blocks = [tensor.gradient(gradient_param)]  # redefine blocks
     # Check axis
     if not isinstance(axis, str):
-        raise TypeError("``axis`` must be a str, either 'samples' or 'properties'")
+        raise TypeError("`axis` must be a `str`, either `'samples'` or `'properties'`")
     if axis not in ["samples", "properties"]:
-        raise ValueError("``axis`` must be passsed as either 'samples' or 'properties'")
+        raise ValueError(
+            "`axis` must be passsed as either `'samples'` or `'properties'`"
+        )
     # Check names
     if not isinstance(names, list):
-        raise TypeError("``names`` must be a list of str")
+        raise TypeError("`names` must be a `list` of `str`")
     for block in blocks:
         tmp_names = block.samples.names if axis == "samples" else block.properties.names
         for name in names:
             if name not in tmp_names:
                 raise ValueError(
                     "the block(s) passed must have samples/properties"
-                    + " names that matches the one passed in ``names``"
+                    + " names that matches the one passed in `names`"
                 )

--- a/python/src/equistore/operations/unique_metadata.py
+++ b/python/src/equistore/operations/unique_metadata.py
@@ -238,7 +238,7 @@ def _check_args(
         raise TypeError("`axis` must be a `str`, either `'samples'` or `'properties'`")
     if axis not in ["samples", "properties"]:
         raise ValueError(
-            "`axis` must be passsed as either `'samples'` or `'properties'`"
+            "`axis` must be passed as either `'samples'` or `'properties'`"
         )
     # Check names
     if not isinstance(names, list):

--- a/python/src/equistore/operations/unique_metadata.py
+++ b/python/src/equistore/operations/unique_metadata.py
@@ -210,7 +210,9 @@ def _check_args(
         # Check gradients
         if gradient_param is not None:
             if not isinstance(gradient_param, str):
-                raise TypeError("`gradient_param` must be a `str`")
+                raise TypeError(
+                    f"`gradient_param` must be a `str`, not {type(gradient_param)}"
+                )
             # Check all blocks have a gradient under the passed param
             if not np.all([block.has_gradient(gradient_param) for block in blocks]):
                 raise ValueError(
@@ -225,7 +227,9 @@ def _check_args(
         # Check gradients
         if gradient_param is not None:
             if not isinstance(gradient_param, str):
-                raise TypeError("`gradient_param` must be a `str`")
+                raise TypeError(
+                    f"`gradient_param` must be a `str`, not {type(gradient_param)}"
+                )
             # Check block has a gradient under the passed param
             if not tensor.has_gradient(gradient_param):
                 raise ValueError(
@@ -235,19 +239,25 @@ def _check_args(
             blocks = [tensor.gradient(gradient_param)]  # redefine blocks
     # Check axis
     if not isinstance(axis, str):
-        raise TypeError("`axis` must be a `str`, either `'samples'` or `'properties'`")
+        raise TypeError(
+            "`axis` must be a `str`, either `'samples'` or `'properties'`,"
+            + f" receieved type {type(axis)}"
+        )
     if axis not in ["samples", "properties"]:
         raise ValueError(
-            "`axis` must be passed as either `'samples'` or `'properties'`"
+            "`axis` must be passed as either `'samples'` or `'properties'`,"
+            + f" {axis} was passed"
         )
     # Check names
     if not isinstance(names, list):
         raise TypeError("`names` must be a `list` of `str`")
-    for block in blocks:
-        tmp_names = block.samples.names if axis == "samples" else block.properties.names
-        for name in names:
-            if name not in tmp_names:
-                raise ValueError(
-                    "the block(s) passed must have samples/properties"
-                    + " names that matches the one passed in `names`"
-                )
+    # Assumes samples/properties names are the same for every block in blocks
+    block_names = (
+        blocks[0].samples.names if axis == "samples" else blocks[0].properties.names
+    )
+    for name in names:
+        if name not in block_names:
+            raise ValueError(
+                f"the block(s) passed must have {axis} names that match those"
+                + f" passed in `names`. {names} were passed, {block_names} found."
+            )

--- a/python/src/equistore/operations/unique_metadata.py
+++ b/python/src/equistore/operations/unique_metadata.py
@@ -17,13 +17,9 @@ def unique_metadata(
     gradient_param: Optional[str] = None,
 ) -> Labels:
     """
-    For a given ``axis`` (either "samples" or "properties"), and for the given
-    samples/proeprties ``names``, returns a :py:class:`Labels` object of the
-    unique metadata in the input :py:class:`TensorMap` ``tensor``.
-
-    If there are no indices in ``tensor`` corresponding to the specified
-    ``axis`` and ``names``, an empty Labels object with the correct names as in
-    the passed ``names`` is returned
+    Returns a :py:class:`Labels` object containing the unique metadata across
+    all blocks of the input :py:class:`TensorMap`  ``tensor``, for the specified
+    ``axis`` (either "samples" or "properties") and metatdata ``names``.
 
     Passing ``gradient_param`` as a str corresponding to a gradient parameter
     (for instance "cell" or "positions") returns the unique indices only for the
@@ -32,25 +28,29 @@ def unique_metadata(
     by definition have the same properties metadata as their parent
     :py:class:`TensorBlock`.
 
-    To find the unique "structure" indices along the "samples" axis present in a
-    given TensorMap:
+    If there are no indices in the (gradient) blocks of ``tensor`` corresponding
+    to the specified ``axis`` and ``names``, an empty Labels object with the
+    correct names as in the passed ``names`` is returned.
+
+    For example, to find the unique "structure" indices in the "samples"
+    metadata present in a given TensorMap:
 
     .. code-block:: python
 
-        unique_samples = unique_metadata(
+        unique_structures = unique_metadata(
             tensor, axis="samples", names=["structure"],
         )
 
-    To find the unique "atom" indices along the "samples" axis present in the
+    To find the unique "atom" indices in the "samples" metadata present in the
     "positions" gradient blocks of a given TensorMap:
 
     .. code-block:: python
 
-        unique_grad_samples = unique_metadata(
+        unique_grad_atoms = unique_metadata(
             tensor, axis="samples", names=["atom"], gradient_param="positions",
         )
 
-    :param block: the :py:class:`TensorMap` to find unique indices for.
+    :param tensor: the :py:class:`TensorMap` to find unique indices for.
     :param axis: a str, either "samples" or "properties", corresponding to the
         axis along which the named unique indices should be found.
     :param names: a str, list of str, or tuple of str corresponding to the
@@ -61,10 +61,10 @@ def unique_metadata(
         (default), the unique indices of the regular TensorBlocks will be
         calculated.
 
-    :return: a sorted :py:class:`Labels` object containing the unique indices
-        for the input ``block`` or its gradient for the specified parameter.
-        Each element in the returned :py:class:`Labels` object has len(names)
-        entries.
+    :return: a sorted :py:class:`Labels` object containing the unique metadata
+        for the blocks of the input ``tensor`` or its gradient blocks for the
+        specified parameter. Each element in the returned :py:class:`Labels`
+        object has len(``names``) entries.
     """
     # Parse input args
     if not isinstance(tensor, TensorMap):
@@ -91,22 +91,22 @@ def unique_metadata_block(
     gradient_param: Optional[str] = None,
 ) -> Labels:
     """
-    For a given ``axis`` (either "samples" or "properties"), and for the given
-    samples/proeprties ``names``, returns a :py:class:`Labels` object of the
-    unique indices in the input :py:class:`TensorBlock` ``block``.
-
-    If there are no indices in ``block`` corresponding to the specified ``axis``
-    and ``names``, an empty Labels object with the correct names as in the
-    passed ``names`` is returned.
+    Returns a :py:class:`Labels` object containing the unique metadata in the
+    input :py:class:`TensorBlock`  ``block``, for the specified ``axis`` (either
+    "samples" or "properties") and metatdata ``names``.
 
     Passing ``gradient_param`` as a str corresponding to a gradient parameter
     (for instance "cell" or "positions") returns the unique indices only for the
-    gradient blocks associated with the input ``block``, according to the
+    gradient block associated with the input ``block`` , according to the
     specified ``axis`` and ``names``. Note that gradient blocks by definition
     have the same properties metadata as their parent :py:class:`TensorBlock`.
 
-    To find the unique "structure" indices along the "samples" axis present in a
-    given TensorBlock:
+    If there are no indices in the ``block`` (or its gradient) corresponding to
+    the specified ``axis`` and ``names``, an empty Labels object with the
+    correct names as in the passed ``names`` is returned.
+
+    For example, to find the unique "structure" indices in the "samples"
+    metadata present in a given TensorBlock:
 
     .. code-block:: python
 
@@ -125,16 +125,16 @@ def unique_metadata_block(
 
     :param block: the :py:class:`TensorBlock` to find unique indices for.
     :param axis: a str, either "samples" or "properties", corresponding to the
-        axis along which the named unique indices should be found.
+        axis along which the named unique metadata should be found.
     :param names: a str, list of str, or tuple of str corresponding to the
-        name(s) of the indices along the specified ``axis`` for which the unique
-        values should be found.
+        name(s) of the metadata along the specified ``axis`` for which the
+        unique indices should be found.
     :param gradient_param: a str corresponding to the gradient parameter name
-        for the gradient blocks to find the unique indices for. If none
-        (default), the unique indices of the regular TensorBlocks will be
+        for the gradient blocks to find the unique metadata for. If none
+        (default), the unique metadata of the regular TensorBlocks will be
         calculated.
 
-    :return: a sorted :py:class:`Labels` object containing the unique indices
+    :return: a sorted :py:class:`Labels` object containing the unique metadata
         for the input ``block`` or its gradient for the specified parameter.
         Each element in the returned :py:class:`Labels` object has len(names)
         entries.
@@ -166,7 +166,7 @@ def _unique_from_blocks(
     """
     Finds the unique metadata of a list of blocks along the given ``axis`` and
     for the specified ``names``. If ``gradient_param`` is specified, only finds
-    the unique indices for gradient blocks under the specified param name.
+    the unique indices for gradient blocks under the specified parameter name.
     """
     # Extract indices from each block
     all_idxs = []

--- a/python/src/equistore/operations/unique_metadata.py
+++ b/python/src/equistore/operations/unique_metadata.py
@@ -60,8 +60,8 @@ def unique_metadata(
         for which the unique values should be found.
     :param gradient_param: a ``str`` corresponding to the gradient parameter
         name for the gradient blocks to find the unique indices for. If none
-        (default), the unique indices of the regular :py:class:`TensorBlock`s
-        will be calculated.
+        (default), the unique indices of the regular :py:class:`TensorBlock`
+        objects will be calculated.
 
     :return: a sorted :py:class:`Labels` object containing the unique metadata
         for the blocks of the input ``tensor`` or its gradient blocks for the
@@ -134,8 +134,8 @@ def unique_metadata_block(
         ``axis`` for which the unique indices should be found.
     :param gradient_param: a ``str`` corresponding to the gradient parameter
         name for the gradient blocks to find the unique metadata for. If none
-        (default), the unique metadata of the regular :py:class:`TensorBlock`s
-        will be calculated.
+        (default), the unique metadata of the regular :py:class:`TensorBlock`
+        objects will be calculated.
 
     :return: a sorted :py:class:`Labels` object containing the unique metadata
         for the input ``block`` or its gradient for the specified parameter.

--- a/python/src/equistore/operations/unique_metadata.py
+++ b/python/src/equistore/operations/unique_metadata.py
@@ -1,0 +1,245 @@
+"""
+Module for finding unique metadata for TensorMaps and TensorBlocks
+"""
+from typing import List, Optional, Tuple, Union
+
+import numpy as np
+
+from ..block import TensorBlock
+from ..labels import Labels
+from ..tensor import TensorMap
+
+
+def unique_metadata(
+    tensor: TensorMap,
+    axis: str,
+    names: Union[List[str], Tuple[str], str],
+    gradient_param: Optional[str] = None,
+) -> Labels:
+    """
+    For a given ``axis`` (either "samples" or "properties"), and for the given
+    samples/proeprties ``names``, returns a :py:class:`Labels` object of the
+    unique metadata in the input :py:class:`TensorMap` ``tensor``.
+
+    If there are no indices in ``tensor`` corresponding to the specified
+    ``axis`` and ``names``, an empty Labels object with the correct names as in
+    the passed ``names`` is returned
+
+    Passing ``gradient_param`` as a str corresponding to a gradient parameter
+    (for instance "cell" or "positions") returns the unique indices only for the
+    gradient blocks associated with each block in the input ``tensor``,
+    according to the specified ``axis`` and ``names``. Note that gradient blocks
+    by definition have the same properties metadata as their parent
+    :py:class:`TensorBlock`.
+
+    To find the unique "structure" indices along the "samples" axis present in a
+    given TensorMap:
+
+    .. code-block:: python
+
+        unique_samples = unique_metadata(
+            tensor, axis="samples", names=["structure"],
+        )
+
+    To find the unique "atom" indices along the "samples" axis present in the
+    "positions" gradient blocks of a given TensorMap:
+
+    .. code-block:: python
+
+        unique_grad_samples = unique_metadata(
+            tensor, axis="samples", names=["atom"], gradient_param="positions",
+        )
+
+    :param block: the :py:class:`TensorMap` to find unique indices for.
+    :param axis: a str, either "samples" or "properties", corresponding to the
+        axis along which the named unique indices should be found.
+    :param names: a str, list of str, or tuple of str corresponding to the
+        name(s) of the indices along the specified ``axis`` for which the unique
+        values should be found.
+    :param gradient_param: a str corresponding to the gradient parameter name
+        for the gradient blocks to find the unique indices for. If none
+        (default), the unique indices of the regular TensorBlocks will be
+        calculated.
+
+    :return: a sorted :py:class:`Labels` object containing the unique indices
+        for the input ``block`` or its gradient for the specified parameter.
+        Each element in the returned :py:class:`Labels` object has len(names)
+        entries.
+    """
+    # Parse input args
+    if not isinstance(tensor, TensorMap):
+        raise TypeError("``tensor`` must be an equistore TensorMap")
+    names = (
+        [names]
+        if isinstance(names, str)
+        else (list(names) if isinstance(names, tuple) else names)
+    )
+    _check_args(tensor, axis, names, gradient_param)
+    # Make a list of the blocks to find unique indices for
+    if gradient_param is None:
+        blocks = tensor.blocks()
+    else:
+        blocks = [block.gradient(gradient_param) for block in tensor.blocks()]
+
+    return _unique_from_blocks(blocks, axis, names, gradient_param)
+
+
+def unique_metadata_block(
+    block: TensorBlock,
+    axis: str,
+    names: Union[List[str], Tuple[str], str],
+    gradient_param: Optional[str] = None,
+) -> Labels:
+    """
+    For a given ``axis`` (either "samples" or "properties"), and for the given
+    samples/proeprties ``names``, returns a :py:class:`Labels` object of the
+    unique indices in the input :py:class:`TensorBlock` ``block``.
+
+    If there are no indices in ``block`` corresponding to the specified ``axis``
+    and ``names``, an empty Labels object with the correct names as in the
+    passed ``names`` is returned.
+
+    Passing ``gradient_param`` as a str corresponding to a gradient parameter
+    (for instance "cell" or "positions") returns the unique indices only for the
+    gradient blocks associated with the input ``block``, according to the
+    specified ``axis`` and ``names``. Note that gradient blocks by definition
+    have the same properties metadata as their parent :py:class:`TensorBlock`.
+
+    To find the unique "structure" indices along the "samples" axis present in a
+    given TensorBlock:
+
+    .. code-block:: python
+
+        unique_samples = unique_metadata_block(
+            block, axis="samples", names=["structure"],
+        )
+
+    To find the unique "atom" indices along the "samples" axis present in the
+    "positions" gradient block of a given TensorBlock:
+
+    .. code-block:: python
+
+        unique_grad_samples = unique_metadata_block(
+            block, axis="samples", names=["atom"], gradient_param="positions",
+        )
+
+    :param block: the :py:class:`TensorBlock` to find unique indices for.
+    :param axis: a str, either "samples" or "properties", corresponding to the
+        axis along which the named unique indices should be found.
+    :param names: a str, list of str, or tuple of str corresponding to the
+        name(s) of the indices along the specified ``axis`` for which the unique
+        values should be found.
+    :param gradient_param: a str corresponding to the gradient parameter name
+        for the gradient blocks to find the unique indices for. If none
+        (default), the unique indices of the regular TensorBlocks will be
+        calculated.
+
+    :return: a sorted :py:class:`Labels` object containing the unique indices
+        for the input ``block`` or its gradient for the specified parameter.
+        Each element in the returned :py:class:`Labels` object has len(names)
+        entries.
+    """
+    # Parse input args
+    if not isinstance(block, TensorBlock):
+        raise TypeError("``block`` must be an equistore TensorBlock")
+    names = (
+        [names]
+        if isinstance(names, str)
+        else (list(names) if isinstance(names, tuple) else names)
+    )
+    _check_args(block, axis, names, gradient_param)
+    # Make a list of the blocks to find unique indices for
+    if gradient_param is None:
+        blocks = [block]
+    else:
+        blocks = [block.gradient(gradient_param)]
+
+    return _unique_from_blocks(blocks, axis, names, gradient_param)
+
+
+def _unique_from_blocks(
+    blocks: List[TensorBlock],
+    axis: str,
+    names: List[str],
+    gradient_param: Optional[str],
+) -> Labels:
+    """
+    Finds the unique metadata of a list of blocks along the given ``axis`` and
+    for the specified ``names``. If ``gradient_param`` is specified, only finds
+    the unique indices for gradient blocks under the specified param name.
+    """
+    # Extract indices from each block
+    all_idxs = []
+    for block in blocks:
+        idxs = block.samples[names] if axis == "samples" else block.properties[names]
+        for idx in idxs:
+            all_idxs.append(idx)
+
+    # If no matching indices across all blocks return a empty Labels w/ the
+    # correct names
+    if len(all_idxs) == 0:
+        # Create Labels with single entry
+        labels = Labels(names=names, values=np.array([[i for i in range(len(names))]]))
+        # rslice to zero length
+        return labels[:0]
+
+    # Define the unique and sorted indices
+    unique_idxs = np.unique(all_idxs, axis=0)
+
+    # Return as Labels
+    return Labels(names=names, values=np.array([[j for j in i] for i in unique_idxs]))
+
+
+def _check_args(
+    tensor: Union[TensorMap, TensorBlock],
+    axis: str,
+    names: List[str],
+    gradient_param: Optional[str] = None,
+):
+    """Checks input args for :py:func:`unique_metadata` and
+    :py:func:`unique_metadata_block`."""
+    # Check tensors
+    if isinstance(tensor, TensorMap):
+        blocks = tensor.blocks()
+        # Check gradients
+        if gradient_param is not None:
+            if not isinstance(gradient_param, str):
+                raise TypeError("``gradient_param`` must be a str")
+            # Check all blocks have a gradient under the passed param
+            if not np.all([block.has_gradient(gradient_param) for block in blocks]):
+                raise ValueError(
+                    "not all input blocks have a gradient under the"
+                    + f" passed ``gradient_param`` {gradient_param}"
+                )
+            blocks = [
+                block.gradient(gradient_param) for block in blocks
+            ]  # redefine blocks
+    elif isinstance(tensor, TensorBlock):
+        blocks = [tensor]
+        # Check gradients
+        if gradient_param is not None:
+            if not isinstance(gradient_param, str):
+                raise TypeError("``gradient_param`` must be a str")
+            # Check block has a gradient under the passed param
+            if not tensor.has_gradient(gradient_param):
+                raise ValueError(
+                    "input block does not have a gradient under the"
+                    + f" passed ``gradient_param`` {gradient_param}"
+                )
+            blocks = [tensor.gradient(gradient_param)]  # redefine blocks
+    # Check axis
+    if not isinstance(axis, str):
+        raise TypeError("``axis`` must be a str, either 'samples' or 'properties'")
+    if axis not in ["samples", "properties"]:
+        raise ValueError("``axis`` must be passsed as either 'samples' or 'properties'")
+    # Check names
+    if not isinstance(names, list):
+        raise TypeError("``names`` must be a list of str")
+    for block in blocks:
+        tmp_names = block.samples.names if axis == "samples" else block.properties.names
+        for name in names:
+            if name not in tmp_names:
+                raise ValueError(
+                    "the block(s) passed must have samples/properties"
+                    + " names that matches the one passed in ``names``"
+                )

--- a/python/src/equistore/operations/unique_metadata.py
+++ b/python/src/equistore/operations/unique_metadata.py
@@ -289,13 +289,3 @@ def _check_args(
             "`names` must be a `list` of `str`, received"
             + f" {[type(name) for name in names]}"
         )
-    # Assumes samples/properties names are the same for every block in blocks
-    # block_names = (
-    #     blocks[0].samples.names if axis == "samples" else blocks[0].properties.names
-    # )
-    # for name in names:
-    #     if name not in block_names:
-    #         raise ValueError(
-    #             f"the block(s) passed must have {axis} names that match those"
-    #             + f" passed in `names`. {names} were passed, {block_names} found."
-    #         )

--- a/python/tests/operations/unique_metadata.py
+++ b/python/tests/operations/unique_metadata.py
@@ -24,76 +24,45 @@ class TestUniqueMetadata(unittest.TestCase):
             use_numpy=True,
         )
 
-    def test_unique_indices_block(self):
+    def test_unique_metadata_block_samples(self):
+        """Tests getting unique metadata along properties axis w/ 3 test cases"""
         # Test case 1
         samples = [0, 1, 2, 5]
-        properties = [0]
         target_samples = Labels(
             names=["samples"], values=np.array([[s] for s in samples])
-        )
-        target_properties = Labels(
-            names=["properties"], values=np.array([[p] for p in properties])
         )
         actual_samples = fn.unique_metadata_block(
             self.tensor1.block(3), "samples", "samples"
         )
-        actual_properties = fn.unique_metadata_block(
-            self.tensor1.block(3), "properties", "properties"
-        )
         self.assertTrue(
             fn._utils._labels_equal(target_samples, actual_samples, exact_order=True)
         )
-        self.assertTrue(
-            fn._utils._labels_equal(
-                target_properties, actual_properties, exact_order=True
-            )
-        )
         # Test case 2
         samples = [0, 2, 4]
-        properties = [3, 4, 5]
         target_samples = Labels(
             names=["samples"], values=np.array([[s] for s in samples])
-        )
-        target_properties = Labels(
-            names=["properties"], values=np.array([[p] for p in properties])
         )
         actual_samples = fn.unique_metadata_block(
             self.tensor2.block(0), "samples", "samples"
         )
-        actual_properties = fn.unique_metadata_block(
-            self.tensor2.block(1), "properties", "properties"
-        )
         self.assertTrue(
             fn._utils._labels_equal(target_samples, actual_samples, exact_order=True)
         )
-        self.assertTrue(
-            fn._utils._labels_equal(
-                target_properties, actual_properties, exact_order=True
-            )
-        )
         # Test case 3
         samples = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
-        properties = [0, 1, 2, 3]
         target_samples = Labels(
             names=["structure"], values=np.array([[s] for s in samples])
-        )
-        target_properties = Labels(
-            names=["n"], values=np.array([[p] for p in properties])
         )
         actual_samples = fn.unique_metadata_block(
             self.tensor3.block(0), "samples", "structure"
         )
-        actual_properties = fn.unique_metadata_block(
-            self.tensor3.block(0), "properties", "n"
-        )
         self.assertTrue(
             fn._utils._labels_equal(target_samples, actual_samples, exact_order=True)
         )
-        self.assertTrue(
-            fn._utils._labels_equal(
-                target_properties, actual_properties, exact_order=True
-            )
-        )
+
+    def test_unique_metadata_block_samples_to_zero(self):
+        """Tests getting unique samples metadata of a block sliced to zero
+        dimension"""
         # Slice block to zero along samples and check labels return is empty
         # with correct names
         target_samples = Labels(names=["structure"], values=np.array([[0]])[:0])
@@ -106,6 +75,52 @@ class TestUniqueMetadata(unittest.TestCase):
             fn._utils._labels_equal(target_samples, actual_samples, exact_order=True)
         )
         self.assertTrue(len(actual_samples) == 0)
+
+    def test_unique_metadata_block_properties(self):
+        """Tests getting unique metadata along properties axis w/ 3 test
+        cases"""
+        properties = [0]
+        target_properties = Labels(
+            names=["properties"], values=np.array([[p] for p in properties])
+        )
+        actual_properties = fn.unique_metadata_block(
+            self.tensor1.block(3), "properties", "properties"
+        )
+        self.assertTrue(
+            fn._utils._labels_equal(
+                target_properties, actual_properties, exact_order=True
+            )
+        )
+        # Test case 2
+        properties = [3, 4, 5]
+        target_properties = Labels(
+            names=["properties"], values=np.array([[p] for p in properties])
+        )
+        actual_properties = fn.unique_metadata_block(
+            self.tensor2.block(1), "properties", "properties"
+        )
+        self.assertTrue(
+            fn._utils._labels_equal(
+                target_properties, actual_properties, exact_order=True
+            )
+        )
+        # Test case 3
+        properties = [0, 1, 2, 3]
+        target_properties = Labels(
+            names=["n"], values=np.array([[p] for p in properties])
+        )
+        actual_properties = fn.unique_metadata_block(
+            self.tensor3.block(0), "properties", "n"
+        )
+        self.assertTrue(
+            fn._utils._labels_equal(
+                target_properties, actual_properties, exact_order=True
+            )
+        )
+
+    def test_unique_metadata_block_properties_to_zero(self):
+        """Tests getting unique properties metadata of a block sliced to zero
+        dimension"""
         # Slice block to zero along properties and check labels return is empty
         # with correct names
         target_properties = Labels(names=["n"], values=np.array([[0]])[:0])
@@ -121,27 +136,67 @@ class TestUniqueMetadata(unittest.TestCase):
         )
         self.assertTrue(len(actual_properties) == 0)
 
-        return
-
-    def test_unique_indices_block_gradient(self):
+    def test_unique_metadata_block_gradient_samples(self):
         # Test case 1
         parameter = "parameter"
         samples = [0, 2]
-        properties = [0]
         target_samples = Labels(
             names=["sample"], values=np.array([[s] for s in samples])
-        )
-        target_properties = Labels(
-            names=["properties"], values=np.array([[p] for p in properties])
         )
         actual_samples = fn.unique_metadata_block(
             self.tensor1.block(0), "samples", "sample", parameter
         )
-        actual_properties = fn.unique_metadata_block(
-            self.tensor1.block(0), "properties", "properties", parameter
+        self.assertTrue(
+            fn._utils._labels_equal(target_samples, actual_samples, exact_order=True)
+        )
+        # Test case 2
+        parameter = "parameter"
+        samples, sname = [[0, -2], [0, 3], [2, -2]], ["sample", "parameter"]
+        target_samples = Labels(names=sname, values=np.array([s for s in samples]))
+        actual_samples = fn.unique_metadata_block(
+            self.tensor2.block(1), "samples", sname, parameter
         )
         self.assertTrue(
             fn._utils._labels_equal(target_samples, actual_samples, exact_order=True)
+        )
+        # Test case 3
+        target_samples = Labels(
+            names=["sample"], values=np.arange(0, 52).reshape(-1, 1)
+        )
+        actual_samples = fn.unique_metadata_block(
+            self.tensor3.block(1), "samples", "sample", "cell"
+        )
+        self.assertTrue(
+            fn._utils._labels_equal(target_samples, actual_samples, exact_order=True)
+        )
+
+    def test_unique_metadata_block_gradient_samples_to_zero(self):
+        """Test unique samples metadata of block sliced to zero"""
+        # Slice block to zero along samples and check labels return is empty
+        # with correct names
+        target_samples = Labels(names=["sample"], values=np.array([[0]])[:0])
+        sliced_block = fn.slice_block(
+            self.tensor3.block(0),
+            samples=Labels(names=["structure"], values=np.array([[-1]])),
+        )
+        actual_samples = fn.unique_metadata_block(
+            sliced_block, "samples", "sample", gradient_param="cell"
+        )
+        self.assertTrue(
+            fn._utils._labels_equal(target_samples, actual_samples, exact_order=True)
+        )
+        self.assertTrue(len(actual_samples) == 0)
+
+    def test_unique_metadata_block_gradient_properties(self):
+        """Test unique properties metadata of gradient blocks"""
+        # Test case 1
+        parameter = "parameter"
+        properties = [0]
+        target_properties = Labels(
+            names=["properties"], values=np.array([[p] for p in properties])
+        )
+        actual_properties = fn.unique_metadata_block(
+            self.tensor1.block(0), "properties", "properties", parameter
         )
         self.assertTrue(
             fn._utils._labels_equal(
@@ -150,20 +205,12 @@ class TestUniqueMetadata(unittest.TestCase):
         )
         # Test case 2
         parameter = "parameter"
-        samples, sname = [[0, -2], [0, 3], [2, -2]], ["sample", "parameter"]
         properties, pname = [[3], [4], [5]], ["properties"]
-        target_samples = Labels(names=sname, values=np.array([s for s in samples]))
         target_properties = Labels(
             names=pname, values=np.array([p for p in properties])
         )
-        actual_samples = fn.unique_metadata_block(
-            self.tensor2.block(1), "samples", sname, parameter
-        )
         actual_properties = fn.unique_metadata_block(
             self.tensor2.block(1), "properties", pname, parameter
-        )
-        self.assertTrue(
-            fn._utils._labels_equal(target_samples, actual_samples, exact_order=True)
         )
         self.assertTrue(
             fn._utils._labels_equal(
@@ -183,18 +230,9 @@ class TestUniqueMetadata(unittest.TestCase):
             )
         )
         # Test case 3
-        target_samples = Labels(
-            names=["sample"], values=np.arange(0, 52).reshape(-1, 1)
-        )
         target_properties = Labels(names=["n"], values=np.arange(0, 4).reshape(-1, 1))
-        actual_samples = fn.unique_metadata_block(
-            self.tensor3.block(1), "samples", "sample", "cell"
-        )
         actual_properties = fn.unique_metadata_block(
             self.tensor3.block(1), "properties", "n", "positions"
-        )
-        self.assertTrue(
-            fn._utils._labels_equal(target_samples, actual_samples, exact_order=True)
         )
         self.assertTrue(
             fn._utils._labels_equal(
@@ -219,20 +257,9 @@ class TestUniqueMetadata(unittest.TestCase):
                 target_properties, actual_properties, exact_order=True
             )
         )
-        # Slice block to zero along samples and check labels return is empty
-        # with correct names
-        target_samples = Labels(names=["sample"], values=np.array([[0]])[:0])
-        sliced_block = fn.slice_block(
-            self.tensor3.block(0),
-            samples=Labels(names=["structure"], values=np.array([[-1]])),
-        )
-        actual_samples = fn.unique_metadata_block(
-            sliced_block, "samples", "sample", gradient_param="cell"
-        )
-        self.assertTrue(
-            fn._utils._labels_equal(target_samples, actual_samples, exact_order=True)
-        )
-        self.assertTrue(len(actual_samples) == 0)
+
+    def test_unique_metadata_block_gradient_properties_to_zero(self):
+        """Test unique samples metadata of block sliced to zero"""
         # Slice block to zero along properties and check labels return is empty
         # with correct names
         target_properties = Labels(names=["n"], values=np.array([[0]])[:0])
@@ -249,60 +276,94 @@ class TestUniqueMetadata(unittest.TestCase):
             )
         )
         self.assertTrue(len(actual_properties) == 0)
-        return
 
-    def test_unique_indices(self):
+    def test_unique_indices_samples(self):
+        """Test unique on whole TensorMap along samples"""
+        # Test case 1
         samples = [0, 1, 2, 3, 4, 5, 6, 8]
-        properties = [0, 3, 4, 5]
         target_samples = Labels(
             names=["samples"], values=np.array([[s] for s in samples])
         )
-        target_properties = Labels(
-            names=["properties"], values=np.array([[p] for p in properties])
-        )
-        # Test case 1
         actual_samples = fn.unique_metadata(self.tensor1, "samples", "samples")
-        actual_properties = fn.unique_metadata(self.tensor1, "properties", "properties")
         self.assertTrue(
             fn._utils._labels_equal(target_samples, actual_samples, exact_order=True)
-        )
-        self.assertTrue(
-            fn._utils._labels_equal(
-                target_properties, actual_properties, exact_order=True
-            )
         )
         # Test case 2
         actual_samples = fn.unique_metadata(self.tensor2, "samples", "samples")
         self.assertTrue(
             fn._utils._labels_equal(actual_samples, target_samples, exact_order=True)
         )
+
+    def test_unique_indices_samples_different_types(self):
+        """Passign names as different types"""
+        samples = [0, 1, 2, 3, 4, 5, 6, 8]
+        target_samples = Labels(
+            names=["samples"], values=np.array([[s] for s in samples])
+        )
+        # Passing names as list
+        actual_samples = fn.unique_metadata(self.tensor2, "samples", ["samples"])
+        self.assertTrue(
+            fn._utils._labels_equal(target_samples, actual_samples, exact_order=True)
+        )
+        # Passing names as tuple
+        actual_samples = fn.unique_metadata(self.tensor2, "samples", ("samples",))
+        self.assertTrue(
+            fn._utils._labels_equal(target_samples, actual_samples, exact_order=True)
+        )
+
+    def test_unique_indices_properties(self):
+        """Test unique on whole TensorMap along samples"""
+        # Test case 1
+        properties = [0, 3, 4, 5]
+        target_properties = Labels(
+            names=["properties"], values=np.array([[p] for p in properties])
+        )
+        actual_properties = fn.unique_metadata(self.tensor1, "properties", "properties")
+        self.assertTrue(
+            fn._utils._labels_equal(
+                target_properties, actual_properties, exact_order=True
+            )
+        )
+        # Test case 2
         properties = [0, 1, 2, 3, 4, 5, 6, 7]
         target_properties = Labels(
             names=["properties"], values=np.array([[p] for p in properties])
         )
         actual_properties = fn.unique_metadata(self.tensor2, "properties", "properties")
         self.assertTrue(
-            fn._utils._labels_equal(actual_samples, target_samples, exact_order=True)
+            fn._utils._labels_equal(
+                target_properties, actual_properties, exact_order=True
+            )
+        )
+
+    def test_unique_indices_properties_different_types(self):
+        """Passing names as different types"""
+        properties = [0, 1, 2, 3, 4, 5, 6, 7]
+        target_properties = Labels(
+            names=["properties"], values=np.array([[p] for p in properties])
         )
         # Passing names as list
         actual_properties = fn.unique_metadata(
             self.tensor2, "properties", ["properties"]
         )
         self.assertTrue(
-            fn._utils._labels_equal(actual_samples, target_samples, exact_order=True)
+            fn._utils._labels_equal(
+                target_properties, actual_properties, exact_order=True
+            )
         )
         # Passing names as tuple
         actual_properties = fn.unique_metadata(
             self.tensor2, "properties", ("properties",)
         )
         self.assertTrue(
-            fn._utils._labels_equal(actual_samples, target_samples, exact_order=True)
+            fn._utils._labels_equal(
+                target_properties, actual_properties, exact_order=True
+            )
         )
 
-        return
-
-    def test_unique_indices_gradients(self):
-        # Samples
+    def test_unique_indices_gradients_samples(self):
+        """Tests getting unique metadata of gradients on whole TensorMap along
+        samples"""
         parameter = "parameter"
         samples = np.array([[0, -2], [0, 1], [0, 3], [1, -2], [2, -2], [2, 3], [3, 3]])
         snames = ["sample", "parameter"]
@@ -311,14 +372,26 @@ class TestUniqueMetadata(unittest.TestCase):
         self.assertTrue(
             fn._utils._labels_equal(actual_samples, target_samples, exact_order=True)
         )
+
+    def test_unique_indices_gradients_samples_incorrect_order(self):
+        """
+        Tests false of getting unique metadata of gradients on whole TensorMap
+        along samples with incorrect order
+        """
+        parameter = "parameter"
         # Incorrect order samples - [1, -2] and [2, -2] switched around
         samples = np.array([[0, -2], [0, 1], [0, 3], [2, -2], [1, -2], [2, 3], [3, 3]])
+        snames = ["sample", "parameter"]
         target_samples = Labels(names=snames, values=samples)
         actual_samples = fn.unique_metadata(self.tensor1, "samples", snames, parameter)
         self.assertFalse(
             fn._utils._labels_equal(actual_samples, target_samples, exact_order=True)
         )
-        # Properties
+
+    def test_unique_indices_gradients_properties(self):
+        """Tests getting unique metadata of gradients on whole TensorMap along
+        properties"""
+        parameter = "parameter"
         properties, pnames = [0, 3, 4, 5], ["properties"]
         target_properties = Labels(
             names=pnames, values=np.array([[p] for p in properties])
@@ -331,7 +404,14 @@ class TestUniqueMetadata(unittest.TestCase):
                 target_properties, actual_properties, exact_order=True
             )
         )
-        # Incorrect order properties
+
+    def test_unique_indices_gradients_properties_incorrect_order(self):
+        """
+        Tests false of getting unique metadata of gradients on whole TensorMap
+        along properties with incorrect order
+        """
+        # 3 and 4 switched
+        parameter = "parameter"
         properties, pnames = [0, 4, 3, 5], ["properties"]
         target_properties = Labels(
             names=pnames, values=np.array([[p] for p in properties])
@@ -340,10 +420,10 @@ class TestUniqueMetadata(unittest.TestCase):
             self.tensor1, "properties", pnames, parameter
         )
         self.assertFalse(
-            fn._utils._labels_equal(actual_samples, target_samples, exact_order=True)
+            fn._utils._labels_equal(
+                target_properties, actual_properties, exact_order=True
+            )
         )
-
-        return
 
 
 class TestUniqueMetadataErrors(unittest.TestCase):
@@ -359,95 +439,108 @@ class TestUniqueMetadataErrors(unittest.TestCase):
         )
         self.block = self.tensor.block(0)
 
-    def test_unique_indices_block(self):
+    def test_unique_indices_block_type_errors(self):
         # TypeError with TM
         with self.assertRaises(TypeError) as cm:
             fn.unique_metadata_block(self.tensor, "samples", ["structure"])
         self.assertEqual(
             str(cm.exception),
-            "``block`` must be an equistore TensorBlock",
+            "`block` must be an equistore `TensorBlock`",
         )
         # TypeError axis as float
         with self.assertRaises(TypeError) as cm:
             fn.unique_metadata_block(self.block, 3.14, ["structure"])
         self.assertEqual(
             str(cm.exception),
-            "``axis`` must be a str, either 'samples' or 'properties'",
+            "`axis` must be a `str`, either `'samples'` or `'properties'`",
         )
+        # TypeError names as float
+        with self.assertRaises(TypeError) as cm:
+            fn.unique_metadata_block(self.block, "properties", 3.14)
+        self.assertEqual(str(cm.exception), "`names` must be a `list` of `str`")
+        # TypeError gradient_param as float
+        with self.assertRaises(TypeError) as cm:
+            fn.unique_metadata_block(
+                self.block, "properties", ["structure"], gradient_param=3.14
+            )
+        self.assertEqual(str(cm.exception), "`gradient_param` must be a `str`")
+
+    def test_unique_indices_block_value_errors(self):
+        """tests raising of value errors"""
         # ValueError axis not "samples" or "properties"
         with self.assertRaises(ValueError) as cm:
             fn.unique_metadata_block(self.block, "ciao", ["structure"])
         self.assertEqual(
             str(cm.exception),
-            "``axis`` must be passsed as either 'samples' or 'properties'",
+            "`axis` must be passsed as either `'samples'` or `'properties'`",
         )
-        # TypeError names as float
-        with self.assertRaises(TypeError) as cm:
-            fn.unique_metadata_block(self.block, "properties", 3.14)
-        self.assertEqual(str(cm.exception), "``names`` must be a list of str")
-        # No error names as str, list of str, or tuple of str
-        fn.unique_metadata_block(self.block, "samples", "structure")
-        fn.unique_metadata_block(self.block, "samples", ["structure"])
-        fn.unique_metadata_block(self.block, "samples", ("structure",))
         # ValueError names not in block
         with self.assertRaises(ValueError) as cm:
             fn.unique_metadata_block(self.block, "properties", ["ciao"])
         self.assertEqual(
             str(cm.exception),
             "the block(s) passed must have samples/properties"
-            + " names that matches the one passed in ``names``",
+            + " names that matches the one passed in `names`",
         )
-        # TypeError gradient_param as float
-        with self.assertRaises(TypeError) as cm:
-            fn.unique_metadata_block(
-                self.block, "properties", ["structure"], gradient_param=3.14
-            )
-        self.assertEqual(str(cm.exception), "``gradient_param`` must be a str")
         # ValueError gradient_param not a valid param for gradients
         with self.assertRaises(TypeError) as cm:
             fn.unique_metadata_block(
                 self.block, "properties", ["structure"], gradient_param=3.14
             )
-        self.assertEqual(str(cm.exception), "``gradient_param`` must be a str")
+        self.assertEqual(str(cm.exception), "`gradient_param` must be a `str`")
 
-    def test_unique(self):
+    def test_unique_indices_block_no_errors(self):
+        """tests no raising of errors"""
+        # No error names as str, list of str, or tuple of str
+        fn.unique_metadata_block(self.block, "samples", "structure")
+        fn.unique_metadata_block(self.block, "samples", ["structure"])
+        fn.unique_metadata_block(self.block, "samples", ("structure",))
+
+    def test_unique_type_errors(self):
+        """tests raising of type errors"""
         # TypeError with TB
         with self.assertRaises(TypeError) as cm:
             fn.unique_metadata(self.block, "samples", ["structure"])
         self.assertEqual(
             str(cm.exception),
-            "``tensor`` must be an equistore TensorMap",
+            "`tensor` must be an equistore `TensorMap`",
         )
         # TypeError axis as float
         with self.assertRaises(TypeError) as cm:
             fn.unique_metadata(self.tensor, 3.14, ["structure"])
         self.assertEqual(
             str(cm.exception),
-            "``axis`` must be a str, either 'samples' or 'properties'",
+            "`axis` must be a `str`, either `'samples'` or `'properties'`",
         )
+        # TypeError names as float
+        with self.assertRaises(TypeError) as cm:
+            fn.unique_metadata(self.tensor, "properties", 3.14)
+        self.assertEqual(str(cm.exception), "`names` must be a `list` of `str`")
+
+    def test_unique_value_errors(self):
+        """tests raising of value errors"""
         # ValueError axis not "samples" or "properties"
         with self.assertRaises(ValueError) as cm:
             fn.unique_metadata(self.tensor, "ciao", ["structure"])
         self.assertEqual(
             str(cm.exception),
-            "``axis`` must be passsed as either 'samples' or 'properties'",
+            "`axis` must be passsed as either `'samples'` or `'properties'`",
         )
-        # TypeError names as float
-        with self.assertRaises(TypeError) as cm:
-            fn.unique_metadata(self.tensor, "properties", 3.14)
-        self.assertEqual(str(cm.exception), "``names`` must be a list of str")
-        # No error names as str, list of str, or tuple of str
-        fn.unique_metadata(self.tensor, "properties", "n")
-        fn.unique_metadata(self.tensor, "properties", ["n"])
-        fn.unique_metadata(self.tensor, "properties", ("n",))
         # ValueError names not in block
         with self.assertRaises(ValueError) as cm:
             fn.unique_metadata(self.tensor, "properties", ["ciao"])
         self.assertEqual(
             str(cm.exception),
             "the block(s) passed must have samples/properties"
-            + " names that matches the one passed in ``names``",
+            + " names that matches the one passed in `names`",
         )
+
+    def test_unique_no_errors(self):
+        """tests no raising of errors"""
+        # No error names as str, list of str, or tuple of str
+        fn.unique_metadata(self.tensor, "properties", "n")
+        fn.unique_metadata(self.tensor, "properties", ["n"])
+        fn.unique_metadata(self.tensor, "properties", ("n",))
 
 
 def test_tensor_map():

--- a/python/tests/operations/unique_metadata.py
+++ b/python/tests/operations/unique_metadata.py
@@ -452,7 +452,8 @@ class TestUniqueMetadataErrors(unittest.TestCase):
             fn.unique_metadata_block(self.block, 3.14, ["structure"])
         self.assertEqual(
             str(cm.exception),
-            "`axis` must be a `str`, either `'samples'` or `'properties'`",
+            "`axis` must be a `str`, either `'samples'` or `'properties'`,"
+            + f" receieved type {type(3.14)}",
         )
         # TypeError names as float
         with self.assertRaises(TypeError) as cm:
@@ -463,7 +464,9 @@ class TestUniqueMetadataErrors(unittest.TestCase):
             fn.unique_metadata_block(
                 self.block, "properties", ["structure"], gradient_param=3.14
             )
-        self.assertEqual(str(cm.exception), "`gradient_param` must be a `str`")
+        self.assertEqual(
+            str(cm.exception), f"`gradient_param` must be a `str`, not {type(3.14)}"
+        )
 
     def test_unique_indices_block_value_errors(self):
         """tests raising of value errors"""
@@ -472,22 +475,33 @@ class TestUniqueMetadataErrors(unittest.TestCase):
             fn.unique_metadata_block(self.block, "ciao", ["structure"])
         self.assertEqual(
             str(cm.exception),
-            "`axis` must be passed as either `'samples'` or `'properties'`",
+            "`axis` must be passed as either `'samples'` or `'properties'`,"
+            + " ciao was passed",
         )
-        # ValueError names not in block
+        # ValueError names not in block - samples
+        with self.assertRaises(ValueError) as cm:
+            fn.unique_metadata_block(self.block, "samples", ["ciao"])
+        self.assertEqual(
+            str(cm.exception),
+            "the block(s) passed must have samples names that match those passed"
+            + " in `names`. ['ciao'] were passed, ('structure', 'center') found.",
+        )
+        # ValueError names not in block - properties
         with self.assertRaises(ValueError) as cm:
             fn.unique_metadata_block(self.block, "properties", ["ciao"])
         self.assertEqual(
             str(cm.exception),
-            "the block(s) passed must have samples/properties"
-            + " names that matches the one passed in `names`",
+            "the block(s) passed must have properties names that match those"
+            + " passed in `names`. ['ciao'] were passed, ('n',) found.",
         )
         # ValueError gradient_param not a valid param for gradients
         with self.assertRaises(TypeError) as cm:
             fn.unique_metadata_block(
                 self.block, "properties", ["structure"], gradient_param=3.14
             )
-        self.assertEqual(str(cm.exception), "`gradient_param` must be a `str`")
+        self.assertEqual(
+            str(cm.exception), f"`gradient_param` must be a `str`, not {type(3.14)}"
+        )
 
     def test_unique_indices_block_no_errors(self):
         """tests no raising of errors"""
@@ -510,7 +524,8 @@ class TestUniqueMetadataErrors(unittest.TestCase):
             fn.unique_metadata(self.tensor, 3.14, ["structure"])
         self.assertEqual(
             str(cm.exception),
-            "`axis` must be a `str`, either `'samples'` or `'properties'`",
+            "`axis` must be a `str`, either `'samples'` or `'properties'`,"
+            + f" receieved type {type(3.14)}",
         )
         # TypeError names as float
         with self.assertRaises(TypeError) as cm:
@@ -524,15 +539,24 @@ class TestUniqueMetadataErrors(unittest.TestCase):
             fn.unique_metadata(self.tensor, "ciao", ["structure"])
         self.assertEqual(
             str(cm.exception),
-            "`axis` must be passed as either `'samples'` or `'properties'`",
+            "`axis` must be passed as either `'samples'` or `'properties'`,"
+            + " ciao was passed",
         )
-        # ValueError names not in block
+        # ValueError names not in block - samples
+        with self.assertRaises(ValueError) as cm:
+            fn.unique_metadata(self.tensor, "samples", ["ciao"])
+        self.assertEqual(
+            str(cm.exception),
+            "the block(s) passed must have samples names that match those passed"
+            + " in `names`. ['ciao'] were passed, ('structure', 'center') found.",
+        )
+        # ValueError names not in block - properties
         with self.assertRaises(ValueError) as cm:
             fn.unique_metadata(self.tensor, "properties", ["ciao"])
         self.assertEqual(
             str(cm.exception),
-            "the block(s) passed must have samples/properties"
-            + " names that matches the one passed in `names`",
+            "the block(s) passed must have properties names that match those"
+            + " passed in `names`. ['ciao'] were passed, ('n',) found.",
         )
 
     def test_unique_no_errors(self):

--- a/python/tests/operations/unique_metadata.py
+++ b/python/tests/operations/unique_metadata.py
@@ -1,0 +1,588 @@
+import os
+import unittest
+
+import numpy as np
+
+import equistore.io
+import equistore.operations as fn
+from equistore import Labels, TensorBlock, TensorMap
+
+
+DATA_ROOT = os.path.join(os.path.dirname(__file__), "..", "data")
+TEST_FILE = "qm7-spherical-expansion.npz"
+
+
+class TestUniqueMetadata(unittest.TestCase):
+    """Finding unique_metadata metadata along a given axis of a TensorMap or
+    TensorBlock"""
+
+    def setUp(self):
+        self.tensor1 = test_tensor_map()  # Test case 1
+        self.tensor2 = test_large_tensor_map()  # Test case 2
+        self.tensor3 = equistore.io.load(  # Test case 3
+            os.path.join(DATA_ROOT, TEST_FILE),
+            use_numpy=True,
+        )
+
+    def test_unique_indices_block(self):
+        # Test case 1
+        samples = [0, 1, 2, 5]
+        properties = [0]
+        target_samples = Labels(
+            names=["samples"], values=np.array([[s] for s in samples])
+        )
+        target_properties = Labels(
+            names=["properties"], values=np.array([[p] for p in properties])
+        )
+        actual_samples = fn.unique_metadata_block(
+            self.tensor1.block(3), "samples", "samples"
+        )
+        actual_properties = fn.unique_metadata_block(
+            self.tensor1.block(3), "properties", "properties"
+        )
+        self.assertTrue(
+            fn._utils._labels_equal(target_samples, actual_samples, exact_order=True)
+        )
+        self.assertTrue(
+            fn._utils._labels_equal(
+                target_properties, actual_properties, exact_order=True
+            )
+        )
+        # Test case 2
+        samples = [0, 2, 4]
+        properties = [3, 4, 5]
+        target_samples = Labels(
+            names=["samples"], values=np.array([[s] for s in samples])
+        )
+        target_properties = Labels(
+            names=["properties"], values=np.array([[p] for p in properties])
+        )
+        actual_samples = fn.unique_metadata_block(
+            self.tensor2.block(0), "samples", "samples"
+        )
+        actual_properties = fn.unique_metadata_block(
+            self.tensor2.block(1), "properties", "properties"
+        )
+        self.assertTrue(
+            fn._utils._labels_equal(target_samples, actual_samples, exact_order=True)
+        )
+        self.assertTrue(
+            fn._utils._labels_equal(
+                target_properties, actual_properties, exact_order=True
+            )
+        )
+        # Test case 3
+        samples = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        properties = [0, 1, 2, 3]
+        target_samples = Labels(
+            names=["structure"], values=np.array([[s] for s in samples])
+        )
+        target_properties = Labels(
+            names=["n"], values=np.array([[p] for p in properties])
+        )
+        actual_samples = fn.unique_metadata_block(
+            self.tensor3.block(0), "samples", "structure"
+        )
+        actual_properties = fn.unique_metadata_block(
+            self.tensor3.block(0), "properties", "n"
+        )
+        self.assertTrue(
+            fn._utils._labels_equal(target_samples, actual_samples, exact_order=True)
+        )
+        self.assertTrue(
+            fn._utils._labels_equal(
+                target_properties, actual_properties, exact_order=True
+            )
+        )
+        # Slice block to zero along samples and check labels return is empty
+        # with correct names
+        target_samples = Labels(names=["structure"], values=np.array([[0]])[:0])
+        sliced_block = fn.slice_block(
+            self.tensor3.block(0),
+            samples=Labels(names=["structure"], values=np.array([[-1]])),
+        )
+        actual_samples = fn.unique_metadata_block(sliced_block, "samples", "structure")
+        self.assertTrue(
+            fn._utils._labels_equal(target_samples, actual_samples, exact_order=True)
+        )
+        self.assertTrue(len(actual_samples) == 0)
+        # Slice block to zero along properties and check labels return is empty
+        # with correct names
+        target_properties = Labels(names=["n"], values=np.array([[0]])[:0])
+        sliced_block = fn.slice_block(
+            self.tensor3.block(0),
+            properties=Labels(names=["n"], values=np.array([[-1]])),
+        )
+        actual_properties = fn.unique_metadata_block(sliced_block, "properties", "n")
+        self.assertTrue(
+            fn._utils._labels_equal(
+                target_properties, actual_properties, exact_order=True
+            )
+        )
+        self.assertTrue(len(actual_properties) == 0)
+
+        return
+
+    def test_unique_indices_block_gradient(self):
+        # Test case 1
+        parameter = "parameter"
+        samples = [0, 2]
+        properties = [0]
+        target_samples = Labels(
+            names=["sample"], values=np.array([[s] for s in samples])
+        )
+        target_properties = Labels(
+            names=["properties"], values=np.array([[p] for p in properties])
+        )
+        actual_samples = fn.unique_metadata_block(
+            self.tensor1.block(0), "samples", "sample", parameter
+        )
+        actual_properties = fn.unique_metadata_block(
+            self.tensor1.block(0), "properties", "properties", parameter
+        )
+        self.assertTrue(
+            fn._utils._labels_equal(target_samples, actual_samples, exact_order=True)
+        )
+        self.assertTrue(
+            fn._utils._labels_equal(
+                target_properties, actual_properties, exact_order=True
+            )
+        )
+        # Test case 2
+        parameter = "parameter"
+        samples, sname = [[0, -2], [0, 3], [2, -2]], ["sample", "parameter"]
+        properties, pname = [[3], [4], [5]], ["properties"]
+        target_samples = Labels(names=sname, values=np.array([s for s in samples]))
+        target_properties = Labels(
+            names=pname, values=np.array([p for p in properties])
+        )
+        actual_samples = fn.unique_metadata_block(
+            self.tensor2.block(1), "samples", sname, parameter
+        )
+        actual_properties = fn.unique_metadata_block(
+            self.tensor2.block(1), "properties", pname, parameter
+        )
+        self.assertTrue(
+            fn._utils._labels_equal(target_samples, actual_samples, exact_order=True)
+        )
+        self.assertTrue(
+            fn._utils._labels_equal(
+                target_properties, actual_properties, exact_order=True
+            )
+        )
+        # By definition the unique TensorBlock and Gradient block properties
+        # should be equivalent
+        actual_properties_tensorblock = fn.unique_metadata_block(
+            self.tensor2.block(1),
+            "properties",
+            pname,
+        )
+        self.assertTrue(
+            fn._utils._labels_equal(
+                actual_properties_tensorblock, actual_properties, exact_order=True
+            )
+        )
+        # Test case 3
+        target_samples = Labels(
+            names=["sample"], values=np.arange(0, 52).reshape(-1, 1)
+        )
+        target_properties = Labels(names=["n"], values=np.arange(0, 4).reshape(-1, 1))
+        actual_samples = fn.unique_metadata_block(
+            self.tensor3.block(1), "samples", "sample", "cell"
+        )
+        actual_properties = fn.unique_metadata_block(
+            self.tensor3.block(1), "properties", "n", "positions"
+        )
+        self.assertTrue(
+            fn._utils._labels_equal(target_samples, actual_samples, exact_order=True)
+        )
+        self.assertTrue(
+            fn._utils._labels_equal(
+                target_properties, actual_properties, exact_order=True
+            )
+        )
+        # Passing names as list
+        actual_properties = fn.unique_metadata_block(
+            self.tensor3.block(1), "properties", ["n"], "positions"
+        )
+        self.assertTrue(
+            fn._utils._labels_equal(
+                target_properties, actual_properties, exact_order=True
+            )
+        )
+        # Passing names as tuple
+        actual_properties = fn.unique_metadata_block(
+            self.tensor3.block(1), "properties", ("n",), "positions"
+        )
+        self.assertTrue(
+            fn._utils._labels_equal(
+                target_properties, actual_properties, exact_order=True
+            )
+        )
+        # Slice block to zero along samples and check labels return is empty
+        # with correct names
+        target_samples = Labels(names=["sample"], values=np.array([[0]])[:0])
+        sliced_block = fn.slice_block(
+            self.tensor3.block(0),
+            samples=Labels(names=["structure"], values=np.array([[-1]])),
+        )
+        actual_samples = fn.unique_metadata_block(
+            sliced_block, "samples", "sample", gradient_param="cell"
+        )
+        self.assertTrue(
+            fn._utils._labels_equal(target_samples, actual_samples, exact_order=True)
+        )
+        self.assertTrue(len(actual_samples) == 0)
+        # Slice block to zero along properties and check labels return is empty
+        # with correct names
+        target_properties = Labels(names=["n"], values=np.array([[0]])[:0])
+        sliced_block = fn.slice_block(
+            self.tensor3.block(0),
+            properties=Labels(names=["n"], values=np.array([[-1]])),
+        )
+        actual_properties = fn.unique_metadata_block(
+            sliced_block, "properties", "n", gradient_param="cell"
+        )
+        self.assertTrue(
+            fn._utils._labels_equal(
+                target_properties, actual_properties, exact_order=True
+            )
+        )
+        self.assertTrue(len(actual_properties) == 0)
+        return
+
+    def test_unique_indices(self):
+        samples = [0, 1, 2, 3, 4, 5, 6, 8]
+        properties = [0, 3, 4, 5]
+        target_samples = Labels(
+            names=["samples"], values=np.array([[s] for s in samples])
+        )
+        target_properties = Labels(
+            names=["properties"], values=np.array([[p] for p in properties])
+        )
+        # Test case 1
+        actual_samples = fn.unique_metadata(self.tensor1, "samples", "samples")
+        actual_properties = fn.unique_metadata(self.tensor1, "properties", "properties")
+        self.assertTrue(
+            fn._utils._labels_equal(target_samples, actual_samples, exact_order=True)
+        )
+        self.assertTrue(
+            fn._utils._labels_equal(
+                target_properties, actual_properties, exact_order=True
+            )
+        )
+        # Test case 2
+        actual_samples = fn.unique_metadata(self.tensor2, "samples", "samples")
+        self.assertTrue(
+            fn._utils._labels_equal(actual_samples, target_samples, exact_order=True)
+        )
+        properties = [0, 1, 2, 3, 4, 5, 6, 7]
+        target_properties = Labels(
+            names=["properties"], values=np.array([[p] for p in properties])
+        )
+        actual_properties = fn.unique_metadata(self.tensor2, "properties", "properties")
+        self.assertTrue(
+            fn._utils._labels_equal(actual_samples, target_samples, exact_order=True)
+        )
+        # Passing names as list
+        actual_properties = fn.unique_metadata(
+            self.tensor2, "properties", ["properties"]
+        )
+        self.assertTrue(
+            fn._utils._labels_equal(actual_samples, target_samples, exact_order=True)
+        )
+        # Passing names as tuple
+        actual_properties = fn.unique_metadata(
+            self.tensor2, "properties", ("properties",)
+        )
+        self.assertTrue(
+            fn._utils._labels_equal(actual_samples, target_samples, exact_order=True)
+        )
+
+        return
+
+    def test_unique_indices_gradients(self):
+        # Samples
+        parameter = "parameter"
+        samples = np.array([[0, -2], [0, 1], [0, 3], [1, -2], [2, -2], [2, 3], [3, 3]])
+        snames = ["sample", "parameter"]
+        target_samples = Labels(names=snames, values=samples)
+        actual_samples = fn.unique_metadata(self.tensor1, "samples", snames, parameter)
+        self.assertTrue(
+            fn._utils._labels_equal(actual_samples, target_samples, exact_order=True)
+        )
+        # Incorrect order samples - [1, -2] and [2, -2] switched around
+        samples = np.array([[0, -2], [0, 1], [0, 3], [2, -2], [1, -2], [2, 3], [3, 3]])
+        target_samples = Labels(names=snames, values=samples)
+        actual_samples = fn.unique_metadata(self.tensor1, "samples", snames, parameter)
+        self.assertFalse(
+            fn._utils._labels_equal(actual_samples, target_samples, exact_order=True)
+        )
+        # Properties
+        properties, pnames = [0, 3, 4, 5], ["properties"]
+        target_properties = Labels(
+            names=pnames, values=np.array([[p] for p in properties])
+        )
+        actual_properties = fn.unique_metadata(
+            self.tensor1, "properties", pnames, parameter
+        )
+        self.assertTrue(
+            fn._utils._labels_equal(
+                target_properties, actual_properties, exact_order=True
+            )
+        )
+        # Incorrect order properties
+        properties, pnames = [0, 4, 3, 5], ["properties"]
+        target_properties = Labels(
+            names=pnames, values=np.array([[p] for p in properties])
+        )
+        actual_properties = fn.unique_metadata(
+            self.tensor1, "properties", pnames, parameter
+        )
+        self.assertFalse(
+            fn._utils._labels_equal(actual_samples, target_samples, exact_order=True)
+        )
+
+        return
+
+
+class TestUniqueMetadataErrors(unittest.TestCase):
+    """
+    Testing the errors raised by :py:func:`unique_metadata` and
+    :py:func:`unique_metadata_block`
+    """
+
+    def setUp(self):
+        self.tensor = equistore.io.load(
+            os.path.join(DATA_ROOT, TEST_FILE),
+            use_numpy=True,
+        )
+        self.block = self.tensor.block(0)
+
+    def test_unique_indices_block(self):
+        # TypeError with TM
+        with self.assertRaises(TypeError) as cm:
+            fn.unique_metadata_block(self.tensor, "samples", ["structure"])
+        self.assertEqual(
+            str(cm.exception),
+            "``block`` must be an equistore TensorBlock",
+        )
+        # TypeError axis as float
+        with self.assertRaises(TypeError) as cm:
+            fn.unique_metadata_block(self.block, 3.14, ["structure"])
+        self.assertEqual(
+            str(cm.exception),
+            "``axis`` must be a str, either 'samples' or 'properties'",
+        )
+        # ValueError axis not "samples" or "properties"
+        with self.assertRaises(ValueError) as cm:
+            fn.unique_metadata_block(self.block, "ciao", ["structure"])
+        self.assertEqual(
+            str(cm.exception),
+            "``axis`` must be passsed as either 'samples' or 'properties'",
+        )
+        # TypeError names as float
+        with self.assertRaises(TypeError) as cm:
+            fn.unique_metadata_block(self.block, "properties", 3.14)
+        self.assertEqual(str(cm.exception), "``names`` must be a list of str")
+        # No error names as str, list of str, or tuple of str
+        fn.unique_metadata_block(self.block, "samples", "structure")
+        fn.unique_metadata_block(self.block, "samples", ["structure"])
+        fn.unique_metadata_block(self.block, "samples", ("structure",))
+        # ValueError names not in block
+        with self.assertRaises(ValueError) as cm:
+            fn.unique_metadata_block(self.block, "properties", ["ciao"])
+        self.assertEqual(
+            str(cm.exception),
+            "the block(s) passed must have samples/properties"
+            + " names that matches the one passed in ``names``",
+        )
+        # TypeError gradient_param as float
+        with self.assertRaises(TypeError) as cm:
+            fn.unique_metadata_block(
+                self.block, "properties", ["structure"], gradient_param=3.14
+            )
+        self.assertEqual(str(cm.exception), "``gradient_param`` must be a str")
+        # ValueError gradient_param not a valid param for gradients
+        with self.assertRaises(TypeError) as cm:
+            fn.unique_metadata_block(
+                self.block, "properties", ["structure"], gradient_param=3.14
+            )
+        self.assertEqual(str(cm.exception), "``gradient_param`` must be a str")
+
+    def test_unique(self):
+        # TypeError with TB
+        with self.assertRaises(TypeError) as cm:
+            fn.unique_metadata(self.block, "samples", ["structure"])
+        self.assertEqual(
+            str(cm.exception),
+            "``tensor`` must be an equistore TensorMap",
+        )
+        # TypeError axis as float
+        with self.assertRaises(TypeError) as cm:
+            fn.unique_metadata(self.tensor, 3.14, ["structure"])
+        self.assertEqual(
+            str(cm.exception),
+            "``axis`` must be a str, either 'samples' or 'properties'",
+        )
+        # ValueError axis not "samples" or "properties"
+        with self.assertRaises(ValueError) as cm:
+            fn.unique_metadata(self.tensor, "ciao", ["structure"])
+        self.assertEqual(
+            str(cm.exception),
+            "``axis`` must be passsed as either 'samples' or 'properties'",
+        )
+        # TypeError names as float
+        with self.assertRaises(TypeError) as cm:
+            fn.unique_metadata(self.tensor, "properties", 3.14)
+        self.assertEqual(str(cm.exception), "``names`` must be a list of str")
+        # No error names as str, list of str, or tuple of str
+        fn.unique_metadata(self.tensor, "properties", "n")
+        fn.unique_metadata(self.tensor, "properties", ["n"])
+        fn.unique_metadata(self.tensor, "properties", ("n",))
+        # ValueError names not in block
+        with self.assertRaises(ValueError) as cm:
+            fn.unique_metadata(self.tensor, "properties", ["ciao"])
+        self.assertEqual(
+            str(cm.exception),
+            "the block(s) passed must have samples/properties"
+            + " names that matches the one passed in ``names``",
+        )
+
+
+def test_tensor_map():
+    """
+    Create a dummy tensor map to be used in tests. This is the same one as the
+    tensor map used in `tensor.rs` tests.
+    """
+    block_1 = TensorBlock(
+        values=np.full((3, 1, 1), 1.0),
+        samples=Labels(["samples"], np.array([[0], [2], [4]], dtype=np.int32)),
+        components=[Labels(["components"], np.array([[0]], dtype=np.int32))],
+        properties=Labels(["properties"], np.array([[0]], dtype=np.int32)),
+    )
+    block_1.add_gradient(
+        "parameter",
+        samples=Labels(
+            ["sample", "parameter"], np.array([[0, -2], [2, 3]], dtype=np.int32)
+        ),
+        data=np.full((2, 1, 1), 11.0),
+        components=[Labels(["components"], np.array([[0]], dtype=np.int32))],
+    )
+
+    block_2 = TensorBlock(
+        values=np.full((3, 1, 3), 2.0),
+        samples=Labels(["samples"], np.array([[0], [1], [3]], dtype=np.int32)),
+        components=[Labels(["components"], np.array([[0]], dtype=np.int32))],
+        properties=Labels(["properties"], np.array([[3], [4], [5]], dtype=np.int32)),
+    )
+    block_2.add_gradient(
+        "parameter",
+        data=np.full((3, 1, 3), 12.0),
+        samples=Labels(
+            ["sample", "parameter"],
+            np.array([[0, -2], [0, 3], [2, -2]], dtype=np.int32),
+        ),
+        components=[Labels(["components"], np.array([[0]], dtype=np.int32))],
+    )
+
+    block_3 = TensorBlock(
+        values=np.full((4, 3, 1), 3.0),
+        samples=Labels(["samples"], np.array([[0], [3], [6], [8]], dtype=np.int32)),
+        components=[Labels(["components"], np.array([[0], [1], [2]], dtype=np.int32))],
+        properties=Labels(["properties"], np.array([[0]], dtype=np.int32)),
+    )
+    block_3.add_gradient(
+        "parameter",
+        data=np.full((1, 3, 1), 13.0),
+        samples=Labels(
+            ["sample", "parameter"],
+            np.array([[1, -2]], dtype=np.int32),
+        ),
+        components=[Labels(["components"], np.array([[0], [1], [2]], dtype=np.int32))],
+    )
+
+    block_4 = TensorBlock(
+        values=np.full((4, 3, 1), 4.0),
+        samples=Labels(["samples"], np.array([[0], [1], [2], [5]], dtype=np.int32)),
+        components=[Labels(["components"], np.array([[0], [1], [2]], dtype=np.int32))],
+        properties=Labels(["properties"], np.array([[0]], dtype=np.int32)),
+    )
+    block_4.add_gradient(
+        "parameter",
+        data=np.full((2, 3, 1), 14.0),
+        samples=Labels(
+            ["sample", "parameter"],
+            np.array([[0, 1], [3, 3]], dtype=np.int32),
+        ),
+        components=[Labels(["components"], np.array([[0], [1], [2]], dtype=np.int32))],
+    )
+
+    # TODO: different number of components?
+
+    keys = Labels(
+        names=["key_1", "key_2"],
+        values=np.array([[0, 0], [1, 0], [2, 2], [2, 3]], dtype=np.int32),
+    )
+
+    return TensorMap(keys, [block_1, block_2, block_3, block_4])
+
+
+def test_large_tensor_map():
+    """
+    Create a dummy tensor map of 16 blocks to be used in tests. This is the same
+    tensor map used in `tensor.rs` tests.
+    """
+    tensor = test_tensor_map()
+    block_list = [block.copy() for _, block in tensor]
+
+    for i in range(8):
+        tmp_bl = TensorBlock(
+            values=np.full((4, 3, 1), 4.0),
+            samples=Labels(["samples"], np.array([[0], [1], [4], [5]], dtype=np.int32)),
+            components=[
+                Labels(["components"], np.array([[0], [1], [2]], dtype=np.int32))
+            ],
+            properties=Labels(["properties"], np.array([[i]], dtype=np.int32)),
+        )
+        tmp_bl.add_gradient(
+            "parameter",
+            data=np.full((2, 3, 1), 14.0),
+            samples=Labels(
+                ["sample", "parameter"],
+                np.array([[0, 1], [3, 3]], dtype=np.int32),
+            ),
+            components=[
+                Labels(
+                    ["components"],
+                    np.array([[0], [1], [2]], dtype=np.int32),
+                )
+            ],
+        )
+        block_list.append(tmp_bl)
+
+    keys = Labels(
+        names=["key_1", "key_2"],
+        values=np.array(
+            [
+                [0, 0],
+                [1, 0],
+                [2, 2],
+                [2, 3],
+                [0, 4],
+                [1, 4],
+                [2, 4],
+                [3, 4],
+                [0, 5],
+                [1, 5],
+                [2, 5],
+                [3, 5],
+            ],
+            dtype=np.int32,
+        ),
+    )
+    return TensorMap(keys, block_list)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/tests/operations/unique_metadata.py
+++ b/python/tests/operations/unique_metadata.py
@@ -472,7 +472,7 @@ class TestUniqueMetadataErrors(unittest.TestCase):
             fn.unique_metadata_block(self.block, "ciao", ["structure"])
         self.assertEqual(
             str(cm.exception),
-            "`axis` must be passsed as either `'samples'` or `'properties'`",
+            "`axis` must be passed as either `'samples'` or `'properties'`",
         )
         # ValueError names not in block
         with self.assertRaises(ValueError) as cm:
@@ -524,7 +524,7 @@ class TestUniqueMetadataErrors(unittest.TestCase):
             fn.unique_metadata(self.tensor, "ciao", ["structure"])
         self.assertEqual(
             str(cm.exception),
-            "`axis` must be passsed as either `'samples'` or `'properties'`",
+            "`axis` must be passed as either `'samples'` or `'properties'`",
         )
         # ValueError names not in block
         with self.assertRaises(ValueError) as cm:


### PR DESCRIPTION
Re-do of PR #117, will close branch 'unique'. This PR introduces the operations ``unique_metadata`` and ``unique_metadata_block`` with a more descriptive name than in PR #117 and while staying inside ``equistore.operations``, with documentation living inside the 'operations/set' sub-class of operations.

**Usage**

To find the unique structure indices of the samples metadata of the blocks of a TensorMap:
```py
from equistore import io
from equistore.operations import unique_metadata

# Load a TensorMap - i.e. SOAP with 10 structures (indices 0 -> 9 inc.)
tensor = io.load("/path/to/tensor.npz")
unique_structures = unique_metadata(tensor, axis="samples", names=["structure"])
unique_structures
>>> Labels([(0,), (1,), (2,), (3,), (4,), (5,), (6,), (7,), (8,), (9,)], dtype=[('structure', '<i4')])
```

For the gradient blocks to find, for instance, the samples named "atom" for the "positions" gradients:

```py
unique_grad_atoms = unique_metadata(tensor, axis="samples", names=["atom"], gradient_param="positions")
unique_grad_atoms
>>> Labels([( 0,), ( 1,), ( 2,), ( 3,), ( 4,), ( 5,), ( 6,), ( 7,), ( 8,), ( 9,), (10,)], dtype=[('atom', '<i4')])
```