### PR TITLE
Change linear system solver from numpy to scipy

### DIFF
--- a/python/src/equistore/operations/_dispatch.py
+++ b/python/src/equistore/operations/_dispatch.py
@@ -112,7 +112,7 @@ def dot(A, B):
         raise TypeError(UNKNOWN_ARRAY_TYPE)
 
 
-def solve(X, Y):
+def solve(X, Y, solver="numpy", lower=None, check_finite=True, assume_a="gen"):
     """
     Computes the solution of a square system of linear equations with a unique
     solution.
@@ -121,7 +121,17 @@ def solve(X, Y):
     """
     if isinstance(X, np.ndarray):
         _check_all_same_type([Y], np.ndarray)
-        return np.linalg.solve(X, Y)
+        if solver == "scipy":
+            return scipy.linalg.solve(
+                X, Y, lower=lower, check_finite=check_finite, assume_a=assume_
+            )
+        elif solver == "numpy":
+            return np.linalg.solve(X, Y)
+        else:
+            raise ValueError(
+                "solver '{ndarray_solver}' for ndarrays is not known. 'scipy' and 'numpy' are supported."
+            )
+
     elif isinstance(X, TorchTensor):
         _check_all_same_type([Y], TorchTensor)
         result = torch.linalg.solve(X, Y)

--- a/python/src/equistore/operations/_dispatch.py
+++ b/python/src/equistore/operations/_dispatch.py
@@ -143,7 +143,8 @@ def solve(X, Y, solver="numpy", lower=None, check_finite=True, assume_a="gen"):
             return np.linalg.solve(X, Y)
         else:
             raise ValueError(
-                "solver '{ndarray_solver}' for ndarrays is not known. 'scipy' and 'numpy' are supported."
+                "solver '{ndarray_solver}' for ndarrays is not known. 'scipy' and \
+                'numpy' are supported."
             )
 
     elif isinstance(X, TorchTensor):

--- a/python/src/equistore/operations/_dispatch.py
+++ b/python/src/equistore/operations/_dispatch.py
@@ -132,7 +132,7 @@ def solve(X, Y, solver="numpy", lower=None, check_finite=True, assume_a="gen"):
         if solver == "scipy":
             if HAS_SCIPY:
                 return scipy.linalg.solve(
-                    X, Y, lower=lower, check_finite=check_finite, assume_a=assume_
+                    X, Y, lower=lower, check_finite=check_finite, assume_a=assume_a
                 )
             else:
                 raise ImportError(

--- a/python/src/equistore/operations/_dispatch.py
+++ b/python/src/equistore/operations/_dispatch.py
@@ -10,6 +10,14 @@ except ImportError:
         pass
 
 
+try:
+    import scipy
+
+    HAS_SCIPY = True
+except ImportError:
+    HAS_SCIPY = False
+
+
 UNKNOWN_ARRAY_TYPE = (
     "unknown array type, only numpy arrays and torch tensors are supported"
 )
@@ -122,9 +130,15 @@ def solve(X, Y, solver="numpy", lower=None, check_finite=True, assume_a="gen"):
     if isinstance(X, np.ndarray):
         _check_all_same_type([Y], np.ndarray)
         if solver == "scipy":
-            return scipy.linalg.solve(
-                X, Y, lower=lower, check_finite=check_finite, assume_a=assume_
-            )
+            if HAS_SCIPY:
+                return scipy.linalg.solve(
+                    X, Y, lower=lower, check_finite=check_finite, assume_a=assume_
+                )
+            else:
+                raise ImportError(
+                    "In `solve` scipy solver was specified, but scipy module not \
+                     found. Please install it and reimport equistore."
+                )
         elif solver == "numpy":
             return np.linalg.solve(X, Y)
         else:

--- a/python/src/equistore/operations/solve.py
+++ b/python/src/equistore/operations/solve.py
@@ -24,17 +24,18 @@ def solve(
 
     :param X: a :py:class:`TensorMap` containing the "coefficient" matrices.
     :param Y: a :py:class:`TensorMap` containing the "dependent variable" values.
-    :param solver: Used only if X and Y store data as ndarray's, decides if numpy's or scipy's solver are used
-    :param lower: Used only if X and Y store data as ndarray's and solver is 'scipy', argument passed to
-        scipy.linalg.solve, otherwise it is ignored. See
+    :param solver: Used only if X and Y store data as ndarray's, determines if numpy's
+        or scipy's solver are used
+    :param lower: Used only if X and Y store data as ndarray's and solver is 'scipy',
+        argument passed to scipy.linalg.solve, otherwise it is ignored. See
         https://docs.scipy.org/doc/scipy/reference/generated/scipy.linalg.solve.html
         for a full description of the parameter
-    :param check_finite: Used only if X and Y store data as ndarray's and solver is 'scipy', argument passed to
-        scipy.linalg.solve, otherwise it is ignored. See
+    :param check_finite: Used only if X and Y store data as ndarray's and solver is
+        'scipy', argument passed to scipy.linalg.solve, otherwise it is ignored. See
         https://docs.scipy.org/doc/scipy/reference/generated/scipy.linalg.solve.html
         for a full description of the parameter
-    :param assume_a: Used only if X and Y store data as ndarray's and solver is 'scipy', argument passed to
-        scipy.linalg.solve, otherwise it is ignored. See
+    :param assume_a: Used only if X and Y store data as ndarray's and solver is
+        'scipy', argument passed to scipy.linalg.solve, otherwise it is ignored. See
         https://docs.scipy.org/doc/scipy/reference/generated/scipy.linalg.solve.html
         for a full description of the parameter
 


### PR DESCRIPTION
The scipy linear system solver is by default using the same LAPACK function under the hood (_gesv), but also allows to use more efficient and/or more stable routines in the case the matrix has certain properties (e.g. positive definitene, symettric, Hermitian). For the Ridge class in equisolve we actually use the positive definiteness of the similarity matrix (A= X^TX, b =X^Ty, solving Aw=b). So I propose to change the solver to the scipy one

<!-- readthedocs-preview equistore start -->
----
:books: Documentation preview :books:: https://equistore--152.org.readthedocs.build/en/152/

<!-- readthedocs-preview equistore end -->