### PR TITLE
Convenience functions for Labels

### DIFF
--- a/python/src/equistore/labels.py
+++ b/python/src/equistore/labels.py
@@ -69,12 +69,6 @@ class Labels(np.ndarray):
             if key != "_eqs_labels_t":
                 raise ValueError(f"unexpected kwarg to Labels: {key}")
 
-        if not isinstance(values, np.ndarray):
-            raise ValueError("values parameter must be a numpy ndarray")
-
-        if len(values.shape) != 2:
-            raise ValueError("values parameter must be a 2D array")
-
         if isinstance(names, str):
             if len(names) == 0:
                 names = tuple()
@@ -82,6 +76,15 @@ class Labels(np.ndarray):
                 names = tuple(names)
         else:
             names = tuple(str(n) for n in names)
+
+        if not isinstance(values, np.ndarray):
+            raise ValueError("values parameter must be a numpy ndarray")
+
+        if len(values) == 0:
+            # if empty array of values we use the required correct 2d shape
+            values = np.zeros((0, len(names)), dtype=np.int32)
+        elif len(values.shape) != 2:
+            raise ValueError("values parameter must be a 2D array")
 
         if len(names) != values.shape[1]:
             raise ValueError(
@@ -150,6 +153,15 @@ class Labels(np.ndarray):
         contains a single block).
         """
         return Labels(names=["_"], values=np.zeros(shape=(1, 1), dtype=np.int32))
+
+    @staticmethod
+    def empty(names) -> "Labels":
+        """Label with given names but no values.
+
+        :param names: names of the variables in the new labels, in the case of a single
+                      name also a single string can be given: ``names = "name"``
+        """
+        return Labels(names=names, values=np.array([]))
 
     def as_namedtuples(self):
         """

--- a/python/tests/labels.py
+++ b/python/tests/labels.py
@@ -158,6 +158,25 @@ class TestLabels(unittest.TestCase):
             "invalid parameter: 'not an ident' is not a valid label name",
         )
 
+    def test_zero_length_label(self):
+        label = Labels(["sample", "structure", "atom"], np.array([]))
+        self.assertEqual(len(label), 0)
+
+    def test_labels_single(self):
+        label = Labels.single()
+        self.assertEqual(label.names, ("_",))
+        self.assertEqual(label.shape, (1,))
+
+    def test_labels_empty(self):
+        names = (
+            "foo",
+            "bar",
+            "baz",
+        )
+        label = Labels.empty(names)
+        self.assertEqual(label.names, names)
+        self.assertEqual(len(label), 0)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
If an empty array is given to the constructor of a `Labels` instance it is now automatically converted into the correct shape. This allows inputs like

```python
Labels(["sample", "structure", "atom"], np.array([]))
```

without manually reshaping as required before

```python
Labels(["sample", "structure", "atom"], np.zeros([0, 3], dtype=np.int32))
```

Also, a function Labels.empty() is added, allowing even simpler constructions like 

```python
Labels.empty(["sample", "structure", "atom"])
```

<!-- readthedocs-preview equistore start -->
----
:books: Documentation preview :books:: https://equistore--160.org.readthedocs.build/en/160/

<!-- readthedocs-preview equistore end -->