### PR TITLE
Move equistore.operations into toplevel import

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,10 +4,14 @@ Equistore
 |test| |docs|
 
 Equistore is a specialized data storage format suited to all your atomistic
-machine learning needs and more (think ``numpy`` or ``torch.Tensor``, but also
-carrying extra metadata for atomistic systems).
+machine learning needs and more. Think of an NumPy "ndarray" or a pytorch "Tensor"
+carrying extra metadata for atomistic systems.
 
-The core of the library is written in Rust and we provide APIs for C/C++ and
+The core functionality of equistore is its "TensorMap" data structure.
+Along with the format equistore also provides a collection of mathematical, logical
+as well as utility operations to make the work with TensorMaps convenient.
+
+A main part of the library is written in Rust and we provide APIs for C/C++ and
 Python as well.
 
 For details, tutorials, and examples, please have a look at our `documentation`_.

--- a/docs/src/reference/python/data.rst
+++ b/docs/src/reference/python/data.rst
@@ -1,3 +1,5 @@
+.. _python-api-array:
+
 Data arrays
 ===========
 

--- a/docs/src/reference/python/index.rst
+++ b/docs/src/reference/python/index.rst
@@ -3,10 +3,8 @@
 Python API reference
 ====================
 
-Most users will find the Python interface to ``equistore`` to be the most
-convenient to use. This interface is built on top of the C API, and can be
-:ref:`installed independently <install-python-lib>`. The functions and classes
-provided in ``equistore`` can be grouped in four main groups:
+.. automodule:: equistore
+    :undoc-members:
 
 .. toctree::
     :maxdepth: 1
@@ -14,6 +12,6 @@ provided in ``equistore`` can be grouped in four main groups:
     tensor
     labels
     block
-    data
     operations/index
+    data
     misc/index

--- a/docs/src/reference/python/misc/io.rst
+++ b/docs/src/reference/python/misc/io.rst
@@ -1,3 +1,5 @@
+.. _python-api-io:
+
 IO
 ==
 

--- a/docs/src/reference/python/operations/creation/empty_like.rst
+++ b/docs/src/reference/python/operations/creation/empty_like.rst
@@ -1,6 +1,6 @@
 empty_like
 ==========
 
-.. autofunction:: equistore.operations.empty_like
+.. autofunction:: equistore.empty_like
 
-.. autofunction:: equistore.operations.empty_like_block
+.. autofunction:: equistore.empty_like_block

--- a/docs/src/reference/python/operations/creation/ones_like.rst
+++ b/docs/src/reference/python/operations/creation/ones_like.rst
@@ -1,6 +1,6 @@
 ones_like
 =========
 
-.. autofunction:: equistore.operations.ones_like
+.. autofunction:: equistore.ones_like
 
-.. autofunction:: equistore.operations.ones_like_block
+.. autofunction:: equistore.ones_like_block

--- a/docs/src/reference/python/operations/creation/zeros_like.rst
+++ b/docs/src/reference/python/operations/creation/zeros_like.rst
@@ -1,6 +1,6 @@
 zeros_like
 ============
 
-.. autofunction:: equistore.operations.zeros_like
+.. autofunction:: equistore.zeros_like
 
-.. autofunction:: equistore.operations.zeros_like_block
+.. autofunction:: equistore.zeros_like_block

--- a/docs/src/reference/python/operations/index.rst
+++ b/docs/src/reference/python/operations/index.rst
@@ -1,12 +1,10 @@
+.. _python-api-operations:
+
 Operations
 ==========
 
 .. automodule:: equistore.operations
     :undoc-members:
-
-
-.. the two groups in the toc tree below correspond to numpy-style operations,
-.. and equistore-specific operations
 
 .. toctree::
     :maxdepth: 2

--- a/docs/src/reference/python/operations/linear_algebra/dot.rst
+++ b/docs/src/reference/python/operations/linear_algebra/dot.rst
@@ -1,4 +1,4 @@
 dot
 ===
 
-.. autofunction:: equistore.operations.dot
+.. autofunction:: equistore.dot

--- a/docs/src/reference/python/operations/linear_algebra/lstsq.rst
+++ b/docs/src/reference/python/operations/linear_algebra/lstsq.rst
@@ -1,4 +1,4 @@
 lstsq
 ======
 
-.. autofunction:: equistore.operations.lstsq
+.. autofunction:: equistore.lstsq

--- a/docs/src/reference/python/operations/linear_algebra/solve.rst
+++ b/docs/src/reference/python/operations/linear_algebra/solve.rst
@@ -1,5 +1,5 @@
 solve
 =====
 
-.. autoclass:: equistore.operations.solve
+.. autoclass:: equistore.solve
     :members:

--- a/docs/src/reference/python/operations/logic/allclose.rst
+++ b/docs/src/reference/python/operations/logic/allclose.rst
@@ -1,10 +1,10 @@
 allclose
 ========
 
-.. autofunction:: equistore.operations.allclose
+.. autofunction:: equistore.allclose
 
-.. autofunction:: equistore.operations.allclose_raise
+.. autofunction:: equistore.allclose_raise
 
-.. autofunction:: equistore.operations.allclose_block
+.. autofunction:: equistore.allclose_block
 
-.. autofunction:: equistore.operations.allclose_block_raise
+.. autofunction:: equistore.allclose_block_raise

--- a/docs/src/reference/python/operations/logic/equal.rst
+++ b/docs/src/reference/python/operations/logic/equal.rst
@@ -1,10 +1,10 @@
 equal
 =====
 
-.. autofunction:: equistore.operations.equal
+.. autofunction:: equistore.equal
 
-.. autofunction:: equistore.operations.equal_raise
+.. autofunction:: equistore.equal_raise
 
-.. autofunction:: equistore.operations.equal_block
+.. autofunction:: equistore.equal_block
 
-.. autofunction:: equistore.operations.equal_block_raise
+.. autofunction:: equistore.equal_block_raise

--- a/docs/src/reference/python/operations/manipulation/join.rst
+++ b/docs/src/reference/python/operations/manipulation/join.rst
@@ -1,4 +1,4 @@
 join
 ====
 
-.. autofunction:: equistore.operations.join
+.. autofunction:: equistore.join

--- a/docs/src/reference/python/operations/manipulation/remove-gradients.rst
+++ b/docs/src/reference/python/operations/manipulation/remove-gradients.rst
@@ -1,4 +1,4 @@
 remove_gradients
 ================
 
-.. autofunction:: equistore.operations.remove_gradients
+.. autofunction:: equistore.remove_gradients

--- a/docs/src/reference/python/operations/manipulation/samples-reduction.rst
+++ b/docs/src/reference/python/operations/manipulation/samples-reduction.rst
@@ -1,10 +1,10 @@
 Reduction over samples
 ======================
 
-.. autofunction:: equistore.operations.sum_over_samples
+.. autofunction:: equistore.sum_over_samples
 
-.. autofunction:: equistore.operations.mean_over_samples
+.. autofunction:: equistore.mean_over_samples
 
-.. autofunction:: equistore.operations.variance_over_samples
+.. autofunction:: equistore.variance_over_samples
 
-.. autofunction:: equistore.operations.std_over_samples
+.. autofunction:: equistore.std_over_samples

--- a/docs/src/reference/python/operations/manipulation/slice.rst
+++ b/docs/src/reference/python/operations/manipulation/slice.rst
@@ -1,6 +1,6 @@
 slice
 ======
 
-.. autofunction:: equistore.operations.slice
+.. autofunction:: equistore.slice
     
-.. autofunction:: equistore.operations.slice_block
+.. autofunction:: equistore.slice_block

--- a/docs/src/reference/python/operations/manipulation/split.rst
+++ b/docs/src/reference/python/operations/manipulation/split.rst
@@ -1,6 +1,6 @@
 split
 ======
 
-.. autofunction:: equistore.operations.split
+.. autofunction:: equistore.split
     
-.. autofunction:: equistore.operations.split_block
+.. autofunction:: equistore.split_block

--- a/docs/src/reference/python/operations/math/add.rst
+++ b/docs/src/reference/python/operations/math/add.rst
@@ -1,4 +1,4 @@
 add
 ===
 
-.. autofunction:: equistore.operations.add
+.. autofunction:: equistore.add

--- a/docs/src/reference/python/operations/math/divide.rst
+++ b/docs/src/reference/python/operations/math/divide.rst
@@ -1,4 +1,4 @@
 divide
 ======
 
-.. autofunction:: equistore.operations.divide
+.. autofunction:: equistore.divide

--- a/docs/src/reference/python/operations/math/multiply.rst
+++ b/docs/src/reference/python/operations/math/multiply.rst
@@ -1,4 +1,4 @@
 multiply
 ========
 
-.. autofunction:: equistore.operations.multiply
+.. autofunction:: equistore.multiply

--- a/docs/src/reference/python/operations/math/pow.rst
+++ b/docs/src/reference/python/operations/math/pow.rst
@@ -1,4 +1,4 @@
 pow
 ===
 
-.. autofunction:: equistore.operations.pow
+.. autofunction:: equistore.pow

--- a/docs/src/reference/python/operations/math/subtract.rst
+++ b/docs/src/reference/python/operations/math/subtract.rst
@@ -1,4 +1,4 @@
 subtract
 ========
 
-.. autofunction:: equistore.operations.subtract
+.. autofunction:: equistore.subtract

--- a/docs/src/reference/python/operations/set/unique_metadata.rst
+++ b/docs/src/reference/python/operations/set/unique_metadata.rst
@@ -1,6 +1,6 @@
 unique_metadata
 ===============
 
-.. autofunction:: equistore.operations.unique_metadata
+.. autofunction:: equistore.unique_metadata
     
