### PR TITLE
Add write permission to the doc builder on CI

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,6 +7,10 @@ on:
   pull_request:
     # Check all PR
 
+# We need write permission on PR to post the RTD link
+permissions:
+  pull-requests: write
+
 jobs:
   build-and-publish:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
This seems to be required to post messages on PR opened from a fork

<!-- readthedocs-preview equistore start -->
----
:books: Documentation preview :books:: https://equistore--163.org.readthedocs.build/en/163/

<!-- readthedocs-preview equistore end -->