### PR TITLE
Bump minimal rustc version to 1.61

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,7 @@ jobs:
 
           # MSRV (Minimally Supported Rust Version)
           - os: ubuntu-20.04
-            rust-version: 1.59
+            rust-version: 1.61
             rust-target: x86_64-unknown-linux-gnu
             build-type: debug
             cargo-build-flags: --all-features

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -56,7 +56,7 @@ on equistore:
 - **the rust compiler**: you will need both ``rustc`` (the compiler) and
   ``cargo`` (associated build tool). You can install both using `rustup`_, or
   use a version provided by your operating system. We need at least Rust version
-  1.59 to build equistore.
+  1.61 to build equistore.
 - **Python**: you can install ``Python`` and ``pip`` from your operating system.
   We require a Python version of at least 3.6.
 - **tox**: a Python test runner, cf https://tox.readthedocs.io/en/latest/. You

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "equistore"
 version = "0.0.0"
 edition = "2021"
+rust-version = "1.61"
 
 [lib]
 # when https://github.com/rust-lang/cargo/pull/8789 lands, use it here!


### PR DESCRIPTION
Bumps the version of rustc to 1.61. Now, we have a consistent 1.61 version everywhere: in the tests, the rtd script and also in the Cargo.toml.