-.. autofunction:: equistore.operations.unique_metadata_block
+.. autofunction:: equistore.unique_metadata_block

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,9 +7,10 @@ requires = [
 build-backend = "setuptools.build_meta"
 
 [tool.isort]
- profile = "black"
- line_length = 88
- indent = 4
- include_trailing_comma = true
- lines_after_imports = 2
- known_first_party = "equistore"
+skip = "__init__.py"
+profile = "black"
+line_length = 88
+indent = 4
+include_trailing_comma = true
+lines_after_imports = 2
+known_first_party = "equistore"

--- a/python/src/equistore/__init__.py
+++ b/python/src/equistore/__init__.py
@@ -1,5 +1,27 @@
+"""
+Most users will find the Python interface to ``equistore`` to be the most
+convenient to use. This interface is built on top of the C API, and can be
+:ref:`installed independently <install-python-lib>`. The functions and classes
+provided in ``equistore`` can be grouped into the following:
+
+First the three core objects :py:class:`equistore.TensorMap`,
+:py:class:`equistore.TensorBlock`, :py:class:`equistore.Labels` of equistore.
+
+:ref:`Operations <python-api-operations>` include mathematical, logical as well as
+utility operations that can applied on the three core objects.
+
+The API also includes more advanced functionalities like
+:ref:`IO operations<python-api-io>` or the
+:ref:`actual array format <python-api-array>` for storing data.
+"""
+
 from ._c_lib import _set_equistore_library_path  # noqa
 from .block import TensorBlock  # noqa
 from .labels import Labels  # noqa
 from .status import EquistoreError  # noqa
 from .tensor import TensorMap  # noqa
+
+from .operations import *  # noqa
+
+
+__all__ = ["TensorBlock", "Labels", "TensorMap"]

--- a/python/src/equistore/operations/__init__.py
+++ b/python/src/equistore/operations/__init__.py
@@ -1,6 +1,7 @@
 """
 The Python API for equistore also provides functions which operate on
-:py:class:`equistore.TensorMap`, and can be used to build Machine Learning
+:py:class:`equistore.TensorMap`, :py:class:`equistore.TensorBlocks` as well as
+:py:class:`equistore.Labels` and can be used to build Machine Learning
 models.
 
 These functions can handle data stored either in numpy arrays or Torch tensor,
@@ -46,6 +47,7 @@ __all__ = [
     "divide",
     "dot",
     "empty_like",
+    "empty_like_block",
     "equal",
     "equal_raise",
     "equal_block",
@@ -54,6 +56,7 @@ __all__ = [
     "lstsq",
     "mean_over_samples",
     "ones_like",
+    "ones_like_block",
     "multiply",
     "pow",
     "remove_gradients",
@@ -69,4 +72,5 @@ __all__ = [
     "unique_metadata_block",
     "variance_over_samples",
     "zeros_like",
+    "zeros_like_block",
 ]

--- a/python/tests/operations/add.py
+++ b/python/tests/operations/add.py
@@ -3,7 +3,7 @@ import unittest
 
 import numpy as np
 
-import equistore.operations as fn
+import equistore
 from equistore import Labels, TensorBlock, TensorMap
 
 
@@ -54,10 +54,10 @@ class TestAdd(unittest.TestCase):
         )
         A = TensorMap(keys, [block_1, block_2])
         B = TensorMap(keys, [block_3, block_4])
-        tensor_sum = fn.add(A, B)
+        tensor_sum = equistore.add(A, B)
         tensor_result = TensorMap(keys, [block_res1, block_res2])
 
-        self.assertTrue(fn.allclose(tensor_result, tensor_sum))
+        self.assertTrue(equistore.allclose(tensor_result, tensor_sum))
 
     def test_self_add_tensors_gradient(self):
         block_1 = TensorBlock(
@@ -181,10 +181,10 @@ class TestAdd(unittest.TestCase):
         )
         A = TensorMap(keys, [block_1, block_2])
         B = TensorMap(keys, [block_3, block_4])
-        tensor_sum = fn.add(A, B)
+        tensor_sum = equistore.add(A, B)
         tensor_result = TensorMap(keys, [block_res1, block_res2])
 
-        self.assertTrue(fn.allclose(tensor_result, tensor_sum))
+        self.assertTrue(equistore.allclose(tensor_result, tensor_sum))
 
     def test_self_add_scalar_gradient(self):
         block_1 = TensorBlock(
@@ -266,12 +266,12 @@ class TestAdd(unittest.TestCase):
         B = 5.1
         C = np.array([5.1])
 
-        tensor_sum = fn.add(A, B)
-        tensor_sum_array = fn.add(A, C)
+        tensor_sum = equistore.add(A, B)
+        tensor_sum_array = equistore.add(A, C)
         tensor_result = TensorMap(keys, [block_res1, block_res2])
 
-        self.assertTrue(fn.allclose(tensor_result, tensor_sum))
-        self.assertTrue(fn.allclose(tensor_result, tensor_sum_array))
+        self.assertTrue(equistore.allclose(tensor_result, tensor_sum))
+        self.assertTrue(equistore.allclose(tensor_result, tensor_sum_array))
 
     def test_self_add_error(self):
         block_1 = TensorBlock(
@@ -287,7 +287,7 @@ class TestAdd(unittest.TestCase):
         B = np.ones((3, 4))
 
         with self.assertRaises(TypeError) as cm:
-            keys = fn.add(A, B)
+            keys = equistore.add(A, B)
         self.assertEqual(
             str(cm.exception),
             "B should be a TensorMap or a scalar value. ",

--- a/python/tests/operations/allclose.py
+++ b/python/tests/operations/allclose.py
@@ -4,7 +4,6 @@ import unittest
 import numpy as np
 
 import equistore.io
-import equistore.operations as fn
 from equistore import Labels, TensorBlock, TensorMap
 
 
@@ -45,11 +44,11 @@ class Testallclose(unittest.TestCase):
             names=["key_1", "key_2"], values=np.array([[0, 0], [1, 0]], dtype=np.int32)
         )
         X = TensorMap(keys, [block_1, block_2])
-        self.assertTrue(fn.allclose(X, X))
+        self.assertTrue(equistore.allclose(X, X))
         Y = TensorMap(keys, [block_3, block_4])
-        self.assertFalse(fn.allclose(X, Y))
+        self.assertFalse(equistore.allclose(X, Y))
         with self.assertRaises(ValueError) as cm:
-            fn.allclose_raise(X, Y)
+            equistore.allclose_raise(X, Y)
 
         self.assertEqual(
             str(cm.exception), "The TensorBlocks with key = (0, 0) are different"
@@ -122,12 +121,12 @@ class Testallclose(unittest.TestCase):
         )
         X_c = TensorMap(keys, [block_1_c, block_2_c])
         X_c_copy = TensorMap(keys, [block_1_c_copy, block_2_c_copy])
-        self.assertFalse(fn.allclose(X, X_c))
+        self.assertFalse(equistore.allclose(X, X_c))
 
-        self.assertTrue(fn.allclose(X_c, X_c))
-        self.assertFalse(fn.allclose(X_c, X_c_copy))
-        self.assertTrue(fn.allclose(X_c, X_c_copy, rtol=1e-5))
-        self.assertTrue(fn.allclose(X_c, X_c_copy, atol=1e-1))
+        self.assertTrue(equistore.allclose(X_c, X_c))
+        self.assertFalse(equistore.allclose(X_c, X_c_copy))
+        self.assertTrue(equistore.allclose(X_c, X_c_copy, rtol=1e-5))
+        self.assertTrue(equistore.allclose(X_c, X_c_copy, atol=1e-1))
 
     def test_self_allclose_grad(self):
         tensor1 = equistore.io.load(
@@ -144,19 +143,19 @@ class Testallclose(unittest.TestCase):
 
         tensor1_copy = TensorMap(tensor1.keys, blocks)
         tensor1_e6 = TensorMap(tensor1.keys, blocks_e6)
-        self.assertTrue(fn.allclose(tensor1, tensor1_copy))
-        self.assertFalse(fn.allclose(tensor1, tensor1_e6))
-        self.assertTrue(fn.allclose(tensor1, tensor1_e6, rtol=1e-5, atol=1e-5))
+        self.assertTrue(equistore.allclose(tensor1, tensor1_copy))
+        self.assertFalse(equistore.allclose(tensor1, tensor1_e6))
+        self.assertTrue(equistore.allclose(tensor1, tensor1_e6, rtol=1e-5, atol=1e-5))
 
         with self.assertRaises(ValueError) as cm:
-            fn.allclose_raise(tensor1, tensor1_e6)
+            equistore.allclose_raise(tensor1, tensor1_e6)
 
         self.assertEqual(
             str(cm.exception), "The TensorBlocks with key = (0, 1, 1) are different"
         )
 
         with self.assertRaises(ValueError) as cm:
-            fn.allclose_block_raise(tensor1.block(0), tensor1_e6.block(0))
+            equistore.allclose_block_raise(tensor1.block(0), tensor1_e6.block(0))
         self.assertEqual(str(cm.exception), "values are not allclose")
 
     def test_self_allclose_exceptions(self):
@@ -205,10 +204,10 @@ class Testallclose(unittest.TestCase):
             properties=Labels(["properties"], np.array([[0]], dtype=np.int32)),
         )
 
-        self.assertFalse(fn.allclose_block(block_1, block_2))
+        self.assertFalse(equistore.allclose_block(block_1, block_2))
 
         with self.assertRaises(ValueError) as cm:
-            fn.allclose_block_raise(block_1, block_2)
+            equistore.allclose_block_raise(block_1, block_2)
 
         self.assertEqual(
             str(cm.exception),
@@ -217,7 +216,7 @@ class Testallclose(unittest.TestCase):
         )
 
         with self.assertRaises(ValueError) as cm:
-            fn.allclose_block_raise(block_1, block_3)
+            equistore.allclose_block_raise(block_1, block_3)
 
         self.assertEqual(
             str(cm.exception),
@@ -226,12 +225,12 @@ class Testallclose(unittest.TestCase):
         )
 
         with self.assertRaises(ValueError) as cm:
-            fn.allclose_block_raise(block_1, block_4)
+            equistore.allclose_block_raise(block_1, block_4)
 
         self.assertEqual(str(cm.exception), "values shapes are different")
 
         with self.assertRaises(ValueError) as cm:
-            fn.allclose_block_raise(block_5, block_4)
+            equistore.allclose_block_raise(block_5, block_4)
 
         self.assertEqual(
             str(cm.exception),
@@ -240,7 +239,7 @@ class Testallclose(unittest.TestCase):
         )
 
         with self.assertRaises(ValueError) as cm:
-            fn.allclose_block_raise(block_6, block_4)
+            equistore.allclose_block_raise(block_6, block_4)
 
         self.assertEqual(
             str(cm.exception),
@@ -282,7 +281,7 @@ class Testallclose(unittest.TestCase):
         )
 
         with self.assertRaises(ValueError) as cm:
-            fn.allclose_block_raise(block_1, block_2)
+            equistore.allclose_block_raise(block_1, block_2)
 
         self.assertEqual(
             str(cm.exception),
@@ -308,7 +307,7 @@ class Testallclose(unittest.TestCase):
         )
 
         with self.assertRaises(ValueError) as cm:
-            fn.allclose_block_raise(block_1, block_3)
+            equistore.allclose_block_raise(block_1, block_3)
 
         self.assertEqual(
             str(cm.exception),
@@ -352,7 +351,7 @@ class Testallclose(unittest.TestCase):
         )
 
         with self.assertRaises(ValueError) as cm:
-            fn.allclose_block_raise(block_5, block_4)
+            equistore.allclose_block_raise(block_5, block_4)
 
         self.assertEqual(
             str(cm.exception),

--- a/python/tests/operations/divide.py
+++ b/python/tests/operations/divide.py
@@ -3,7 +3,7 @@ import unittest
 
 import numpy as np
 
-import equistore.operations as fn
+import equistore
 from equistore import Labels, TensorBlock, TensorMap
 
 
@@ -54,10 +54,10 @@ class TestDivide(unittest.TestCase):
         )
         A = TensorMap(keys, [block_1, block_2])
         B = TensorMap(keys, [block_3, block_4])
-        tensor_sum = fn.divide(A, B)
+        tensor_sum = equistore.divide(A, B)
         tensor_result = TensorMap(keys, [block_res1, block_res2])
 
-        self.assertTrue(fn.allclose(tensor_result, tensor_sum))
+        self.assertTrue(equistore.allclose(tensor_result, tensor_sum))
 
     def test_self_divide_tensors_gradient(self):
         block_1 = TensorBlock(
@@ -195,10 +195,10 @@ class TestDivide(unittest.TestCase):
         )
         A = TensorMap(keys, [block_1, block_2])
         B = TensorMap(keys, [block_3, block_4])
-        tensor_sum = fn.divide(A, B)
+        tensor_sum = equistore.divide(A, B)
         tensor_result = TensorMap(keys, [block_res1, block_res2])
         self.assertTrue(
-            fn.allclose(
+            equistore.allclose(
                 tensor_result,
                 tensor_sum,
                 atol=1e-8,
@@ -300,12 +300,12 @@ class TestDivide(unittest.TestCase):
         B = 5.1
         C = np.array([5.1])
 
-        tensor_sum = fn.divide(A, B)
-        tensor_sum_array = fn.divide(A, C)
+        tensor_sum = equistore.divide(A, B)
+        tensor_sum_array = equistore.divide(A, C)
         tensor_result = TensorMap(keys, [block_res1, block_res2])
 
-        self.assertTrue(fn.allclose(tensor_result, tensor_sum, rtol=1e-8))
-        self.assertTrue(fn.allclose(tensor_result, tensor_sum_array, rtol=1e-8))
+        self.assertTrue(equistore.allclose(tensor_result, tensor_sum, rtol=1e-8))
+        self.assertTrue(equistore.allclose(tensor_result, tensor_sum_array, rtol=1e-8))
 
     def test_self_divide_error(self):
         block_1 = TensorBlock(
@@ -321,7 +321,7 @@ class TestDivide(unittest.TestCase):
         B = np.ones((3, 4))
 
         with self.assertRaises(TypeError) as cm:
-            keys = fn.divide(A, B)
+            keys = equistore.divide(A, B)
         self.assertEqual(
             str(cm.exception),
             "B should be a TensorMap or a scalar value. ",

--- a/python/tests/operations/dot.py
+++ b/python/tests/operations/dot.py
@@ -3,8 +3,8 @@ import unittest
 
 import numpy as np
 
+import equistore
 import equistore.io
-import equistore.operations as fn
 from equistore import Labels, TensorBlock, TensorMap
 
 
@@ -18,9 +18,9 @@ class TestDot(unittest.TestCase):
             # the npz is using DEFLATE compression, equistore only supports STORED
             use_numpy=True,
         )
-        tensor2 = fn.remove_gradients(tensor1)
+        tensor2 = equistore.remove_gradients(tensor1)
 
-        dot_tensor = fn.dot(A=tensor1, B=tensor2)
+        dot_tensor = equistore.dot(A=tensor1, B=tensor2)
         self.assertTrue(np.all(tensor1.keys == dot_tensor.keys))
 
         for key, block1 in tensor1:
@@ -80,7 +80,7 @@ class TestDot(unittest.TestCase):
 
         tensor2 = TensorMap(tensor1.keys, tensor2)
 
-        dot_tensor = fn.dot(A=tensor1, B=tensor2)
+        dot_tensor = equistore.dot(A=tensor1, B=tensor2)
         self.assertTrue(np.all(tensor1.keys == dot_tensor.keys))
 
         for key, block1 in tensor1:

--- a/python/tests/operations/empty_like.py
+++ b/python/tests/operations/empty_like.py
@@ -3,8 +3,8 @@ import unittest
 
 import numpy as np
 
+import equistore
 import equistore.io
-import equistore.operations as fn
 
 
 DATA_ROOT = os.path.join(os.path.dirname(__file__), "..", "data")
@@ -17,7 +17,7 @@ class TestEmpty_like(unittest.TestCase):
             # the npz is using DEFLATE compression, equistore only supports STORED
             use_numpy=True,
         )
-        empty_tensor = fn.empty_like(tensor)
+        empty_tensor = equistore.empty_like(tensor)
 
         self.assertTrue(np.all(tensor.keys == empty_tensor.keys))
         for key, empty_block in empty_tensor:
@@ -63,8 +63,8 @@ class TestEmpty_like(unittest.TestCase):
             # the npz is using DEFLATE compression, equistore only supports STORED
             use_numpy=True,
         )
-        empty_tensor = fn.empty_like(tensor)
-        empty_tensor_positions = fn.empty_like(tensor, parameters="positions")
+        empty_tensor = equistore.empty_like(tensor)
+        empty_tensor_positions = equistore.empty_like(tensor, parameters="positions")
 
         self.assertTrue(np.all(tensor.keys == empty_tensor.keys))
         self.assertTrue(np.all(tensor.keys == empty_tensor_positions.keys))
@@ -131,7 +131,7 @@ class TestEmpty_like(unittest.TestCase):
         )
 
         with self.assertRaises(ValueError) as cm:
-            tensor = fn.empty_like(tensor, parameters=["positions", "err"])
+            tensor = equistore.empty_like(tensor, parameters=["positions", "err"])
         self.assertEqual(
             str(cm.exception),
             "The requested parameter 'err' in empty_like_block "

--- a/python/tests/operations/equal.py
+++ b/python/tests/operations/equal.py
@@ -3,8 +3,8 @@ import unittest
 
 import numpy as np
 
+import equistore
 import equistore.io
-import equistore.operations as fn
 from equistore import Labels, TensorBlock, TensorMap
 
 
@@ -45,11 +45,11 @@ class TestEqual(unittest.TestCase):
             names=["key_1", "key_2"], values=np.array([[0, 0], [1, 0]], dtype=np.int32)
         )
         X = TensorMap(keys, [block_1, block_2])
-        self.assertTrue(fn.equal(X, X))
+        self.assertTrue(equistore.equal(X, X))
         Y = TensorMap(keys, [block_3, block_4])
-        self.assertFalse(fn.equal(X, Y))
+        self.assertFalse(equistore.equal(X, Y))
         with self.assertRaises(ValueError) as cm:
-            fn.equal_raise(X, Y)
+            equistore.equal_raise(X, Y)
 
         self.assertEqual(
             str(cm.exception), "The TensorBlocks with key = (0, 0) are different"
@@ -122,10 +122,10 @@ class TestEqual(unittest.TestCase):
         )
         X_c = TensorMap(keys, [block_1_c, block_2_c])
         X_c_copy = TensorMap(keys, [block_1_c_copy, block_2_c_copy])
-        self.assertFalse(fn.equal(X, X_c))
+        self.assertFalse(equistore.equal(X, X_c))
 
-        self.assertTrue(fn.equal(X_c, X_c))
-        self.assertFalse(fn.equal(X_c, X_c_copy))
+        self.assertTrue(equistore.equal(X_c, X_c))
+        self.assertFalse(equistore.equal(X_c, X_c_copy))
 
     def test_self_equal_grad(self):
         tensor1 = equistore.io.load(
@@ -142,19 +142,19 @@ class TestEqual(unittest.TestCase):
 
         tensor1_copy = TensorMap(tensor1.keys, blocks)
         tensor1_e6 = TensorMap(tensor1.keys, blocks_e6)
-        self.assertTrue(fn.equal(tensor1, tensor1_copy))
-        self.assertFalse(fn.equal(tensor1, tensor1_e6))
-        self.assertTrue(fn.equal(tensor1, tensor1_e6, only_metadata=True))
+        self.assertTrue(equistore.equal(tensor1, tensor1_copy))
+        self.assertFalse(equistore.equal(tensor1, tensor1_e6))
+        self.assertTrue(equistore.equal(tensor1, tensor1_e6, only_metadata=True))
 
         with self.assertRaises(ValueError) as cm:
-            fn.equal_raise(tensor1, tensor1_e6)
+            equistore.equal_raise(tensor1, tensor1_e6)
 
         self.assertEqual(
             str(cm.exception), "The TensorBlocks with key = (0, 1, 1) are different"
         )
 
         with self.assertRaises(ValueError) as cm:
-            fn.equal_block_raise(tensor1.block(0), tensor1_e6.block(0))
+            equistore.equal_block_raise(tensor1.block(0), tensor1_e6.block(0))
         self.assertEqual(str(cm.exception), "values are not equal")
 
     def test_self_equal_exceptions(self):
@@ -203,11 +203,11 @@ class TestEqual(unittest.TestCase):
             properties=Labels(["properties"], np.array([[0]], dtype=np.int32)),
         )
 
-        self.assertFalse(fn.equal_block(block_1, block_2))
-        self.assertFalse(fn.equal_block(block_1, block_2, only_metadata=True))
+        self.assertFalse(equistore.equal_block(block_1, block_2))
+        self.assertFalse(equistore.equal_block(block_1, block_2, only_metadata=True))
 
         with self.assertRaises(ValueError) as cm:
-            fn.equal_block_raise(block_1, block_2)
+            equistore.equal_block_raise(block_1, block_2)
 
         self.assertEqual(
             str(cm.exception),
@@ -216,7 +216,7 @@ class TestEqual(unittest.TestCase):
         )
 
         with self.assertRaises(ValueError) as cm:
-            fn.equal_block_raise(block_1, block_3)
+            equistore.equal_block_raise(block_1, block_3)
 
         self.assertEqual(
             str(cm.exception),
@@ -225,12 +225,12 @@ class TestEqual(unittest.TestCase):
         )
 
         with self.assertRaises(ValueError) as cm:
-            fn.equal_block_raise(block_1, block_4)
+            equistore.equal_block_raise(block_1, block_4)
 
         self.assertEqual(str(cm.exception), "values shapes are different")
 
         with self.assertRaises(ValueError) as cm:
-            fn.equal_block_raise(block_5, block_4)
+            equistore.equal_block_raise(block_5, block_4)
 
         self.assertEqual(
             str(cm.exception),
@@ -239,7 +239,7 @@ class TestEqual(unittest.TestCase):
         )
 
         with self.assertRaises(ValueError) as cm:
-            fn.equal_block_raise(block_6, block_4)
+            equistore.equal_block_raise(block_6, block_4)
 
         self.assertEqual(
             str(cm.exception),
@@ -275,14 +275,14 @@ class TestEqual(unittest.TestCase):
             properties=Labels(["properties"], np.array([[0]], dtype=np.int32)),
         )
 
-        self.assertFalse(fn.equal_block(block_7, block_8))
-        self.assertFalse(fn.equal_block(block_7, block_8, only_metadata=True))
+        self.assertFalse(equistore.equal_block(block_7, block_8))
+        self.assertFalse(equistore.equal_block(block_7, block_8, only_metadata=True))
 
-        self.assertFalse(fn.equal_block(block_8, block_9))
-        self.assertTrue(fn.equal_block(block_8, block_9, only_metadata=True))
+        self.assertFalse(equistore.equal_block(block_8, block_9))
+        self.assertTrue(equistore.equal_block(block_8, block_9, only_metadata=True))
 
         with self.assertRaises(ValueError) as cm:
-            fn.equal_block_raise(block_7, block_8)
+            equistore.equal_block_raise(block_7, block_8)
 
         self.assertEqual(
             str(cm.exception),
@@ -291,7 +291,7 @@ class TestEqual(unittest.TestCase):
         )
 
         with self.assertRaises(ValueError) as cm:
-            fn.equal_block_raise(block_8, block_9)
+            equistore.equal_block_raise(block_8, block_9)
 
         self.assertEqual(
             str(cm.exception),
@@ -332,7 +332,7 @@ class TestEqual(unittest.TestCase):
         )
 
         with self.assertRaises(ValueError) as cm:
-            fn.equal_block_raise(block_1, block_2)
+            equistore.equal_block_raise(block_1, block_2)
 
         self.assertEqual(
             str(cm.exception),
@@ -358,7 +358,7 @@ class TestEqual(unittest.TestCase):
         )
 
         with self.assertRaises(ValueError) as cm:
-            fn.equal_block_raise(block_1, block_3)
+            equistore.equal_block_raise(block_1, block_3)
 
         self.assertEqual(
             str(cm.exception),
@@ -402,7 +402,7 @@ class TestEqual(unittest.TestCase):
         )
 
         with self.assertRaises(ValueError) as cm:
-            fn.equal_block_raise(block_5, block_4)
+            equistore.equal_block_raise(block_5, block_4)
 
         self.assertEqual(
             str(cm.exception),
@@ -429,7 +429,7 @@ class TestEqual(unittest.TestCase):
             ],
         )
         with self.assertRaises(ValueError) as cm:
-            fn.equal_block_raise(block_5, block_6)
+            equistore.equal_block_raise(block_5, block_6)
 
         self.assertEqual(
             str(cm.exception),
@@ -455,11 +455,11 @@ class TestEqual(unittest.TestCase):
                 Labels(["component_1"], np.array([[-1], [6], [1]], dtype=np.int32))
             ],
         )
-        self.assertFalse(fn.equal_block(block_6, block_7))
-        self.assertTrue(fn.equal_block(block_6, block_7, only_metadata=True))
+        self.assertFalse(equistore.equal_block(block_6, block_7))
+        self.assertTrue(equistore.equal_block(block_6, block_7, only_metadata=True))
 
         with self.assertRaises(ValueError) as cm:
-            fn.equal_block_raise(block_6, block_7)
+            equistore.equal_block_raise(block_6, block_7)
 
         self.assertEqual(
             str(cm.exception),

--- a/python/tests/operations/lstsq.py
+++ b/python/tests/operations/lstsq.py
@@ -3,7 +3,7 @@ import unittest
 
 import numpy as np
 
-import equistore.operations as fn
+import equistore
 from equistore import Labels, TensorBlock, TensorMap
 
 
@@ -45,7 +45,7 @@ class TestLstsq(unittest.TestCase):
 
         # Try to do with solve -> Raise Error
         with self.assertRaises(ValueError) as cm:
-            w = fn.solve(X, Y)
+            w = equistore.solve(X, Y)
 
         self.assertEqual(
             str(cm.exception),
@@ -53,7 +53,7 @@ class TestLstsq(unittest.TestCase):
         )
 
         # solve with least square
-        w = fn.lstsq(X, Y, rcond=1e-13)
+        w = equistore.lstsq(X, Y, rcond=1e-13)
 
         self.assertTrue(len(w) == 2)
         self.assertTrue(np.all(w.keys == X.keys))
@@ -65,8 +65,8 @@ class TestLstsq(unittest.TestCase):
             self.assertTrue(np.all(blockw.samples == Y.block(key).properties))
             self.assertTrue(np.all(blockw.properties == X.block(key).properties))
 
-        Ydot = fn.dot(X, w)
-        self.assertTrue(fn.allclose(Ydot, Y))
+        Ydot = equistore.dot(X, w)
+        self.assertTrue(equistore.allclose(Ydot, Y))
 
     def test_self_lstsq_grad(self):
         Xval, Xgradval, Yval, Ygradval = get_value_linear_solve()
@@ -116,7 +116,7 @@ class TestLstsq(unittest.TestCase):
 
         X = TensorMap(keys, [block_X])
         Y = TensorMap(keys, [block_Y])
-        w = fn.lstsq(X, Y, rcond=1e-13)
+        w = equistore.lstsq(X, Y, rcond=1e-13)
 
         self.assertTrue(len(w) == 1)
         self.assertTrue(np.all(w.keys == X.keys))
@@ -128,8 +128,8 @@ class TestLstsq(unittest.TestCase):
             self.assertTrue(np.all(block_w.samples == Y.block(key).properties))
             self.assertTrue(np.all(block_w.properties == X.block(key).properties))
 
-        Ydot = fn.dot(X, w)
-        self.assertTrue(fn.allclose(Ydot, Y))
+        Ydot = equistore.dot(X, w)
+        self.assertTrue(equistore.allclose(Ydot, Y))
 
     def test_self_lstsq_grad_components(self):
         Xval, Xgradval, Yval, Ygradval = get_value_linear_solve()
@@ -191,7 +191,7 @@ class TestLstsq(unittest.TestCase):
 
         X = TensorMap(keys, [block_X])
         Y = TensorMap(keys, [block_Y])
-        w = fn.lstsq(X, Y, rcond=1e-13)
+        w = equistore.lstsq(X, Y, rcond=1e-13)
 
         self.assertTrue(len(w) == 1)
         self.assertTrue(np.all(w.keys == X.keys))
@@ -203,8 +203,8 @@ class TestLstsq(unittest.TestCase):
             self.assertTrue(np.all(blockw.samples == Y.block(key).properties))
             self.assertTrue(np.all(blockw.properties == X.block(key).properties))
 
-        Ydot = fn.dot(X, w)
-        self.assertTrue(fn.allclose(Ydot, Y))
+        Ydot = equistore.dot(X, w)
+        self.assertTrue(equistore.allclose(Ydot, Y))
 
 
 def Xfun1(x, y, z):

--- a/python/tests/operations/multiply.py
+++ b/python/tests/operations/multiply.py
@@ -3,7 +3,7 @@ import unittest
 
 import numpy as np
 
-import equistore.operations as fn
+import equistore
 from equistore import Labels, TensorBlock, TensorMap
 
 
@@ -54,10 +54,10 @@ class TestMultiply(unittest.TestCase):
         )
         A = TensorMap(keys, [block_1, block_2])
         B = TensorMap(keys, [block_3, block_4])
-        tensor_sum = fn.multiply(A, B)
+        tensor_sum = equistore.multiply(A, B)
         tensor_result = TensorMap(keys, [block_res1, block_res2])
 
-        self.assertTrue(fn.allclose(tensor_result, tensor_sum))
+        self.assertTrue(equistore.allclose(tensor_result, tensor_sum))
 
     def test_self_multiply_tensors_gradient(self):
         block_1 = TensorBlock(
@@ -183,10 +183,10 @@ class TestMultiply(unittest.TestCase):
         )
         A = TensorMap(keys, [block_1, block_2])
         B = TensorMap(keys, [block_3, block_4])
-        tensor_sum = fn.multiply(A, B)
+        tensor_sum = equistore.multiply(A, B)
         tensor_result = TensorMap(keys, [block_res1, block_res2])
 
-        self.assertTrue(fn.allclose(tensor_result, tensor_sum))
+        self.assertTrue(equistore.allclose(tensor_result, tensor_sum))
 
     def test_self_multiply_scalar_gradient(self):
         block_1 = TensorBlock(
@@ -272,12 +272,12 @@ class TestMultiply(unittest.TestCase):
         B = 5.1
         C = np.array([5.1])
 
-        tensor_sum = fn.multiply(A, B)
-        tensor_sum_array = fn.multiply(A, C)
+        tensor_sum = equistore.multiply(A, B)
+        tensor_sum_array = equistore.multiply(A, C)
         tensor_result = TensorMap(keys, [block_res1, block_res2])
 
-        self.assertTrue(fn.allclose(tensor_result, tensor_sum))
-        self.assertTrue(fn.allclose(tensor_result, tensor_sum_array))
+        self.assertTrue(equistore.allclose(tensor_result, tensor_sum))
+        self.assertTrue(equistore.allclose(tensor_result, tensor_sum_array))
 
     def test_self_multiply_error(self):
         block_1 = TensorBlock(
@@ -293,7 +293,7 @@ class TestMultiply(unittest.TestCase):
         B = np.ones((3, 4))
 
         with self.assertRaises(TypeError) as cm:
-            keys = fn.multiply(A, B)
+            keys = equistore.multiply(A, B)
         self.assertEqual(
             str(cm.exception),
             "B should be a TensorMap or a scalar value. ",

--- a/python/tests/operations/ones_like.py
+++ b/python/tests/operations/ones_like.py
@@ -3,8 +3,8 @@ import unittest
 
 import numpy as np
 
+import equistore
 import equistore.io
-import equistore.operations as fn
 
 
 DATA_ROOT = os.path.join(os.path.dirname(__file__), "..", "data")
@@ -17,7 +17,7 @@ class TestOnes_like(unittest.TestCase):
             # the npz is using DEFLATE compression, equistore only supports STORED
             use_numpy=True,
         )
-        ones_tensor = fn.ones_like(tensor)
+        ones_tensor = equistore.ones_like(tensor)
 
         self.assertTrue(np.all(tensor.keys == ones_tensor.keys))
         for key, ones_block in ones_tensor:
@@ -60,8 +60,8 @@ class TestOnes_like(unittest.TestCase):
             # the npz is using DEFLATE compression, equistore only supports STORED
             use_numpy=True,
         )
-        ones_tensor = fn.ones_like(tensor)
-        ones_tensor_positions = fn.ones_like(tensor, parameters="positions")
+        ones_tensor = equistore.ones_like(tensor)
+        ones_tensor_positions = equistore.ones_like(tensor, parameters="positions")
 
         self.assertTrue(np.all(tensor.keys == ones_tensor.keys))
         self.assertTrue(np.all(tensor.keys == ones_tensor_positions.keys))
@@ -128,7 +128,7 @@ class TestOnes_like(unittest.TestCase):
         )
 
         with self.assertRaises(ValueError) as cm:
-            tensor = fn.ones_like(tensor, parameters=["positions", "err"])
+            tensor = equistore.ones_like(tensor, parameters=["positions", "err"])
         self.assertEqual(
             str(cm.exception),
             "The requested parameter 'err' in ones_like_block "

--- a/python/tests/operations/pow.py
+++ b/python/tests/operations/pow.py
@@ -3,7 +3,7 @@ import unittest
 
 import numpy as np
 
-import equistore.operations as fn
+import equistore
 from equistore import Labels, TensorBlock, TensorMap
 
 
@@ -120,12 +120,12 @@ class TestPow(unittest.TestCase):
 
         C = np.array([2.0])
 
-        tensor_sum = fn.pow(A, B)
-        tensor_sum_array = fn.pow(A, C)
+        tensor_sum = equistore.pow(A, B)
+        tensor_sum_array = equistore.pow(A, C)
         tensor_result = TensorMap(keys, [block_res1, block_res2])
 
-        self.assertTrue(fn.allclose(tensor_result, tensor_sum))
-        self.assertTrue(fn.allclose(tensor_result, tensor_sum_array))
+        self.assertTrue(equistore.allclose(tensor_result, tensor_sum))
+        self.assertTrue(equistore.allclose(tensor_result, tensor_sum_array))
 
     def test_self_pow_scalar_sqrt_gradient(self):
         b1_s0 = np.array([1, 2])
@@ -236,12 +236,12 @@ class TestPow(unittest.TestCase):
 
         C = np.array([0.5])
 
-        tensor_sum = fn.pow(A, B)
-        tensor_sum_array = fn.pow(A, C)
+        tensor_sum = equistore.pow(A, B)
+        tensor_sum_array = equistore.pow(A, C)
         tensor_result = TensorMap(keys, [block_res1, block_res2])
 
-        self.assertTrue(fn.allclose(tensor_result, tensor_sum))
-        self.assertTrue(fn.allclose(tensor_result, tensor_sum_array))
+        self.assertTrue(equistore.allclose(tensor_result, tensor_sum))
+        self.assertTrue(equistore.allclose(tensor_result, tensor_sum_array))
 
     def test_self_pow_error(self):
         block_1 = TensorBlock(
@@ -257,7 +257,7 @@ class TestPow(unittest.TestCase):
         B = np.ones((3, 4))
 
         with self.assertRaises(TypeError) as cm:
-            keys = fn.pow(A, B)
+            keys = equistore.pow(A, B)
         self.assertEqual(
             str(cm.exception),
             "B should be a scalar value. ",

--- a/python/tests/operations/reduce_over_samples.py
+++ b/python/tests/operations/reduce_over_samples.py
@@ -3,8 +3,8 @@ import unittest
 
 import numpy as np
 
+import equistore
 import equistore.io
-import equistore.operations as fn
 from equistore import Labels, TensorBlock, TensorMap
 
 
@@ -23,8 +23,10 @@ class TestSumSamples(unittest.TestCase):
         )
         bl1 = tensor_ps[0]
 
-        reduce_tensor_se = fn.sum_over_samples(tensor_se, samples_names=["center"])
-        reduce_tensor_ps = fn.sum_over_samples(tensor_ps, samples_names="center")
+        reduce_tensor_se = equistore.sum_over_samples(
+            tensor_se, samples_names=["center"]
+        )
+        reduce_tensor_ps = equistore.sum_over_samples(tensor_ps, samples_names="center")
 
         self.assertTrue(
             np.all(
@@ -170,9 +172,11 @@ class TestSumSamples(unittest.TestCase):
         )
         X = TensorMap(keys, [block_1])
 
-        reduce_X_12 = fn.sum_over_samples(X, samples_names="samples3")
-        reduce_X_23 = fn.sum_over_samples(X, samples_names=["samples1"])
-        reduce_X_2 = fn.sum_over_samples(X, samples_names=["samples1", "samples3"])
+        reduce_X_12 = equistore.sum_over_samples(X, samples_names="samples3")
+        reduce_X_23 = equistore.sum_over_samples(X, samples_names=["samples1"])
+        reduce_X_2 = equistore.sum_over_samples(
+            X, samples_names=["samples1", "samples3"]
+        )
 
         self.assertTrue(
             np.all(
@@ -254,8 +258,12 @@ class TestMeanSamples(unittest.TestCase):
         )
         bl1 = tensor_ps[0]
 
-        reduce_tensor_se = fn.mean_over_samples(tensor_se, samples_names="center")
-        reduce_tensor_ps = fn.mean_over_samples(tensor_ps, samples_names=["center"])
+        reduce_tensor_se = equistore.mean_over_samples(
+            tensor_se, samples_names="center"
+        )
+        reduce_tensor_ps = equistore.mean_over_samples(
+            tensor_ps, samples_names=["center"]
+        )
 
         self.assertTrue(
             np.all(
@@ -429,9 +437,11 @@ class TestMeanSamples(unittest.TestCase):
         )
         X = TensorMap(keys, [block_1])
 
-        reduce_X_12 = fn.mean_over_samples(X, samples_names=["samples3"])
-        reduce_X_23 = fn.mean_over_samples(X, samples_names="samples1")
-        reduce_X_2 = fn.mean_over_samples(X, samples_names=["samples1", "samples3"])
+        reduce_X_12 = equistore.mean_over_samples(X, samples_names=["samples3"])
+        reduce_X_23 = equistore.mean_over_samples(X, samples_names="samples1")
+        reduce_X_2 = equistore.mean_over_samples(
+            X, samples_names=["samples1", "samples3"]
+        )
 
         self.assertTrue(
             np.all(
@@ -537,14 +547,14 @@ class TestReductionAllSamples(unittest.TestCase):
         )
         X = TensorMap(keys, [block_1])
 
-        sum_X = fn.sum_over_samples(X, samples_names=["samples"])
-        mean_X = fn.mean_over_samples(X, samples_names=["samples"])
-        var_X = fn.variance_over_samples(X, samples_names=["samples"])
-        std_X = fn.std_over_samples(X, samples_names=["samples"])
+        sum_X = equistore.sum_over_samples(X, samples_names=["samples"])
+        mean_X = equistore.mean_over_samples(X, samples_names=["samples"])
+        var_X = equistore.variance_over_samples(X, samples_names=["samples"])
+        std_X = equistore.std_over_samples(X, samples_names=["samples"])
 
-        self.assertTrue(fn.equal(sum_X, mean_X, only_metadata=True))
-        self.assertTrue(fn.equal(sum_X, std_X, only_metadata=True))
-        self.assertTrue(fn.equal(mean_X, var_X, only_metadata=True))
+        self.assertTrue(equistore.equal(sum_X, mean_X, only_metadata=True))
+        self.assertTrue(equistore.equal(sum_X, std_X, only_metadata=True))
+        self.assertTrue(equistore.equal(mean_X, var_X, only_metadata=True))
         self.assertTrue(sum_X[0].samples == Labels.single())
         self.assertTrue(std_X[0].samples == Labels.single())
 
@@ -564,13 +574,15 @@ class TestStdSamples(unittest.TestCase):
             os.path.join(DATA_ROOT, "qm7-power-spectrum.npz"),
             use_numpy=True,
         )
-        # tensor_ps = fn.remove_gradients(tensor_ps)
-        tensor_se = fn.remove_gradients(tensor_se)
+        # tensor_ps = equistore.remove_gradients(tensor_ps)
+        tensor_se = equistore.remove_gradients(tensor_se)
 
         bl1 = tensor_ps[0]
 
-        reduce_tensor_se = fn.std_over_samples(tensor_se, samples_names="center")
-        reduce_tensor_ps = fn.std_over_samples(tensor_ps, samples_names=["center"])
+        reduce_tensor_se = equistore.std_over_samples(tensor_se, samples_names="center")
+        reduce_tensor_ps = equistore.std_over_samples(
+            tensor_ps, samples_names=["center"]
+        )
 
         self.assertTrue(
             np.allclose(
@@ -769,9 +781,11 @@ class TestStdSamples(unittest.TestCase):
         )
         X = TensorMap(keys, [block_1])
 
-        reduce_X_12 = fn.std_over_samples(X, samples_names=["samples3"])
-        reduce_X_23 = fn.std_over_samples(X, samples_names="samples1")
-        reduce_X_2 = fn.std_over_samples(X, samples_names=["samples1", "samples3"])
+        reduce_X_12 = equistore.std_over_samples(X, samples_names=["samples3"])
+        reduce_X_23 = equistore.std_over_samples(X, samples_names="samples1")
+        reduce_X_2 = equistore.std_over_samples(
+            X, samples_names=["samples1", "samples3"]
+        )
 
         self.assertTrue(
             np.all(
@@ -883,21 +897,21 @@ class TestStdSamples(unittest.TestCase):
         keys = Labels(names=["key_1"], values=np.array([[0]], dtype=np.int32))
         X = TensorMap(keys, [block_1])
 
-        add_X = fn.sum_over_samples(X, samples_names=["samples1"])
-        mean_X = fn.mean_over_samples(X, samples_names=["samples1"])
-        var_X = fn.variance_over_samples(X, samples_names=["samples1"])
-        std_X = fn.std_over_samples(X, samples_names=["samples1"])
+        add_X = equistore.sum_over_samples(X, samples_names=["samples1"])
+        mean_X = equistore.mean_over_samples(X, samples_names=["samples1"])
+        var_X = equistore.variance_over_samples(X, samples_names=["samples1"])
+        std_X = equistore.std_over_samples(X, samples_names=["samples1"])
 
         # print(add_X[0])
         # print(X[0].values, add_X[0].values)
         self.assertTrue(np.all(X[0].values == add_X[0].values))
         self.assertTrue(np.all(X[0].values == mean_X[0].values))
-        self.assertTrue(fn.equal(add_X, mean_X))
-        self.assertTrue(fn.equal(add_X, var_X, only_metadata=True))
-        self.assertTrue(fn.equal(mean_X, std_X, only_metadata=True))
+        self.assertTrue(equistore.equal(add_X, mean_X))
+        self.assertTrue(equistore.equal(add_X, var_X, only_metadata=True))
+        self.assertTrue(equistore.equal(mean_X, std_X, only_metadata=True))
 
         self.assertTrue(np.all(np.zeros((3, 3)) == std_X[0].values))
-        self.assertTrue(fn.equal(var_X, std_X))
+        self.assertTrue(equistore.equal(var_X, std_X))
 
         # Gradients
         grad_sample_label = Labels(

--- a/python/tests/operations/remove_gradients.py
+++ b/python/tests/operations/remove_gradients.py
@@ -1,8 +1,8 @@
 import os
 import unittest
 
+import equistore
 import equistore.io
-import equistore.operations as fn
 
 
 DATA_ROOT = os.path.join(os.path.dirname(__file__), "..", "data")
@@ -18,7 +18,7 @@ class TestRemoveGradients(unittest.TestCase):
 
         self.assertEqual(tensor.block(0).gradients_list(), ["cell", "positions"])
 
-        tensor = fn.remove_gradients(tensor)
+        tensor = equistore.remove_gradients(tensor)
         self.assertEqual(tensor.block(0).gradients_list(), [])
 
     def test_remove_subset(self):
@@ -30,7 +30,7 @@ class TestRemoveGradients(unittest.TestCase):
 
         self.assertEqual(tensor.block(0).gradients_list(), ["cell", "positions"])
 
-        tensor = fn.remove_gradients(tensor, ["positions"])
+        tensor = equistore.remove_gradients(tensor, ["positions"])
         self.assertEqual(tensor.block(0).gradients_list(), ["cell"])
 
 

--- a/python/tests/operations/slice.py
+++ b/python/tests/operations/slice.py
@@ -4,8 +4,8 @@ import warnings
 
 import numpy as np
 
+import equistore
 import equistore.io
-import equistore.operations as fn
 from equistore import Labels
 
 
@@ -100,7 +100,7 @@ class TestSliceSamples(unittest.TestCase):
             values=structures_to_keep,
         )
         block = self.tensor.block(0)
-        sliced_block = fn.slice_block(
+        sliced_block = equistore.slice_block(
             block,
             samples=samples,
         )
@@ -115,7 +115,7 @@ class TestSliceSamples(unittest.TestCase):
 
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
-            sliced_block = fn.slice_block(
+            sliced_block = equistore.slice_block(
                 block,
                 samples=samples,
             )
@@ -129,7 +129,7 @@ class TestSliceSamples(unittest.TestCase):
             names=["structure"],
             values=structures_to_keep,
         )
-        sliced_tensor = fn.slice(
+        sliced_tensor = equistore.slice(
             self.tensor,
             samples=samples,
         )
@@ -150,7 +150,7 @@ class TestSliceSamples(unittest.TestCase):
 
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
-            sliced_tensor = fn.slice(
+            sliced_tensor = equistore.slice(
                 self.tensor,
                 samples=samples,
             )
@@ -246,7 +246,7 @@ class TestSliceProperties(unittest.TestCase):
         )
 
         block = self.tensor.block(0)
-        sliced_block = fn.slice_block(
+        sliced_block = equistore.slice_block(
             block,
             properties=properties,
         )
@@ -261,7 +261,7 @@ class TestSliceProperties(unittest.TestCase):
 
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
-            sliced_block = fn.slice_block(
+            sliced_block = equistore.slice_block(
                 block,
                 properties=properties,
             )
@@ -276,7 +276,7 @@ class TestSliceProperties(unittest.TestCase):
             values=radial_to_keep,
         )
 
-        sliced_tensor = fn.slice(
+        sliced_tensor = equistore.slice(
             self.tensor,
             properties=properties,
         )
@@ -297,7 +297,7 @@ class TestSliceProperties(unittest.TestCase):
 
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
-            sliced_tensor = fn.slice(
+            sliced_tensor = equistore.slice(
                 self.tensor,
                 properties=properties,
             )
@@ -328,7 +328,7 @@ class TestSliceBoth(unittest.TestCase):
             values=channels_to_keep,
         )
 
-        sliced_block = fn.slice_block(
+        sliced_block = equistore.slice_block(
             block,
             samples=samples,
             properties=properties,
@@ -373,14 +373,16 @@ class TestSliceBoth(unittest.TestCase):
         )
         # Original tensor returned if no samples/properties to slice by are passed
         self.assertTrue(
-            fn.equal_block(
-                fn.slice_block(tensor.block(0), samples=None, properties=None),
+            equistore.equal_block(
+                equistore.slice_block(tensor.block(0), samples=None, properties=None),
                 tensor.block(0),
             )
         )
         # Original tensor returned if no samples/properties to slice by are passed
         self.assertTrue(
-            fn.equal(fn.slice(tensor, samples=None, properties=None), tensor)
+            equistore.equal(
+                equistore.slice(tensor, samples=None, properties=None), tensor
+            )
         )
 
 
@@ -399,7 +401,7 @@ class TestSliceErrors(unittest.TestCase):
         )
 
         with self.assertRaises(TypeError) as cm:
-            fn.slice(self.tensor.block(0), samples=samples),
+            equistore.slice(self.tensor.block(0), samples=samples),
 
         self.assertEqual(
             str(cm.exception),
@@ -408,7 +410,7 @@ class TestSliceErrors(unittest.TestCase):
 
         # passing samples=np.array raises TypeError
         with self.assertRaises(TypeError) as cm:
-            fn.slice(
+            equistore.slice(
                 self.tensor,
                 samples=np.array([[5], [6]]),
             )
@@ -420,7 +422,7 @@ class TestSliceErrors(unittest.TestCase):
 
         # passing properties=np.array raises TypeError
         with self.assertRaises(TypeError) as cm:
-            fn.slice(
+            equistore.slice(
                 self.tensor,
                 properties=np.array([[5], [6]]),
             )
@@ -438,7 +440,7 @@ class TestSliceErrors(unittest.TestCase):
         )
 
         with self.assertRaises(TypeError) as cm:
-            fn.slice_block(self.tensor, samples=samples),
+            equistore.slice_block(self.tensor, samples=samples),
 
         self.assertEqual(
             str(cm.exception), "``block`` should be an equistore ``TensorBlock``"
@@ -447,7 +449,7 @@ class TestSliceErrors(unittest.TestCase):
         block = self.tensor.block(0)
         # passing samples=np.array raises TypeError
         with self.assertRaises(TypeError) as cm:
-            fn.slice_block(
+            equistore.slice_block(
                 block,
                 samples=np.array([[5], [6]]),
             )
@@ -459,7 +461,7 @@ class TestSliceErrors(unittest.TestCase):
 
         # passing properties=np.array raises TypeError
         with self.assertRaises(TypeError) as cm:
-            fn.slice_block(
+            equistore.slice_block(
                 block,
                 properties=np.array([[5], [6]]),
             )

--- a/python/tests/operations/solve.py
+++ b/python/tests/operations/solve.py
@@ -3,7 +3,7 @@ import unittest
 
 import numpy as np
 
-import equistore.operations as fn
+import equistore
 from equistore import Labels, TensorBlock, TensorMap
 
 
@@ -41,7 +41,7 @@ class TestSolve(unittest.TestCase):
         )
         X = TensorMap(keys, [block_1, block_2])
         Y = TensorMap(keys, [block_3, block_4])
-        w = fn.solve(X, Y)
+        w = equistore.solve(X, Y)
 
         self.assertTrue(len(w) == 2)
         self.assertTrue(np.all(w.keys == X.keys))
@@ -55,8 +55,8 @@ class TestSolve(unittest.TestCase):
             self.assertTrue(np.all(blockw.samples == Y.block(key).properties))
             self.assertTrue(np.all(blockw.properties == X.block(key).properties))
 
-        Ydot = fn.dot(X, w)
-        self.assertTrue(fn.allclose(Ydot, Y))
+        Ydot = equistore.dot(X, w)
+        self.assertTrue(equistore.allclose(Ydot, Y))
 
 
 # TODO: add tests with torch & torch scripting/tracing

--- a/python/tests/operations/subtract.py
+++ b/python/tests/operations/subtract.py
@@ -3,7 +3,7 @@ import unittest
 
 import numpy as np
 
-import equistore.operations as fn
+import equistore
 from equistore import Labels, TensorBlock, TensorMap
 
 
@@ -54,10 +54,10 @@ class TestSubtract(unittest.TestCase):
         )
         A = TensorMap(keys, [block_1, block_2])
         B = TensorMap(keys, [block_3, block_4])
-        tensor_sum = fn.subtract(A, B)
+        tensor_sum = equistore.subtract(A, B)
         tensor_result = TensorMap(keys, [block_res1, block_res2])
 
-        self.assertTrue(fn.allclose(tensor_result, tensor_sum))
+        self.assertTrue(equistore.allclose(tensor_result, tensor_sum))
 
     def test_self_subtract_tensors_gradient(self):
         block_1 = TensorBlock(
@@ -181,10 +181,10 @@ class TestSubtract(unittest.TestCase):
         )
         A = TensorMap(keys, [block_1, block_2])
         B = TensorMap(keys, [block_3, block_4])
-        tensor_sum = fn.subtract(A, B)
+        tensor_sum = equistore.subtract(A, B)
         tensor_result = TensorMap(keys, [block_res1, block_res2])
 
-        self.assertTrue(fn.allclose(tensor_result, tensor_sum))
+        self.assertTrue(equistore.allclose(tensor_result, tensor_sum))
 
     def test_self_subtract_scalar_gradient(self):
         block_1 = TensorBlock(
@@ -266,12 +266,12 @@ class TestSubtract(unittest.TestCase):
         B = -5.1
         C = np.array([-5.1])
 
-        tensor_sum = fn.subtract(A, B)
-        tensor_sum_array = fn.subtract(A, C)
+        tensor_sum = equistore.subtract(A, B)
+        tensor_sum_array = equistore.subtract(A, C)
         tensor_result = TensorMap(keys, [block_res1, block_res2])
 
-        self.assertTrue(fn.allclose(tensor_result, tensor_sum))
-        self.assertTrue(fn.allclose(tensor_result, tensor_sum_array))
+        self.assertTrue(equistore.allclose(tensor_result, tensor_sum))
+        self.assertTrue(equistore.allclose(tensor_result, tensor_sum_array))
 
     def test_self_subtract_error(self):
         block_1 = TensorBlock(
@@ -287,7 +287,7 @@ class TestSubtract(unittest.TestCase):
         B = np.ones((3, 4))
 
         with self.assertRaises(TypeError) as cm:
-            keys = fn.subtract(A, B)
+            keys = equistore.subtract(A, B)
         self.assertEqual(
             str(cm.exception),
             "B should be a TensorMap or a scalar value. ",

--- a/python/tests/operations/unique_metadata.py
+++ b/python/tests/operations/unique_metadata.py
@@ -3,9 +3,10 @@ import unittest
 
 import numpy as np
 
+import equistore
 import equistore.io
-import equistore.operations as fn
 from equistore import Labels, TensorBlock, TensorMap
+from equistore.operations._utils import _labels_equal
 
 
 DATA_ROOT = os.path.join(os.path.dirname(__file__), "..", "data")
@@ -31,34 +32,28 @@ class TestUniqueMetadata(unittest.TestCase):
         target_samples = Labels(
             names=["samples"], values=np.array([[s] for s in samples])
         )
-        actual_samples = fn.unique_metadata_block(
+        actual_samples = equistore.unique_metadata_block(
             self.tensor1.block(3), "samples", "samples"
         )
-        self.assertTrue(
-            fn._utils._labels_equal(target_samples, actual_samples, exact_order=True)
-        )
+        self.assertTrue(_labels_equal(target_samples, actual_samples, exact_order=True))
         # Test case 2
         samples = [0, 2, 4]
         target_samples = Labels(
             names=["samples"], values=np.array([[s] for s in samples])
         )
-        actual_samples = fn.unique_metadata_block(
+        actual_samples = equistore.unique_metadata_block(
             self.tensor2.block(0), "samples", "samples"
         )
-        self.assertTrue(
-            fn._utils._labels_equal(target_samples, actual_samples, exact_order=True)
-        )
+        self.assertTrue(_labels_equal(target_samples, actual_samples, exact_order=True))
         # Test case 3
         samples = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
         target_samples = Labels(
             names=["structure"], values=np.array([[s] for s in samples])
         )
-        actual_samples = fn.unique_metadata_block(
+        actual_samples = equistore.unique_metadata_block(
             self.tensor3.block(0), "samples", "structure"
         )
-        self.assertTrue(
-            fn._utils._labels_equal(target_samples, actual_samples, exact_order=True)
-        )
+        self.assertTrue(_labels_equal(target_samples, actual_samples, exact_order=True))
 
     def test_unique_metadata_block_samples_to_zero(self):
         """Tests getting unique samples metadata of a block sliced to zero
@@ -66,14 +61,14 @@ class TestUniqueMetadata(unittest.TestCase):
         # Slice block to zero along samples and check labels return is empty
         # with correct names
         target_samples = Labels(names=["structure"], values=np.array([[0]])[:0])
-        sliced_block = fn.slice_block(
+        sliced_block = equistore.slice_block(
             self.tensor3.block(0),
             samples=Labels(names=["structure"], values=np.array([[-1]])),
         )
-        actual_samples = fn.unique_metadata_block(sliced_block, "samples", "structure")
-        self.assertTrue(
-            fn._utils._labels_equal(target_samples, actual_samples, exact_order=True)
+        actual_samples = equistore.unique_metadata_block(
+            sliced_block, "samples", "structure"
         )
+        self.assertTrue(_labels_equal(target_samples, actual_samples, exact_order=True))
         self.assertTrue(len(actual_samples) == 0)
 
     def test_unique_metadata_block_properties(self):
@@ -83,39 +78,33 @@ class TestUniqueMetadata(unittest.TestCase):
         target_properties = Labels(
             names=["properties"], values=np.array([[p] for p in properties])
         )
-        actual_properties = fn.unique_metadata_block(
+        actual_properties = equistore.unique_metadata_block(
             self.tensor1.block(3), "properties", "properties"
         )
         self.assertTrue(
-            fn._utils._labels_equal(
-                target_properties, actual_properties, exact_order=True
-            )
+            _labels_equal(target_properties, actual_properties, exact_order=True)
         )
         # Test case 2
         properties = [3, 4, 5]
         target_properties = Labels(
             names=["properties"], values=np.array([[p] for p in properties])
         )
-        actual_properties = fn.unique_metadata_block(
+        actual_properties = equistore.unique_metadata_block(
             self.tensor2.block(1), "properties", "properties"
         )
         self.assertTrue(
-            fn._utils._labels_equal(
-                target_properties, actual_properties, exact_order=True
-            )
+            _labels_equal(target_properties, actual_properties, exact_order=True)
         )
         # Test case 3
         properties = [0, 1, 2, 3]
         target_properties = Labels(
             names=["n"], values=np.array([[p] for p in properties])
         )
-        actual_properties = fn.unique_metadata_block(
+        actual_properties = equistore.unique_metadata_block(
             self.tensor3.block(0), "properties", "n"
         )
         self.assertTrue(
-            fn._utils._labels_equal(
-                target_properties, actual_properties, exact_order=True
-            )
+            _labels_equal(target_properties, actual_properties, exact_order=True)
         )
 
     def test_unique_metadata_block_properties_to_zero(self):
@@ -124,15 +113,15 @@ class TestUniqueMetadata(unittest.TestCase):
         # Slice block to zero along properties and check labels return is empty
         # with correct names
         target_properties = Labels(names=["n"], values=np.array([[0]])[:0])
-        sliced_block = fn.slice_block(
+        sliced_block = equistore.slice_block(
             self.tensor3.block(0),
             properties=Labels(names=["n"], values=np.array([[-1]])),
         )
-        actual_properties = fn.unique_metadata_block(sliced_block, "properties", "n")
+        actual_properties = equistore.unique_metadata_block(
+            sliced_block, "properties", "n"
+        )
         self.assertTrue(
-            fn._utils._labels_equal(
-                target_properties, actual_properties, exact_order=True
-            )
+            _labels_equal(target_properties, actual_properties, exact_order=True)
         )
         self.assertTrue(len(actual_properties) == 0)
 
@@ -143,48 +132,40 @@ class TestUniqueMetadata(unittest.TestCase):
         target_samples = Labels(
             names=["sample"], values=np.array([[s] for s in samples])
         )
-        actual_samples = fn.unique_metadata_block(
+        actual_samples = equistore.unique_metadata_block(
             self.tensor1.block(0), "samples", "sample", parameter
         )
-        self.assertTrue(
-            fn._utils._labels_equal(target_samples, actual_samples, exact_order=True)
-        )
+        self.assertTrue(_labels_equal(target_samples, actual_samples, exact_order=True))
         # Test case 2
         parameter = "parameter"
         samples, sname = [[0, -2], [0, 3], [2, -2]], ["sample", "parameter"]
         target_samples = Labels(names=sname, values=np.array([s for s in samples]))
-        actual_samples = fn.unique_metadata_block(
+        actual_samples = equistore.unique_metadata_block(
             self.tensor2.block(1), "samples", sname, parameter
         )
-        self.assertTrue(
-            fn._utils._labels_equal(target_samples, actual_samples, exact_order=True)
-        )
+        self.assertTrue(_labels_equal(target_samples, actual_samples, exact_order=True))
         # Test case 3
         target_samples = Labels(
             names=["sample"], values=np.arange(0, 52).reshape(-1, 1)
         )
-        actual_samples = fn.unique_metadata_block(
+        actual_samples = equistore.unique_metadata_block(
             self.tensor3.block(1), "samples", "sample", "cell"
         )
-        self.assertTrue(
-            fn._utils._labels_equal(target_samples, actual_samples, exact_order=True)
-        )
+        self.assertTrue(_labels_equal(target_samples, actual_samples, exact_order=True))
 
     def test_unique_metadata_block_gradient_samples_to_zero(self):
         """Test unique samples metadata of block sliced to zero"""
         # Slice block to zero along samples and check labels return is empty
         # with correct names
         target_samples = Labels(names=["sample"], values=np.array([[0]])[:0])
-        sliced_block = fn.slice_block(
+        sliced_block = equistore.slice_block(
             self.tensor3.block(0),
             samples=Labels(names=["structure"], values=np.array([[-1]])),
         )
-        actual_samples = fn.unique_metadata_block(
+        actual_samples = equistore.unique_metadata_block(
             sliced_block, "samples", "sample", gradient_param="cell"
         )
-        self.assertTrue(
-            fn._utils._labels_equal(target_samples, actual_samples, exact_order=True)
-        )
+        self.assertTrue(_labels_equal(target_samples, actual_samples, exact_order=True))
         self.assertTrue(len(actual_samples) == 0)
 
     def test_unique_metadata_block_gradient_properties(self):
@@ -195,13 +176,11 @@ class TestUniqueMetadata(unittest.TestCase):
         target_properties = Labels(
             names=["properties"], values=np.array([[p] for p in properties])
         )
-        actual_properties = fn.unique_metadata_block(
+        actual_properties = equistore.unique_metadata_block(
             self.tensor1.block(0), "properties", "properties", parameter
         )
         self.assertTrue(
-            fn._utils._labels_equal(
-                target_properties, actual_properties, exact_order=True
-            )
+            _labels_equal(target_properties, actual_properties, exact_order=True)
         )
         # Test case 2
         parameter = "parameter"
@@ -209,53 +188,45 @@ class TestUniqueMetadata(unittest.TestCase):
         target_properties = Labels(
             names=pname, values=np.array([p for p in properties])
         )
-        actual_properties = fn.unique_metadata_block(
+        actual_properties = equistore.unique_metadata_block(
             self.tensor2.block(1), "properties", pname, parameter
         )
         self.assertTrue(
-            fn._utils._labels_equal(
-                target_properties, actual_properties, exact_order=True
-            )
+            _labels_equal(target_properties, actual_properties, exact_order=True)
         )
         # By definition the unique TensorBlock and Gradient block properties
         # should be equivalent
-        actual_properties_tensorblock = fn.unique_metadata_block(
+        actual_properties_tensorblock = equistore.unique_metadata_block(
             self.tensor2.block(1),
             "properties",
             pname,
         )
         self.assertTrue(
-            fn._utils._labels_equal(
+            _labels_equal(
                 actual_properties_tensorblock, actual_properties, exact_order=True
             )
         )
         # Test case 3
         target_properties = Labels(names=["n"], values=np.arange(0, 4).reshape(-1, 1))
-        actual_properties = fn.unique_metadata_block(
+        actual_properties = equistore.unique_metadata_block(
             self.tensor3.block(1), "properties", "n", "positions"
         )
         self.assertTrue(
-            fn._utils._labels_equal(
-                target_properties, actual_properties, exact_order=True
-            )
+            _labels_equal(target_properties, actual_properties, exact_order=True)
         )
         # Passing names as list
-        actual_properties = fn.unique_metadata_block(
+        actual_properties = equistore.unique_metadata_block(
             self.tensor3.block(1), "properties", ["n"], "positions"
         )
         self.assertTrue(
-            fn._utils._labels_equal(
-                target_properties, actual_properties, exact_order=True
-            )
+            _labels_equal(target_properties, actual_properties, exact_order=True)
         )
         # Passing names as tuple
-        actual_properties = fn.unique_metadata_block(
+        actual_properties = equistore.unique_metadata_block(
             self.tensor3.block(1), "properties", ("n",), "positions"
         )
         self.assertTrue(
-            fn._utils._labels_equal(
-                target_properties, actual_properties, exact_order=True
-            )
+            _labels_equal(target_properties, actual_properties, exact_order=True)
         )
 
     def test_unique_metadata_block_gradient_properties_to_zero(self):
@@ -263,17 +234,15 @@ class TestUniqueMetadata(unittest.TestCase):
         # Slice block to zero along properties and check labels return is empty
         # with correct names
         target_properties = Labels(names=["n"], values=np.array([[0]])[:0])
-        sliced_block = fn.slice_block(
+        sliced_block = equistore.slice_block(
             self.tensor3.block(0),
             properties=Labels(names=["n"], values=np.array([[-1]])),
         )
-        actual_properties = fn.unique_metadata_block(
+        actual_properties = equistore.unique_metadata_block(
             sliced_block, "properties", "n", gradient_param="cell"
         )
         self.assertTrue(
-            fn._utils._labels_equal(
-                target_properties, actual_properties, exact_order=True
-            )
+            _labels_equal(target_properties, actual_properties, exact_order=True)
         )
         self.assertTrue(len(actual_properties) == 0)
 
@@ -284,15 +253,11 @@ class TestUniqueMetadata(unittest.TestCase):
         target_samples = Labels(
             names=["samples"], values=np.array([[s] for s in samples])
         )
-        actual_samples = fn.unique_metadata(self.tensor1, "samples", "samples")
-        self.assertTrue(
-            fn._utils._labels_equal(target_samples, actual_samples, exact_order=True)
-        )
+        actual_samples = equistore.unique_metadata(self.tensor1, "samples", "samples")
+        self.assertTrue(_labels_equal(target_samples, actual_samples, exact_order=True))
         # Test case 2
-        actual_samples = fn.unique_metadata(self.tensor2, "samples", "samples")
-        self.assertTrue(
-            fn._utils._labels_equal(actual_samples, target_samples, exact_order=True)
-        )
+        actual_samples = equistore.unique_metadata(self.tensor2, "samples", "samples")
+        self.assertTrue(_labels_equal(actual_samples, target_samples, exact_order=True))
 
     def test_unique_metadata_samples_different_types(self):
         """Passign names as different types"""
@@ -301,15 +266,13 @@ class TestUniqueMetadata(unittest.TestCase):
             names=["samples"], values=np.array([[s] for s in samples])
         )
         # Passing names as list
-        actual_samples = fn.unique_metadata(self.tensor2, "samples", ["samples"])
-        self.assertTrue(
-            fn._utils._labels_equal(target_samples, actual_samples, exact_order=True)
-        )
+        actual_samples = equistore.unique_metadata(self.tensor2, "samples", ["samples"])
+        self.assertTrue(_labels_equal(target_samples, actual_samples, exact_order=True))
         # Passing names as tuple
-        actual_samples = fn.unique_metadata(self.tensor2, "samples", ("samples",))
-        self.assertTrue(
-            fn._utils._labels_equal(target_samples, actual_samples, exact_order=True)
+        actual_samples = equistore.unique_metadata(
+            self.tensor2, "samples", ("samples",)
         )
+        self.assertTrue(_labels_equal(target_samples, actual_samples, exact_order=True))
 
     def test_unique_metadata_properties(self):
         """Test unique on whole TensorMap along samples"""
@@ -318,22 +281,22 @@ class TestUniqueMetadata(unittest.TestCase):
         target_properties = Labels(
             names=["properties"], values=np.array([[p] for p in properties])
         )
-        actual_properties = fn.unique_metadata(self.tensor1, "properties", "properties")
+        actual_properties = equistore.unique_metadata(
+            self.tensor1, "properties", "properties"
+        )
         self.assertTrue(
-            fn._utils._labels_equal(
-                target_properties, actual_properties, exact_order=True
-            )
+            _labels_equal(target_properties, actual_properties, exact_order=True)
         )
         # Test case 2
         properties = [0, 1, 2, 3, 4, 5, 6, 7]
         target_properties = Labels(
             names=["properties"], values=np.array([[p] for p in properties])
         )
-        actual_properties = fn.unique_metadata(self.tensor2, "properties", "properties")
+        actual_properties = equistore.unique_metadata(
+            self.tensor2, "properties", "properties"
+        )
         self.assertTrue(
-            fn._utils._labels_equal(
-                target_properties, actual_properties, exact_order=True
-            )
+            _labels_equal(target_properties, actual_properties, exact_order=True)
         )
 
     def test_unique_metadata_properties_different_types(self):
@@ -343,22 +306,18 @@ class TestUniqueMetadata(unittest.TestCase):
             names=["properties"], values=np.array([[p] for p in properties])
         )
         # Passing names as list
-        actual_properties = fn.unique_metadata(
+        actual_properties = equistore.unique_metadata(
             self.tensor2, "properties", ["properties"]
         )
         self.assertTrue(
-            fn._utils._labels_equal(
-                target_properties, actual_properties, exact_order=True
-            )
+            _labels_equal(target_properties, actual_properties, exact_order=True)
         )
         # Passing names as tuple
-        actual_properties = fn.unique_metadata(
+        actual_properties = equistore.unique_metadata(
             self.tensor2, "properties", ("properties",)
         )
         self.assertTrue(
-            fn._utils._labels_equal(
-                target_properties, actual_properties, exact_order=True
-            )
+            _labels_equal(target_properties, actual_properties, exact_order=True)
         )
 
     def test_unique_metadata_gradients_samples(self):
@@ -368,10 +327,10 @@ class TestUniqueMetadata(unittest.TestCase):
         samples = np.array([[0, -2], [0, 1], [0, 3], [1, -2], [2, -2], [2, 3], [3, 3]])
         snames = ["sample", "parameter"]
         target_samples = Labels(names=snames, values=samples)
-        actual_samples = fn.unique_metadata(self.tensor1, "samples", snames, parameter)
-        self.assertTrue(
-            fn._utils._labels_equal(actual_samples, target_samples, exact_order=True)
+        actual_samples = equistore.unique_metadata(
+            self.tensor1, "samples", snames, parameter
         )
+        self.assertTrue(_labels_equal(actual_samples, target_samples, exact_order=True))
 
     def test_unique_metadata_gradients_samples_incorrect_order(self):
         """
@@ -383,9 +342,11 @@ class TestUniqueMetadata(unittest.TestCase):
         samples = np.array([[0, -2], [0, 1], [0, 3], [2, -2], [1, -2], [2, 3], [3, 3]])
         snames = ["sample", "parameter"]
         target_samples = Labels(names=snames, values=samples)
-        actual_samples = fn.unique_metadata(self.tensor1, "samples", snames, parameter)
+        actual_samples = equistore.unique_metadata(
+            self.tensor1, "samples", snames, parameter
+        )
         self.assertFalse(
-            fn._utils._labels_equal(actual_samples, target_samples, exact_order=True)
+            _labels_equal(actual_samples, target_samples, exact_order=True)
         )
 
     def test_unique_metadata_gradients_properties(self):
@@ -396,13 +357,11 @@ class TestUniqueMetadata(unittest.TestCase):
         target_properties = Labels(
             names=pnames, values=np.array([[p] for p in properties])
         )
-        actual_properties = fn.unique_metadata(
+        actual_properties = equistore.unique_metadata(
             self.tensor1, "properties", pnames, parameter
         )
         self.assertTrue(
-            fn._utils._labels_equal(
-                target_properties, actual_properties, exact_order=True
-            )
+            _labels_equal(target_properties, actual_properties, exact_order=True)
         )
 
     def test_unique_metadata_gradients_properties_incorrect_order(self):
@@ -416,13 +375,11 @@ class TestUniqueMetadata(unittest.TestCase):
         target_properties = Labels(
             names=pnames, values=np.array([[p] for p in properties])
         )
-        actual_properties = fn.unique_metadata(
+        actual_properties = equistore.unique_metadata(
             self.tensor1, "properties", pnames, parameter
         )
         self.assertFalse(
-            fn._utils._labels_equal(
-                target_properties, actual_properties, exact_order=True
-            )
+            _labels_equal(target_properties, actual_properties, exact_order=True)
         )
 
     def test_unique_metadata_block_empty_labels(self):
@@ -432,19 +389,15 @@ class TestUniqueMetadata(unittest.TestCase):
             names=names, values=np.arange(len(names)).reshape(1, -1)
         )[:0]
         # names not in block - samples
-        actual_labels = fn.unique_metadata_block(
+        actual_labels = equistore.unique_metadata_block(
             self.tensor1.block(0), "samples", names=names
         )
-        self.assertTrue(
-            fn._utils._labels_equal(target_labels, actual_labels, exact_order=True)
-        )
+        self.assertTrue(_labels_equal(target_labels, actual_labels, exact_order=True))
         # names not in block - properties
-        actual_labels = fn.unique_metadata_block(
+        actual_labels = equistore.unique_metadata_block(
             self.tensor1.block(0), "properties", names=names
         )
-        self.assertTrue(
-            fn._utils._labels_equal(target_labels, actual_labels, exact_order=True)
-        )
+        self.assertTrue(_labels_equal(target_labels, actual_labels, exact_order=True))
 
     def test_unique_metadata_empty_labels(self):
         """Tests empty labels returned when passing names not in tensor"""
@@ -453,15 +406,13 @@ class TestUniqueMetadata(unittest.TestCase):
             names=names, values=np.arange(len(names)).reshape(1, -1)
         )[:0]
         # names not in block - samples
-        actual_labels = fn.unique_metadata(self.tensor1, "samples", names=names)
-        self.assertTrue(
-            fn._utils._labels_equal(target_labels, actual_labels, exact_order=True)
-        )
+        actual_labels = equistore.unique_metadata(self.tensor1, "samples", names=names)
+        self.assertTrue(_labels_equal(target_labels, actual_labels, exact_order=True))
         # names not in block - properties
-        actual_labels = fn.unique_metadata(self.tensor1, "properties", names=names)
-        self.assertTrue(
-            fn._utils._labels_equal(target_labels, actual_labels, exact_order=True)
+        actual_labels = equistore.unique_metadata(
+            self.tensor1, "properties", names=names
         )
+        self.assertTrue(_labels_equal(target_labels, actual_labels, exact_order=True))
 
 
 class TestUniqueMetadataErrors(unittest.TestCase):
@@ -480,14 +431,14 @@ class TestUniqueMetadataErrors(unittest.TestCase):
     def test_unique_metadata_block_type_errors(self):
         # TypeError with TM
         with self.assertRaises(TypeError) as cm:
-            fn.unique_metadata_block(self.tensor, "samples", ["structure"])
+            equistore.unique_metadata_block(self.tensor, "samples", ["structure"])
         self.assertEqual(
             str(cm.exception),
             "`block` must be an equistore `TensorBlock`",
         )
         # TypeError axis as float
         with self.assertRaises(TypeError) as cm:
-            fn.unique_metadata_block(self.block, 3.14, ["structure"])
+            equistore.unique_metadata_block(self.block, 3.14, ["structure"])
         self.assertEqual(
             str(cm.exception),
             "`axis` must be a `str`, either `'samples'` or `'properties'`,"
@@ -495,14 +446,16 @@ class TestUniqueMetadataErrors(unittest.TestCase):
         )
         # TypeError names as float
         with self.assertRaises(TypeError) as cm:
-            fn.unique_metadata_block(self.block, "properties", 3.14)
+            equistore.unique_metadata_block(self.block, "properties", 3.14)
         self.assertEqual(
             str(cm.exception),
             f"`names` must be a `list` of `str`, received {type(3.14)}",
         )
         # TypeError names as list of [str, float]
         with self.assertRaises(TypeError) as cm:
-            fn.unique_metadata_block(self.block, "properties", ["structure", 3.14])
+            equistore.unique_metadata_block(
+                self.block, "properties", ["structure", 3.14]
+            )
         self.assertEqual(
             str(cm.exception),
             "`names` must be a `list` of `str`, received"
@@ -510,7 +463,7 @@ class TestUniqueMetadataErrors(unittest.TestCase):
         )
         # TypeError gradient_param as float
         with self.assertRaises(TypeError) as cm:
-            fn.unique_metadata_block(
+            equistore.unique_metadata_block(
                 self.block, "properties", ["structure"], gradient_param=3.14
             )
         self.assertEqual(
@@ -521,7 +474,7 @@ class TestUniqueMetadataErrors(unittest.TestCase):
         """tests raising of value errors"""
         # ValueError axis not "samples" or "properties"
         with self.assertRaises(ValueError) as cm:
-            fn.unique_metadata_block(self.block, "ciao", ["structure"])
+            equistore.unique_metadata_block(self.block, "ciao", ["structure"])
         self.assertEqual(
             str(cm.exception),
             "`axis` must be passed as either `'samples'` or `'properties'`,"
@@ -529,7 +482,7 @@ class TestUniqueMetadataErrors(unittest.TestCase):
         )
         # ValueError gradient_param not a valid param for gradients
         with self.assertRaises(TypeError) as cm:
-            fn.unique_metadata_block(
+            equistore.unique_metadata_block(
                 self.block, "properties", ["structure"], gradient_param=3.14
             )
         self.assertEqual(
@@ -539,22 +492,22 @@ class TestUniqueMetadataErrors(unittest.TestCase):
     def test_unique_metadata_block_no_errors(self):
         """tests no raising of errors"""
         # No error names as str, list of str, or tuple of str
-        fn.unique_metadata_block(self.block, "samples", "structure")
-        fn.unique_metadata_block(self.block, "samples", ["structure"])
-        fn.unique_metadata_block(self.block, "samples", ("structure",))
+        equistore.unique_metadata_block(self.block, "samples", "structure")
+        equistore.unique_metadata_block(self.block, "samples", ["structure"])
+        equistore.unique_metadata_block(self.block, "samples", ("structure",))
 
     def test_unique_type_errors(self):
         """tests raising of type errors"""
         # TypeError with TB
         with self.assertRaises(TypeError) as cm:
-            fn.unique_metadata(self.block, "samples", ["structure"])
+            equistore.unique_metadata(self.block, "samples", ["structure"])
         self.assertEqual(
             str(cm.exception),
             "`tensor` must be an equistore `TensorMap`",
         )
         # TypeError axis as float
         with self.assertRaises(TypeError) as cm:
-            fn.unique_metadata(self.tensor, 3.14, ["structure"])
+            equistore.unique_metadata(self.tensor, 3.14, ["structure"])
         self.assertEqual(
             str(cm.exception),
             "`axis` must be a `str`, either `'samples'` or `'properties'`,"
@@ -562,14 +515,16 @@ class TestUniqueMetadataErrors(unittest.TestCase):
         )
         # TypeError names as float
         with self.assertRaises(TypeError) as cm:
-            fn.unique_metadata(self.tensor, "properties", 3.14)
+            equistore.unique_metadata(self.tensor, "properties", 3.14)
         self.assertEqual(
             str(cm.exception),
             f"`names` must be a `list` of `str`, received {type(3.14)}",
         )
         # TypeError names as list of [str, float]
         with self.assertRaises(TypeError) as cm:
-            fn.unique_metadata_block(self.block, "properties", ["structure", 3.14])
+            equistore.unique_metadata_block(
+                self.block, "properties", ["structure", 3.14]
+            )
         self.assertEqual(
             str(cm.exception),
             "`names` must be a `list` of `str`, received"
@@ -580,7 +535,7 @@ class TestUniqueMetadataErrors(unittest.TestCase):
         """tests raising of value errors"""
         # ValueError axis not "samples" or "properties"
         with self.assertRaises(ValueError) as cm:
-            fn.unique_metadata(self.tensor, "ciao", ["structure"])
+            equistore.unique_metadata(self.tensor, "ciao", ["structure"])
         self.assertEqual(
             str(cm.exception),
             "`axis` must be passed as either `'samples'` or `'properties'`,"
@@ -590,9 +545,9 @@ class TestUniqueMetadataErrors(unittest.TestCase):
     def test_unique_metadata_no_errors(self):
         """tests no raising of errors"""
         # No error names as str, list of str, or tuple of str
-        fn.unique_metadata(self.tensor, "properties", "n")
-        fn.unique_metadata(self.tensor, "properties", ["n"])
-        fn.unique_metadata(self.tensor, "properties", ("n",))
+        equistore.unique_metadata(self.tensor, "properties", "n")
+        equistore.unique_metadata(self.tensor, "properties", ["n"])
+        equistore.unique_metadata(self.tensor, "properties", ("n",))
 
 
 def test_tensor_map():

--- a/python/tests/operations/zeros_like.py
+++ b/python/tests/operations/zeros_like.py
@@ -3,8 +3,8 @@ import unittest
 
 import numpy as np
 
+import equistore
 import equistore.io
-import equistore.operations as fn
 
 
 DATA_ROOT = os.path.join(os.path.dirname(__file__), "..", "data")
@@ -17,7 +17,7 @@ class TestZeros_like(unittest.TestCase):
             # the npz is using DEFLATE compression, equistore only supports STORED
             use_numpy=True,
         )
-        zeros_tensor = fn.zeros_like(tensor)
+        zeros_tensor = equistore.zeros_like(tensor)
 
         self.assertTrue(np.all(tensor.keys == zeros_tensor.keys))
         for key, zeros_block in zeros_tensor:
@@ -62,8 +62,8 @@ class TestZeros_like(unittest.TestCase):
             # the npz is using DEFLATE compression, equistore only supports STORED
             use_numpy=True,
         )
-        zeros_tensor = fn.zeros_like(tensor)
-        zeros_tensor_positions = fn.zeros_like(tensor, parameters="positions")
+        zeros_tensor = equistore.zeros_like(tensor)
+        zeros_tensor_positions = equistore.zeros_like(tensor, parameters="positions")
 
         self.assertTrue(np.all(tensor.keys == zeros_tensor.keys))
         self.assertTrue(np.all(tensor.keys == zeros_tensor_positions.keys))
@@ -132,7 +132,7 @@ class TestZeros_like(unittest.TestCase):
         )
 
         with self.assertRaises(ValueError) as cm:
-            tensor = fn.zeros_like(tensor, parameters=["positions", "err"])
+            tensor = equistore.zeros_like(tensor, parameters=["positions", "err"])
         self.assertEqual(
             str(cm.exception),
             "The requested parameter 'err' in zeros_like_block "


### PR DESCRIPTION
As given in the title this moves all operations into the Python toplevel import i.e. `equistore.add` instead of `equistore.operations.add`. I also tried to highlight the oparations a bit more in the documentation.

<!-- readthedocs-preview equistore start -->
----
:books: Documentation preview :books:: https://equistore--135.org.readthedocs.build/en/135/

<!-- readthedocs-preview equistore end -->