### PR TITLE
Feat/label single names

### DIFF
--- a/python/src/equistore/labels.py
+++ b/python/src/equistore/labels.py
@@ -60,23 +60,23 @@ class Labels(np.ndarray):
     def __new__(cls, names: Union[List[str], str], values: np.ndarray, **kwargs):
         """
         :param names: names of the variables in the new labels, in the case of a single
-                      name also a single string can be given: ``names = ["name"]``
-                      is equivalent to ``names = "name"``
+                      name also a single string can be given: ``names = "name"``
         :param values: values of the variables, this needs to be a 2D array of
             ``np.int32`` values
         """
-        if isinstance(names, str):
-            if len(names) == 0:
-                names = []
-            else:
-                names = [names]
         if not isinstance(values, np.ndarray):
             raise ValueError("values parameter must be a numpy ndarray")
 
         if len(values.shape) != 2:
             raise ValueError("values parameter must be a 2D array")
 
-        names = tuple(str(n) for n in names)
+        if isinstance(names, str):
+            if len(names) == 0:
+                names = tuple()
+            else:
+                names = tuple(names)
+        else:
+            names = tuple(str(n) for n in names)
 
         if len(names) != values.shape[1]:
             raise ValueError(

--- a/python/src/equistore/labels.py
+++ b/python/src/equistore/labels.py
@@ -1,6 +1,6 @@
 import ctypes
 from collections import namedtuple
-from typing import List, Optional
+from typing import List, Optional, Union
 
 import numpy as np
 
@@ -57,12 +57,16 @@ class Labels(np.ndarray):
             ...
     """
 
-    def __new__(cls, names: List[str], values: np.ndarray, **kwargs):
+    def __new__(cls, names: Union[List[str], str], values: np.ndarray, **kwargs):
         """
-        :param names: names of the variables in the new labels
+        :param names: names of the variables in the new labels, in the case of a single
+                      name also a single string can be given: ``names = ["name"]``
+                      is equivalent to ``names = "name"``
         :param values: values of the variables, this needs to be a 2D array of
             ``np.int32`` values
         """
+        if isinstance(names, str):
+            names = [names]
         if not isinstance(values, np.ndarray):
             raise ValueError("values parameter must be a numpy ndarray")
 

--- a/python/src/equistore/labels.py
+++ b/python/src/equistore/labels.py
@@ -66,7 +66,10 @@ class Labels(np.ndarray):
             ``np.int32`` values
         """
         if isinstance(names, str):
-            names = [names]
+            if len(names) == 0:
+                names = []
+            else:
+                names = [names]
         if not isinstance(values, np.ndarray):
             raise ValueError("values parameter must be a numpy ndarray")
 

--- a/python/tests/labels.py
+++ b/python/tests/labels.py
@@ -39,6 +39,26 @@ class TestLabels(unittest.TestCase):
         self.assertTrue(np.all(labels.asarray() == np.array([[1]])))
         self.assertTrue(np.all(labels.asarray() == labels_str.asarray()))
 
+        # check empty arrays
+        labels = Labels(
+            names=[],
+            values=np.array([[]], dtype=np.int32),
+        )
+
+        labels_str = Labels(
+            names="",
+            values=np.array([[]], dtype=np.int32),
+        )
+
+        self.assertEqual(labels.names, [])
+        self.assertEqual(labels.names, labels_str.names)
+        self.assertEqual(len(labels), 1)
+        self.assertEqual(len(labels_str), 1)
+        self.assertEqual(tuple(labels_str[0]), tuple(labels[0]))
+
+        self.assertTrue(np.all(labels.asarray() == np.array([[]])))
+        self.assertTrue(np.all(labels.asarray() == labels_str.asarray()))
+
         # check that we can convert from more than strict 2D arrays of int32
         labels = Labels(
             names=["a", "b"],

--- a/python/tests/labels.py
+++ b/python/tests/labels.py
@@ -19,6 +19,26 @@ class TestLabels(unittest.TestCase):
 
         self.assertTrue(np.all(labels.asarray() == np.array([[0, 0]])))
 
+        # check we can use single str for single name
+        labels = Labels(
+            names=["a"],
+            values=np.array([[1]], dtype=np.int32),
+        )
+        labels_str = Labels(
+            names="a",
+            values=np.array([[1]], dtype=np.int32),
+        )
+
+        self.assertEqual(labels.names, ("a",))
+        self.assertEqual(labels.names, labels_str.names)
+        self.assertEqual(len(labels), 1)
+        self.assertEqual(len(labels_str), 1)
+        self.assertEqual(tuple(labels_str[0]), (1,))
+        self.assertEqual(tuple(labels_str[0]), tuple(labels[0]))
+
+        self.assertTrue(np.all(labels.asarray() == np.array([[1]])))
+        self.assertTrue(np.all(labels.asarray() == labels_str.asarray()))
+
         # check that we can convert from more than strict 2D arrays of int32
         labels = Labels(
             names=["a", "b"],


### PR DESCRIPTION
simple fix for #110 

Now:
```
Labels(names="species", values=np.array([[1]]))
```

is equivalent to:

```
Labels(names=["species"], values=np.array([[1]]))
```

also:
```
Labels(names="", values=np.array([[]]))
```
is equivalent to:
```
Labels(names=[], values=np.array([[]]))
```