### PR TITLE
Fix RTD post only running on PRs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -51,7 +51,8 @@ jobs:
           publish_dir: ./gh-pages/
           force_orphan: true
 
-      - name: Post link to RTD
+      - if: github.event_name == 'pull_request'
+        name: Post link to RTD
         uses: readthedocs/actions/preview@v1
         with:
           project-slug: "equistore"


### PR DESCRIPTION
The RTD post fails if it is not on a PR...

<!-- readthedocs-preview equistore start -->
----
:books: Documentation preview :books:: https://equistore--138.org.readthedocs.build/en/138/

<!-- readthedocs-preview equistore end -->