### PR TITLE
Port Python core tests to pytest

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,3 +14,6 @@ indent = 4
 include_trailing_comma = true
 lines_after_imports = 2
 known_first_party = "equistore"
+
+[tool.pytest.ini_options]
+testpaths = "python/tests/*.py"

--- a/python/tests/blocks.py
+++ b/python/tests/blocks.py
@@ -1,11 +1,10 @@
-import unittest
-
 import numpy as np
+from numpy.testing import assert_equal
 
 from equistore import Labels, TensorBlock
 
 
-class TestBlocks(unittest.TestCase):
+class TestBlocks:
     def test_repr(self):
         block = TensorBlock(
             values=np.full((3, 2), -1.0),
@@ -18,7 +17,7 @@ class TestBlocks(unittest.TestCase):
     components (): []
     properties (2): ['properties']
     gradients: no"""
-        self.assertTrue(block.__repr__() == expected)
+        assert block.__repr__() == expected
 
     def test_block_no_components(self):
         block = TensorBlock(
@@ -28,20 +27,20 @@ class TestBlocks(unittest.TestCase):
             properties=Labels(["properties"], np.array([[5], [3]], dtype=np.int32)),
         )
 
-        self.assertTrue(np.all(block.values == np.full((3, 2), -1.0)))
+        assert_equal(block.values, np.full((3, 2), -1.0))
 
-        self.assertEqual(block.samples.names, ("samples",))
-        self.assertEqual(len(block.samples), 3)
-        self.assertEqual(tuple(block.samples[0]), (0,))
-        self.assertEqual(tuple(block.samples[1]), (2,))
-        self.assertEqual(tuple(block.samples[2]), (4,))
+        assert block.samples.names == ("samples",)
+        assert len(block.samples) == 3
+        assert tuple(block.samples[0]) == (0,)
+        assert tuple(block.samples[1]) == (2,)
+        assert tuple(block.samples[2]) == (4,)
 
-        self.assertEqual(len(block.components), 0)
+        assert len(block.components) == 0
 
-        self.assertEqual(block.properties.names, ("properties",))
-        self.assertEqual(len(block.properties), 2)
-        self.assertEqual(tuple(block.properties[0]), (5,))
-        self.assertEqual(tuple(block.properties[1]), (3,))
+        assert block.properties.names == ("properties",)
+        assert len(block.properties) == 2
+        assert tuple(block.properties[0]) == (5,)
+        assert tuple(block.properties[1]) == (3,)
 
     def test_block_with_components(self):
         block = TensorBlock(
@@ -58,34 +57,34 @@ class TestBlocks(unittest.TestCase):
     components (3, 2): ['component_1', 'component_2']
     properties (2): ['properties']
     gradients: no"""
-        self.assertTrue(block.__repr__() == expected)
+        assert block.__repr__() == expected
 
-        self.assertTrue(np.all(block.values == np.full((3, 3, 2, 2), -1.0)))
+        assert_equal(block.values, np.full((3, 3, 2, 2), -1.0))
 
-        self.assertEqual(block.samples.names, ("samples",))
-        self.assertEqual(len(block.samples), 3)
-        self.assertEqual(tuple(block.samples[0]), (0,))
-        self.assertEqual(tuple(block.samples[1]), (2,))
-        self.assertEqual(tuple(block.samples[2]), (4,))
+        assert block.samples.names == ("samples",)
+        assert len(block.samples) == 3
+        assert tuple(block.samples[0]) == (0,)
+        assert tuple(block.samples[1]) == (2,)
+        assert tuple(block.samples[2]) == (4,)
 
-        self.assertEqual(len(block.components), 2)
+        assert len(block.components) == 2
         component_1 = block.components[0]
-        self.assertEqual(component_1.names, ("component_1",))
-        self.assertEqual(len(component_1), 3)
-        self.assertEqual(tuple(component_1[0]), (-1,))
-        self.assertEqual(tuple(component_1[1]), (0,))
-        self.assertEqual(tuple(component_1[2]), (1,))
+        assert component_1.names == ("component_1",)
+        assert len(component_1) == 3
+        assert tuple(component_1[0]) == (-1,)
+        assert tuple(component_1[1]) == (0,)
+        assert tuple(component_1[2]) == (1,)
 
         component_2 = block.components[1]
-        self.assertEqual(component_2.names, ("component_2",))
-        self.assertEqual(len(component_2), 2)
-        self.assertEqual(tuple(component_2[0]), (-4,))
-        self.assertEqual(tuple(component_2[1]), (1,))
+        assert component_2.names == ("component_2",)
+        assert len(component_2) == 2
+        assert tuple(component_2[0]) == (-4,)
+        assert tuple(component_2[1]) == (1,)
 
-        self.assertEqual(block.properties.names, ("properties",))
-        self.assertEqual(len(block.properties), 2)
-        self.assertEqual(tuple(block.properties[0]), (5,))
-        self.assertEqual(tuple(block.properties[1]), (3,))
+        assert block.properties.names, ("properties",)
+        assert len(block.properties) == 2
+        assert tuple(block.properties[0]) == (5,)
+        assert tuple(block.properties[1]) == (3,)
 
     def test_gradients(self):
         block = TensorBlock(
@@ -115,12 +114,12 @@ class TestBlocks(unittest.TestCase):
     components (3, 2): ['component_1', 'component_2']
     properties (2): ['properties']
     gradients: ['parameter']"""
-        self.assertTrue(block.__repr__() == expected)
+        assert block.__repr__() == expected
 
-        self.assertTrue(block.has_gradient("parameter"))
-        self.assertFalse(block.has_gradient("something else"))
+        assert block.has_gradient("parameter")
+        assert not block.has_gradient("something else")
 
-        self.assertEqual(block.gradients_list(), ["parameter"])
+        assert block.gradients_list() == ["parameter"]
 
         gradient = block.gradient("parameter")
 
@@ -129,14 +128,14 @@ parameter: 'parameter'
 samples (2): ['sample', 'parameter']
 components (3, 2): ['component_1', 'component_2']
 properties (2): ['properties']"""
-        self.assertTrue(gradient.__repr__() == expected_grad)
+        assert gradient.__repr__() == expected_grad
 
-        self.assertEqual(gradient.samples.names, ("sample", "parameter"))
-        self.assertEqual(len(gradient.samples), 2)
-        self.assertEqual(tuple(gradient.samples[0]), (0, -2))
-        self.assertEqual(tuple(gradient.samples[1]), (2, 3))
+        assert gradient.samples.names == ("sample", "parameter")
+        assert len(gradient.samples) == 2
+        assert tuple(gradient.samples[0]) == (0, -2)
+        assert tuple(gradient.samples[1]) == (2, 3)
 
-        self.assertTrue(np.all(gradient.data == np.full((2, 3, 2, 2), 11.0)))
+        assert_equal(gradient.data, np.full((2, 3, 2, 2), 11.0))
 
     def test_copy(self):
         block = TensorBlock(
@@ -152,15 +151,11 @@ properties (2): ['properties']"""
 
         del block
 
-        self.assertNotEqual(id(copy.values), block_values_id)
+        assert id(copy.values) != block_values_id
 
-        self.assertTrue(np.all(copy.values == np.full((3, 3, 2), 2.0)))
-        self.assertEqual(copy.samples.names, ("samples",))
-        self.assertEqual(len(copy.samples), 3)
-        self.assertEqual(tuple(copy.samples[0]), (0,))
-        self.assertEqual(tuple(copy.samples[1]), (2,))
-        self.assertEqual(tuple(copy.samples[2]), (4,))
-
-
-if __name__ == "__main__":
-    unittest.main()
+        assert_equal(copy.values, np.full((3, 3, 2), 2.0))
+        assert copy.samples.names == ("samples",)
+        assert len(copy.samples) == 3
+        assert tuple(copy.samples[0]) == (0,)
+        assert tuple(copy.samples[1]) == (2,)
+        assert tuple(copy.samples[2]) == (4,)

--- a/python/tests/data.py
+++ b/python/tests/data.py
@@ -1,9 +1,9 @@
 import gc
 import os
-import unittest
 import weakref
 
 import numpy as np
+from numpy.testing import assert_equal
 
 
 try:
@@ -28,19 +28,16 @@ def free_eqs_array(array):
     array.destroy(array.ptr)
 
 
-class TestArrayWrapperMixin:
+class ArrayWrapperMixin:
     def test_origin(self):
         array = self.create_array((2, 3, 4))
         wrapper = data.ArrayWrapper(array)
         eqs_array = wrapper.into_eqs_array()
 
-        self.assertEqual(
-            id(data.eqs_array_to_python_array(eqs_array)),
-            id(array),
-        )
+        assert id(data.eqs_array_to_python_array(eqs_array)) == id(array)
 
         origin = data.data_origin(eqs_array)
-        self.assertEqual(data.data_origin_name(origin), self.expected_origin())
+        assert data.data_origin_name(origin) == self.expected_origin()
 
         free_eqs_array(eqs_array)
 
@@ -49,13 +46,13 @@ class TestArrayWrapperMixin:
         wrapper = data.ArrayWrapper(array)
         eqs_array = wrapper.into_eqs_array()
 
-        self.assertEqual(_get_shape(eqs_array, self), [2, 3, 4])
+        assert _get_shape(eqs_array, self) == [2, 3, 4]
 
         new_shape = ctypes.ARRAY(c_uintptr_t, 4)(2, 3, 2, 2)
         status = eqs_array.reshape(eqs_array.ptr, new_shape, len(new_shape))
-        self.assertEqual(status, EQS_SUCCESS)
+        assert status == EQS_SUCCESS
 
-        self.assertEqual(_get_shape(eqs_array, self), [2, 3, 2, 2])
+        assert _get_shape(eqs_array, self) == [2, 3, 2, 2]
 
         free_eqs_array(eqs_array)
 
@@ -65,7 +62,7 @@ class TestArrayWrapperMixin:
         eqs_array = wrapper.into_eqs_array()
 
         eqs_array.swap_axes(eqs_array.ptr, 1, 3)
-        self.assertEqual(_get_shape(eqs_array, self), [2, 23, 18, 3])
+        assert _get_shape(eqs_array, self) == [2, 23, 18, 3]
 
         free_eqs_array(eqs_array)
 
@@ -81,25 +78,25 @@ class TestArrayWrapperMixin:
         status = eqs_array.create(
             eqs_array.ptr, new_shape, len(new_shape), new_eqs_array
         )
-        self.assertEqual(status, EQS_SUCCESS)
+        assert status == EQS_SUCCESS
 
         new_array = data.eqs_array_to_python_array(new_eqs_array)
-        self.assertNotEqual(id(new_array), id(array))
+        assert id(new_array) != id(array)
 
-        self.assertTrue(np.all(np.array(new_array) == np.zeros((18, 4))))
+        assert_equal(new_array, np.zeros((18, 4)))
 
         del array
         del wrapper
         gc.collect()
 
         # there is still one reference to the array through eqs_array
-        self.assertIsNotNone(array_ref())
+        assert array_ref() is not None
 
         free_eqs_array(eqs_array)
         del eqs_array
         gc.collect()
 
-        self.assertIsNone(array_ref())
+        assert array_ref() is None
 
         free_eqs_array(new_eqs_array)
 
@@ -112,12 +109,12 @@ class TestArrayWrapperMixin:
 
         copy = eqs_array_t()
         status = eqs_array.copy(eqs_array.ptr, copy)
-        self.assertEqual(status, EQS_SUCCESS)
+        assert status == EQS_SUCCESS
 
         array_copy = data.eqs_array_to_python_array(copy)
-        self.assertNotEqual(id(array_copy), id(array))
+        assert id(array_copy) != id(array)
 
-        self.assertTrue(np.all(np.array(array_copy) == np.array(array)))
+        assert_equal(np.array(array_copy), np.array(array))
 
         free_eqs_array(eqs_array)
         free_eqs_array(copy)
@@ -160,13 +157,13 @@ class TestArrayWrapperMixin:
                 ],
             ]
         )
-        self.assertTrue(np.all(np.array(array) == expected))
+        assert_equal(array, expected)
 
         free_eqs_array(eqs_array)
         free_eqs_array(eqs_array_other)
 
 
-class TestNumpyData(unittest.TestCase, TestArrayWrapperMixin):
+class TestNumpyData(ArrayWrapperMixin):
     def expected_origin(self):
         return "equistore.data.array.numpy"
 
@@ -176,7 +173,7 @@ class TestNumpyData(unittest.TestCase, TestArrayWrapperMixin):
 
 if HAS_TORCH:
 
-    class TestTorchData(unittest.TestCase, TestArrayWrapperMixin):
+    class TestTorchData(ArrayWrapperMixin):
         def expected_origin(self):
             return "equistore.data.array.torch"
 
@@ -189,7 +186,7 @@ def _get_shape(eqs_array, test):
     shape_count = c_uintptr_t()
     status = eqs_array.shape(eqs_array.ptr, shape_ptr, shape_count)
 
-    test.assertEqual(status, EQS_SUCCESS)
+    assert status == EQS_SUCCESS
 
     shape = []
     for i in range(shape_count.value):
@@ -224,38 +221,34 @@ def create_test_array(shape_ptr, shape_count, array):
     array[0] = eqs_array
 
 
-class TestRustData(unittest.TestCase):
+class TestRustData:
     def test_parent_keepalive(self):
         path = os.path.join(ROOT, "..", "..", "equistore-core", "tests", "data.npz")
         tensor = equistore.io.load_custom_array(path, create_test_array)
 
         values = tensor.block(0).values
-        self.assertTrue(isinstance(values, equistore.data.extract.ExternalCpuArray))
-        self.assertIsNotNone(values._parent)
+        assert isinstance(values, equistore.data.extract.ExternalCpuArray)
+        assert values._parent is not None
 
         tensor_ref = weakref.ref(tensor)
         del tensor
         gc.collect()
 
         # values should keep the tensor alive
-        self.assertIsNotNone(tensor_ref())
+        assert tensor_ref() is not None
 
         view = values[::2]
         del values
         gc.collect()
 
         # view should keep the tensor alive
-        self.assertIsNotNone(tensor_ref())
+        assert tensor_ref() is not None
 
         transformed = np.sum(view)
         del view
         gc.collect()
 
         # transformed should NOT keep the tensor alive
-        self.assertIsNone(tensor_ref())
+        assert tensor_ref() is None
 
-        self.assertTrue(np.isclose(transformed, 1.1596965632269784))
-
-
-if __name__ == "__main__":
-    unittest.main()
+        assert np.isclose(transformed, 1.1596965632269784)

--- a/python/tests/labels.py
+++ b/python/tests/labels.py
@@ -1,23 +1,23 @@
-import unittest
-
 import numpy as np
-from utils import test_tensor_map
+import pytest
+from numpy.testing import assert_equal
+from utils import tensor_map
 
 from equistore import EquistoreError, Labels
 
 
-class TestLabels(unittest.TestCase):
+class TestLabels:
     def test_python_labels(self):
         labels = Labels(
             names=["a", "b"],
             values=np.array([[0, 0]], dtype=np.int32),
         )
 
-        self.assertEqual(labels.names, ("a", "b"))
-        self.assertEqual(len(labels), 1)
-        self.assertEqual(tuple(labels[0]), (0, 0))
+        assert labels.names == ("a", "b")
+        assert len(labels) == 1
+        assert tuple(labels[0]) == (0, 0)
 
-        self.assertTrue(np.all(labels.asarray() == np.array([[0, 0]])))
+        assert_equal(labels.asarray(), np.array([[0, 0]]))
 
         # check we can use single str for single name
         labels = Labels(
@@ -29,15 +29,15 @@ class TestLabels(unittest.TestCase):
             values=np.array([[1]], dtype=np.int32),
         )
 
-        self.assertEqual(labels.names, ("a",))
-        self.assertEqual(labels.names, labels_str.names)
-        self.assertEqual(len(labels), 1)
-        self.assertEqual(len(labels_str), 1)
-        self.assertEqual(tuple(labels_str[0]), (1,))
-        self.assertEqual(tuple(labels_str[0]), tuple(labels[0]))
+        assert labels.names == ("a",)
+        assert labels.names == labels_str.names
+        assert len(labels) == 1
+        assert len(labels_str) == 1
+        assert tuple(labels_str[0]) == (1,)
+        assert tuple(labels_str[0]) == tuple(labels[0])
 
-        self.assertTrue(np.all(labels.asarray() == np.array([[1]])))
-        self.assertTrue(np.all(labels.asarray() == labels_str.asarray()))
+        assert_equal(labels.asarray(), np.array([[1]]))
+        assert_equal(labels.asarray(), labels_str.asarray())
 
         # check empty arrays
         labels = Labels(
@@ -50,14 +50,14 @@ class TestLabels(unittest.TestCase):
             values=np.array([[]], dtype=np.int32),
         )
 
-        self.assertEqual(labels.names, [])
-        self.assertEqual(labels.names, labels_str.names)
-        self.assertEqual(len(labels), 1)
-        self.assertEqual(len(labels_str), 1)
-        self.assertEqual(tuple(labels_str[0]), tuple(labels[0]))
+        assert labels.names == []
+        assert labels.names == labels_str.names
+        assert len(labels) == 1
+        assert len(labels_str) == 1
+        assert tuple(labels_str[0]) == tuple(labels[0])
 
-        self.assertTrue(np.all(labels.asarray() == np.array([[]])))
-        self.assertTrue(np.all(labels.asarray() == labels_str.asarray()))
+        assert_equal(labels.asarray(), np.array([[]]))
+        assert_equal(labels.asarray(), labels_str.asarray())
 
         # check that we can convert from more than strict 2D arrays of int32
         labels = Labels(
@@ -70,26 +70,23 @@ class TestLabels(unittest.TestCase):
             values=np.array([[0, 0]], dtype=np.int64),
         )
 
-        with self.assertRaises(TypeError) as cm:
+        with pytest.raises(
+            TypeError, match="Labels values must be convertible to integers"
+        ):
             labels = Labels(
-                names=["a", "b"],
-                values=np.array([[0, 0]], dtype=np.float64),
+                names=["a", "b"], values=np.array([[0, 0]], dtype=np.float64)
             )
-        self.assertEqual(
-            str(cm.exception),
-            "Labels values must be convertible to integers",
-        )
 
     def test_native_labels(self):
-        tensor = test_tensor_map()
+        tensor = tensor_map()
         labels = tensor.keys
 
-        self.assertEqual(labels.names, ("key_1", "key_2"))
-        self.assertEqual(len(labels), 4)
-        self.assertEqual(tuple(labels[0]), (0, 0))
-        self.assertEqual(tuple(labels[1]), (1, 0))
-        self.assertEqual(tuple(labels[2]), (2, 2))
-        self.assertEqual(tuple(labels[3]), (2, 3))
+        assert labels.names == ("key_1", "key_2")
+        assert len(labels) == 4
+        assert tuple(labels[0]) == (0, 0)
+        assert tuple(labels[1]) == (1, 0)
+        assert tuple(labels[2]) == (2, 2)
+        assert tuple(labels[3]) == (2, 3)
 
         expected = np.array(
             [
@@ -99,73 +96,71 @@ class TestLabels(unittest.TestCase):
                 [2, 3],
             ]
         )
-        self.assertTrue(np.all(labels.asarray() == expected))
+        assert_equal(labels.asarray(), expected)
 
     def test_position(self):
-        tensor = test_tensor_map()
+        tensor = tensor_map()
         labels = tensor.keys
 
-        self.assertEqual(labels.position((0, 0)), 0)
-        self.assertEqual(labels.position((2, 3)), 3)
-        self.assertEqual(labels.position((2, -1)), None)
+        assert labels.position((0, 0)) == 0
+        assert labels.position((2, 3)) == 3
+        assert labels.position((2, -1)) is None
 
     def test_contains(self):
-        tensor = test_tensor_map()
+        tensor = tensor_map()
         labels = tensor.keys
 
-        self.assertTrue((0, 0) in labels)
-        self.assertTrue((2, 3) in labels)
-        self.assertFalse((2, -1) in labels)
+        assert (0, 0) in labels
+        assert (2, 3) in labels
+        assert (2, -1) not in labels
 
     def test_named_tuples(self):
-        tensor = test_tensor_map()
+        tensor = tensor_map()
         labels = tensor.keys
 
         iterator = labels.as_namedtuples()
         first = next(iterator)
 
-        self.assertTrue(isinstance(first, tuple))
-        self.assertTrue(hasattr(first, "_fields"))
+        assert isinstance(first, tuple)
+        assert hasattr(first, "_fields")
 
-        self.assertEqual(first.key_1, 0)
-        self.assertEqual(first.key_2, 0)
-        self.assertEqual(first.as_dict(), {"key_1": 0, "key_2": 0})
+        assert first.key_1 == 0
+        assert first.key_2 == 0
+        assert first.as_dict() == {"key_1": 0, "key_2": 0}
 
-        self.assertEqual(first, (0, 0))
-        self.assertEqual(next(iterator), (1, 0))
-        self.assertEqual(next(iterator), (2, 2))
-        self.assertEqual(next(iterator), (2, 3))
+        assert first == (0, 0)
+        assert next(iterator) == (1, 0)
+        assert next(iterator) == (2, 2)
+        assert next(iterator) == (2, 3)
 
-        self.assertRaises(StopIteration, next, iterator)
+        with pytest.raises(StopIteration):
+            next(iterator)
 
     def test_not_writeable(self):
-        tensor = test_tensor_map()
+        tensor = tensor_map()
         labels = tensor.keys
 
-        with self.assertRaises(ValueError) as cm:
+        with pytest.raises(ValueError, match="assignment destination is read-only"):
             labels[0][0] = 4
 
-        self.assertEqual(str(cm.exception), "assignment destination is read-only")
-
     def test_invalid_names(self):
-        with self.assertRaises(EquistoreError) as cm:
+        with pytest.raises(
+            EquistoreError,
+            match="invalid parameter: 'not an ident' is not a valid label name",
+        ):
             _ = Labels(
                 names=["not an ident"],
                 values=np.array([[0]], dtype=np.int32),
             )
-        self.assertEqual(
-            str(cm.exception),
-            "invalid parameter: 'not an ident' is not a valid label name",
-        )
 
     def test_zero_length_label(self):
         label = Labels(["sample", "structure", "atom"], np.array([]))
-        self.assertEqual(len(label), 0)
+        assert len(label) == 0
 
     def test_labels_single(self):
         label = Labels.single()
-        self.assertEqual(label.names, ("_",))
-        self.assertEqual(label.shape, (1,))
+        assert label.names == ("_",)
+        assert label.shape == (1,)
 
     def test_labels_empty(self):
         names = (
@@ -174,9 +169,5 @@ class TestLabels(unittest.TestCase):
             "baz",
         )
         label = Labels.empty(names)
-        self.assertEqual(label.names, names)
-        self.assertEqual(len(label), 0)
-
-
-if __name__ == "__main__":
-    unittest.main()
+        assert label.names == names
+        assert len(label) == 0

--- a/python/tests/operations/unique_metadata.py
+++ b/python/tests/operations/unique_metadata.py
@@ -18,8 +18,8 @@ class TestUniqueMetadata(unittest.TestCase):
     TensorBlock"""
 
     def setUp(self):
-        self.tensor1 = test_tensor_map()  # Test case 1
-        self.tensor2 = test_large_tensor_map()  # Test case 2
+        self.tensor1 = tensor_map()  # Test case 1
+        self.tensor2 = large_tensor_map()  # Test case 2
         self.tensor3 = equistore.io.load(  # Test case 3
             os.path.join(DATA_ROOT, TEST_FILE),
             use_numpy=True,
@@ -550,7 +550,7 @@ class TestUniqueMetadataErrors(unittest.TestCase):
         equistore.unique_metadata(self.tensor, "properties", ("n",))
 
 
-def test_tensor_map():
+def tensor_map():
     """
     Create a dummy tensor map to be used in tests. This is the same one as the
     tensor map used in `tensor.rs` tests.
@@ -628,12 +628,12 @@ def test_tensor_map():
     return TensorMap(keys, [block_1, block_2, block_3, block_4])
 
 
-def test_large_tensor_map():
+def large_tensor_map():
     """
     Create a dummy tensor map of 16 blocks to be used in tests. This is the same
     tensor map used in `tensor.rs` tests.
     """
-    tensor = test_tensor_map()
+    tensor = tensor_map()
     block_list = [block.copy() for _, block in tensor]
 
     for i in range(8):

--- a/python/tests/serialization.py
+++ b/python/tests/serialization.py
@@ -1,9 +1,9 @@
 import os
-import tempfile
-import unittest
 
 import numpy as np
-from utils import test_tensor_map
+import pytest
+from numpy.testing import assert_equal
+from utils import tensor_map
 
 import equistore.io
 from equistore import TensorMap
@@ -12,72 +12,55 @@ from equistore import TensorMap
 ROOT = os.path.dirname(__file__)
 
 
-class TestIo(unittest.TestCase):
-    def test_load(self):
-        def check(tensor):
-            self.assertIsInstance(tensor, TensorMap)
-            self.assertEqual(
-                tensor.keys.names,
-                ("spherical_harmonics_l", "center_species", "neighbor_species"),
-            )
-            self.assertEqual(len(tensor.keys), 27)
+class TestIo:
+    @pytest.mark.parametrize("use_numpy", (True, False))
+    def test_load(self, use_numpy):
+        tensor = equistore.io.load(
+            os.path.join(ROOT, "..", "..", "equistore-core", "tests", "data.npz"),
+            use_numpy=use_numpy,
+        )
 
-            block = tensor.block(
-                spherical_harmonics_l=2, center_species=6, neighbor_species=1
-            )
-            self.assertEqual(block.samples.names, ("structure", "center"))
-            self.assertEqual(block.values.shape, (9, 5, 3))
+        assert isinstance(tensor, TensorMap)
+        assert tensor.keys.names == (
+            "spherical_harmonics_l",
+            "center_species",
+            "neighbor_species",
+        )
+        assert len(tensor.keys) == 27
 
-            gradient = block.gradient("positions")
-            self.assertEqual(gradient.samples.names, ("sample", "structure", "atom"))
-            self.assertEqual(gradient.data.shape, (59, 3, 5, 3))
+        block = tensor.block(
+            spherical_harmonics_l=2, center_species=6, neighbor_species=1
+        )
+        assert block.samples.names == ("structure", "center")
+        assert block.values.shape == (9, 5, 3)
 
-        path = os.path.join(ROOT, "..", "..", "equistore-core", "tests", "data.npz")
+        gradient = block.gradient("positions")
+        assert gradient.samples.names == ("sample", "structure", "atom")
+        assert gradient.data.shape == (59, 3, 5, 3)
 
-        tensor = equistore.io.load(path, use_numpy=False)
-        check(tensor)
+    @pytest.mark.parametrize("use_numpy", (True, False))
+    def test_save(self, use_numpy, tmpdir):
+        """Check that as saved file loads fine with numpy."""
+        tensor = tensor_map()
+        tmpfile = "serialize-test.npz"
 
-        tensor = equistore.io.load(path, use_numpy=True)
-        check(tensor)
+        with tmpdir.as_cwd():
+            equistore.io.save(tmpfile, tensor, use_numpy=use_numpy)
+            data = np.load(tmpfile)
 
-    def test_save(self):
-        def check_file(path, tensor):
-            # check that the file loads fine with numpy
-            data = np.load(path)
-            self.assertEqual(len(data.keys()), 29)
+        assert len(data.keys()) == 29
 
-            self.assertTrue(np.all(data["keys"] == tensor.keys))
-            for i, (_, block) in enumerate(tensor):
-                prefix = f"blocks/{i}/values"
-                self.assertTrue(np.all(data[f"{prefix}/data"] == block.values))
-                self.assertTrue(np.all(data[f"{prefix}/samples"] == block.samples))
-                self.assertTrue(
-                    np.all(data[f"{prefix}/components/0"] == block.components[0])
-                )
-                self.assertTrue(
-                    np.all(data[f"{prefix}/properties"] == block.properties)
-                )
+        assert_equal(data["keys"], tensor.keys)
+        for i, (_, block) in enumerate(tensor):
+            prefix = f"blocks/{i}/values"
+            assert_equal(data[f"{prefix}/data"], block.values)
+            assert_equal(data[f"{prefix}/samples"], block.samples)
+            assert_equal(data[f"{prefix}/components/0"], block.components[0])
+            assert_equal(data[f"{prefix}/properties"], block.properties)
 
-                for parameter in block.gradients_list():
-                    gradient = block.gradient(parameter)
-                    prefix = f"blocks/{i}/gradients/{parameter}"
-                    self.assertTrue(np.all(data[f"{prefix}/data"] == gradient.data))
-                    self.assertTrue(
-                        np.all(data[f"{prefix}/samples"] == gradient.samples)
-                    )
-                    self.assertTrue(
-                        np.all(data[f"{prefix}/components/0"] == gradient.components[0])
-                    )
-
-        tmpfile = os.path.join(tempfile.gettempdir(), "serialize-test.npz")
-        tensor = test_tensor_map()
-
-        equistore.io.save(tmpfile, tensor, use_numpy=False)
-        check_file(tmpfile, tensor)
-
-        equistore.io.save(tmpfile, tensor, use_numpy=True)
-        check_file(tmpfile, tensor)
-
-
-if __name__ == "__main__":
-    unittest.main()
+            for parameter in block.gradients_list():
+                gradient = block.gradient(parameter)
+                prefix = f"blocks/{i}/gradients/{parameter}"
+                assert_equal(data[f"{prefix}/data"], gradient.data)
+                assert_equal(data[f"{prefix}/samples"], gradient.samples)
+                assert_equal(data[f"{prefix}/components/0"], gradient.components[0])

--- a/python/tests/tensor.py
+++ b/python/tests/tensor.py
@@ -1,37 +1,37 @@
-import unittest
-
 import numpy as np
-from utils import test_large_tensor_map, test_tensor_map
+import pytest
+from numpy.testing import assert_equal
+from utils import large_tensor_map, tensor_map
 
 
-class TestTensorMap(unittest.TestCase):
+class TestTensorMap:
     def test_copy(self):
-        tensor = test_tensor_map()
+        tensor = tensor_map()
         copy = tensor.copy()
         block_1_values_id = id(tensor.block(0).values)
 
         del tensor
 
-        self.assertNotEqual(id(copy.block(0).values), block_1_values_id)
+        assert id(copy.block(0).values) != block_1_values_id
 
-        self.assertTrue(np.all(copy.block(0).values == np.full((3, 1, 1), 1.0)))
+        assert_equal(copy.block(0).values, np.full((3, 1, 1), 1.0))
 
     def test_keys(self):
-        tensor = test_tensor_map()
-        self.assertEqual(tensor.keys.names, ("key_1", "key_2"))
-        self.assertEqual(len(tensor.keys), 4)
-        self.assertEqual(len(tensor), 4)
-        self.assertEqual(tuple(tensor.keys[0]), (0, 0))
-        self.assertEqual(tuple(tensor.keys[1]), (1, 0))
-        self.assertEqual(tuple(tensor.keys[2]), (2, 2))
-        self.assertEqual(tuple(tensor.keys[3]), (2, 3))
+        tensor = tensor_map()
+        assert tensor.keys.names == ("key_1", "key_2")
+        assert len(tensor.keys) == 4
+        assert len(tensor) == 4
+        assert tuple(tensor.keys[0]) == (0, 0)
+        assert tuple(tensor.keys[1]) == (1, 0)
+        assert tuple(tensor.keys[2]) == (2, 2)
+        assert tuple(tensor.keys[3]) == (2, 3)
 
     def test_print(self):
         """
         Test routine for the print function of the TensorBlock.
         It compare the results with those in a file.
         """
-        tensor = test_tensor_map()
+        tensor = tensor_map()
         repr = tensor.__repr__()
         expected = """TensorMap with 4 blocks
 keys: ['key_1' 'key_2']
@@ -39,9 +39,10 @@ keys: ['key_1' 'key_2']
           1       0
           2       2
           2       3"""
-        self.assertTrue(expected == repr)
+        assert expected == repr
 
-        tensor = test_large_tensor_map()
+    def test_print_large(self):
+        tensor = large_tensor_map()
         _print = tensor.__repr__()
         expected = """TensorMap with 12 blocks
 keys: ['key_1' 'key_2']
@@ -52,153 +53,137 @@ keys: ['key_1' 'key_2']
           1       5
           2       5
           3       5"""
-        self.assertTrue(expected == _print)
+        assert expected == _print
 
     def test_labels_names(self):
-        tensor = test_tensor_map()
+        tensor = tensor_map()
 
-        self.assertEqual(tensor.sample_names, ("samples",))
-        self.assertEqual(tensor.components_names, [("components",)])
-        self.assertEqual(tensor.property_names, ("properties",))
+        assert tensor.sample_names == ("samples",)
+        assert tensor.components_names == [("components",)]
+        assert tensor.property_names == ("properties",)
 
     def test_block(self):
-        tensor = test_tensor_map()
+        tensor = tensor_map()
 
         # block by index
         block = tensor.block(2)
-        self.assertTrue(np.all(block.values == np.full((4, 3, 1), 3.0)))
+        assert_equal(block.values, np.full((4, 3, 1), 3.0))
 
         # block by index with __getitem__
         block = tensor[2]
-        self.assertTrue(np.all(block.values == np.full((4, 3, 1), 3.0)))
+        assert_equal(block.values, np.full((4, 3, 1), 3.0))
 
         # block by kwargs
         block = tensor.block(key_1=1, key_2=0)
-        self.assertTrue(np.all(block.values == np.full((3, 1, 1), 2.0)))
+        assert_equal(block.values, np.full((3, 1, 3), 2.0))
 
         # block by Label entry
         block = tensor.block(tensor.keys[0])
-        self.assertTrue(np.all(block.values == np.full((3, 1, 1), 1.0)))
+        assert_equal(block.values, np.full((3, 1, 1), 1.0))
 
         # block by Label entry with __getitem__
         block = tensor[tensor.keys[0]]
-        self.assertTrue(np.all(block.values == np.full((3, 1, 1), 1.0)))
+        assert_equal(block.values, np.full((3, 1, 1), 1.0))
 
         # More arguments than needed: two integers
         # by index
-        with self.assertRaises(ValueError) as cm:
+        with pytest.raises(
+            ValueError, match="only one non-keyword argument is supported, 2 are given"
+        ):
             tensor.block(3, 4)
 
-        self.assertEqual(
-            str(cm.exception),
-            "only one non-keyword argument is supported, 2 are given",
-        )
-
         # 4 input with the first as integer by __getitem__
-        with self.assertRaises(ValueError) as cm:
+        with pytest.raises(
+            ValueError, match="only one non-keyword argument is supported, 4 are given"
+        ):
             tensor[3, 4, 7.0, "r"]
 
-        self.assertEqual(
-            str(cm.exception),
-            "only one non-keyword argument is supported, 4 are given",
-        )
-
         # More arguments than needed: 3 Labels
-        with self.assertRaises(ValueError) as cm:
+        with pytest.raises(
+            ValueError, match="only one non-keyword argument is supported, 3 are given"
+        ):
             tensor.block(tensor.keys[0], tensor.keys[1], tensor.keys[3])
 
-        self.assertEqual(
-            str(cm.exception),
-            "only one non-keyword argument is supported, 3 are given",
-        )
-
         # by __getitem__
-        with self.assertRaises(ValueError) as cm:
+        with pytest.raises(
+            ValueError, match="only one non-keyword argument is supported, 2 are given"
+        ):
             tensor[tensor.keys[1], 4]
 
-        self.assertEqual(
-            str(cm.exception),
-            "only one non-keyword argument is supported, 2 are given",
-        )
-
         # 0 blocks matching criteria
-        with self.assertRaises(ValueError) as cm:
+        with pytest.raises(
+            ValueError,
+            match="Couldn't find any block matching the selection 'key_1 = 3'",
+        ):
             tensor.block(key_1=3)
 
-        self.assertEqual(
-            str(cm.exception),
-            "Couldn't find any block matching the selection 'key_1 = 3'",
-        )
-
         # more than one block matching criteria
-        with self.assertRaises(ValueError) as cm:
+        with pytest.raises(
+            ValueError,
+            match="more than one block matched 'key_2 = 0', use `TensorMap.blocks` "
+            "if you want to get all of them",
+        ):
             tensor.block(key_2=0)
 
-        self.assertEqual(
-            str(cm.exception),
-            "more than one block matched 'key_2 = 0', use `TensorMap.blocks` "
-            "if you want to get all of them",
-        )
-
     def test_blocks(self):
-        tensor = test_tensor_map()
+        tensor = tensor_map()
 
         # block by index
         blocks = tensor.blocks(2)
-        self.assertEqual(len(blocks), 1)
-        self.assertTrue(np.all(blocks[0].values == np.full((4, 3, 1), 3.0)))
+        assert len(blocks) == 1
+        assert_equal(blocks[0].values, np.full((4, 3, 1), 3.0))
 
         # block by kwargs
         blocks = tensor.blocks(key_1=1, key_2=0)
-        self.assertEqual(len(blocks), 1)
-        self.assertTrue(np.all(blocks[0].values == np.full((3, 1, 1), 2.0)))
+        assert len(blocks) == 1
+        assert_equal(blocks[0].values, np.full((3, 1, 3), 2.0))
 
         # more than one block
         blocks = tensor.blocks(key_2=0)
-        self.assertEqual(len(blocks), 2)
+        assert len(blocks) == 2
 
-        self.assertTrue(np.all(blocks[0].values == np.full((3, 1, 1), 1.0)))
-        self.assertTrue(np.all(blocks[1].values == np.full((3, 1, 3), 2.0)))
+        assert_equal(blocks[0].values, np.full((3, 1, 1), 1.0))
+        assert_equal(blocks[1].values, np.full((3, 1, 3), 2.0))
 
     def test_iter(self):
         expected = [
             ((0, 0), np.full((3, 1, 1), 1.0)),
-            ((1, 0), np.full((3, 1, 1), 2.0)),
+            ((1, 0), np.full((3, 1, 3), 2.0)),
             ((2, 2), np.full((4, 3, 1), 3.0)),
             ((2, 3), np.full((4, 3, 1), 4.0)),
         ]
 
-        tensor = test_tensor_map()
+        tensor = tensor_map()
         for i, (sparse, block) in enumerate(tensor):
             expected_sparse, expected_values = expected[i]
 
-            self.assertEqual(tuple(sparse), expected_sparse)
-            self.assertTrue(np.all(block.values == expected_values))
+            assert tuple(sparse) == expected_sparse
+            assert_equal(block.values, expected_values)
 
     def test_keys_to_properties(self):
-        tensor = test_tensor_map().keys_to_properties("key_1")
+        tensor = tensor_map().keys_to_properties("key_1")
 
-        self.assertEqual(tensor.keys.names, ("key_2",))
-        self.assertEqual(tuple(tensor.keys[0]), (0,))
-        self.assertEqual(tuple(tensor.keys[1]), (2,))
-        self.assertEqual(tuple(tensor.keys[2]), (3,))
+        assert tensor.keys.names == ("key_2",)
+        assert tuple(tensor.keys[0]) == (0,)
+        assert tuple(tensor.keys[1]) == (2,)
+        assert tuple(tensor.keys[2]) == (3,)
 
         # The new first block contains the old first two blocks merged
         block = tensor.block(0)
-        self.assertEqual(tuple(block.samples[0]), (0,))
-        self.assertEqual(tuple(block.samples[1]), (1,))
-        self.assertEqual(tuple(block.samples[2]), (2,))
-        self.assertEqual(tuple(block.samples[3]), (3,))
-        self.assertEqual(tuple(block.samples[4]), (4,))
+        assert tuple(block.samples[0]) == (0,)
+        assert tuple(block.samples[1]) == (1,)
+        assert tuple(block.samples[2]) == (2,)
+        assert tuple(block.samples[3]) == (3,)
+        assert tuple(block.samples[4]) == (4,)
 
-        self.assertEqual(len(block.components), 1)
-        self.assertEqual(tuple(block.components[0][0]), (0,))
+        assert len(block.components), 1
+        assert tuple(block.components[0][0]), (0,)
 
-        self.assertEqual(block.properties.names, ("key_1", "properties"))
-        self.assertEqual(tuple(block.properties[0]), (0, 0))
-        self.assertEqual(tuple(block.properties[1]), (1, 3))
-        self.assertEqual(tuple(block.properties[2]), (1, 4))
-        self.assertEqual(tuple(block.properties[3]), (1, 5))
+        assert block.properties.names == ("key_1", "properties")
+        assert tuple(block.properties[0]) == (0, 0)
+        assert tuple(block.properties[1]) == (1, 3)
+        assert tuple(block.properties[2]) == (1, 4)
+        assert tuple(block.properties[3]) == (1, 5)
 
         expected = np.array(
             [
@@ -209,13 +194,13 @@ keys: ['key_1' 'key_2']
                 [[1.0, 0.0, 0.0, 0.0]],
             ]
         )
-        self.assertTrue(np.all(block.values == expected))
+        assert_equal(block.values, expected)
 
         gradient = block.gradient("parameter")
-        self.assertEqual(tuple(gradient.samples[0]), (0, -2))
-        self.assertEqual(tuple(gradient.samples[1]), (0, 3))
-        self.assertEqual(tuple(gradient.samples[2]), (3, -2))
-        self.assertEqual(tuple(gradient.samples[3]), (4, 3))
+        assert tuple(gradient.samples[0]) == (0, -2)
+        assert tuple(gradient.samples[1]) == (0, 3)
+        assert tuple(gradient.samples[2]) == (3, -2)
+        assert tuple(gradient.samples[3]) == (4, 3)
 
         expected = np.array(
             [
@@ -225,59 +210,59 @@ keys: ['key_1' 'key_2']
                 [[11.0, 0.0, 0.0, 0.0]],
             ]
         )
-        self.assertTrue(np.all(gradient.data == expected))
+        assert_equal(gradient.data, expected)
 
         # The new second block contains the old third block
         block = tensor.block(1)
-        self.assertEqual(block.properties.names, ("key_1", "properties"))
-        self.assertEqual(tuple(block.properties[0]), (2, 0))
+        assert block.properties.names == ("key_1", "properties")
+        assert tuple(block.properties[0]) == (2, 0)
 
-        self.assertTrue(np.all(block.values == np.full((4, 3, 1), 3.0)))
+        assert_equal(block.values, np.full((4, 3, 1), 3.0))
 
         # The new third block contains the old fourth block
         block = tensor.block(2)
-        self.assertEqual(block.properties.names, ("key_1", "properties"))
-        self.assertEqual(tuple(block.properties[0]), (2, 0))
+        assert block.properties.names == ("key_1", "properties")
+        assert tuple(block.properties[0]) == (2, 0)
 
-        self.assertTrue(np.all(block.values == np.full((4, 3, 1), 4.0)))
+        assert_equal(block.values, np.full((4, 3, 1), 4.0))
 
     def test_keys_to_samples(self):
-        tensor = test_tensor_map().keys_to_samples("key_2", sort_samples=True)
+        tensor = tensor_map().keys_to_samples("key_2", sort_samples=True)
 
-        self.assertEqual(tensor.keys.names, ("key_1",))
-        self.assertEqual(tuple(tensor.keys[0]), (0,))
-        self.assertEqual(tuple(tensor.keys[1]), (1,))
-        self.assertEqual(tuple(tensor.keys[2]), (2,))
+        assert tensor.keys.names == ("key_1",)
+        assert tuple(tensor.keys[0]) == (0,)
+        assert tuple(tensor.keys[1]) == (1,)
+        assert tuple(tensor.keys[2]) == (2,)
 
         # The first two blocks are not modified
         block = tensor.block(0)
-        self.assertEqual(block.samples.names, ("samples", "key_2"))
-        self.assertEqual(tuple(block.samples[0]), (0, 0))
-        self.assertEqual(tuple(block.samples[1]), (2, 0))
-        self.assertEqual(tuple(block.samples[2]), (4, 0))
+        assert block.samples.names, ("samples", "key_2")
+        assert tuple(block.samples[0]) == (0, 0)
+        assert tuple(block.samples[1]) == (2, 0)
+        assert tuple(block.samples[2]) == (4, 0)
 
-        self.assertTrue(np.all(block.values == np.full((3, 1, 1), 1.0)))
+        assert_equal(block.values, np.full((3, 1, 1), 1.0))
 
         block = tensor.block(1)
-        self.assertEqual(block.samples.names, ("samples", "key_2"))
-        self.assertEqual(tuple(block.samples[0]), (0, 0))
-        self.assertEqual(tuple(block.samples[1]), (1, 0))
-        self.assertEqual(tuple(block.samples[2]), (3, 0))
+        assert block.samples.names == ("samples", "key_2")
+        assert tuple(block.samples[0]) == (0, 0)
+        assert tuple(block.samples[1]) == (1, 0)
+        assert tuple(block.samples[2]) == (3, 0)
 
-        self.assertTrue(np.all(block.values == np.full((3, 1, 3), 2.0)))
+        assert_equal(block.values, np.full((3, 1, 3), 2.0))
 
         # The new third block contains the old third and fourth blocks merged
         block = tensor.block(2)
 
-        self.assertEqual(block.samples.names, ("samples", "key_2"))
-        self.assertEqual(tuple(block.samples[0]), (0, 2))
-        self.assertEqual(tuple(block.samples[1]), (0, 3))
-        self.assertEqual(tuple(block.samples[2]), (1, 3))
-        self.assertEqual(tuple(block.samples[3]), (2, 3))
-        self.assertEqual(tuple(block.samples[4]), (3, 2))
-        self.assertEqual(tuple(block.samples[5]), (5, 3))
-        self.assertEqual(tuple(block.samples[6]), (6, 2))
-        self.assertEqual(tuple(block.samples[7]), (8, 2))
+        assert block.samples.names == ("samples", "key_2")
+        assert tuple(block.samples[0]) == (0, 2)
+        assert tuple(block.samples[1]) == (0, 3)
+        assert tuple(block.samples[2]) == (1, 3)
+        assert tuple(block.samples[3]) == (2, 3)
+        assert tuple(block.samples[4]) == (3, 2)
+        assert tuple(block.samples[5]) == (5, 3)
+        assert tuple(block.samples[6]) == (6, 2)
+        assert tuple(block.samples[7]) == (8, 2)
 
         expected = np.array(
             [
@@ -291,13 +276,13 @@ keys: ['key_1' 'key_2']
                 [[3.0], [3.0], [3.0]],
             ]
         )
-        self.assertTrue(np.all(block.values == expected))
+        assert_equal(block.values, expected)
 
         gradient = block.gradient("parameter")
-        self.assertEqual(gradient.samples.names, ("sample", "parameter"))
-        self.assertEqual(tuple(gradient.samples[0]), (1, 1))
-        self.assertEqual(tuple(gradient.samples[1]), (4, -2))
-        self.assertEqual(tuple(gradient.samples[2]), (5, 3))
+        assert gradient.samples.names == ("sample", "parameter")
+        assert tuple(gradient.samples[0]) == (1, 1)
+        assert tuple(gradient.samples[1]) == (4, -2)
+        assert tuple(gradient.samples[2]) == (5, 3)
 
         expected = np.array(
             [
@@ -306,50 +291,46 @@ keys: ['key_1' 'key_2']
                 [[14.0], [14.0], [14.0]],
             ]
         )
-        self.assertTrue(np.all(gradient.data == expected))
+        assert_equal(gradient.data, expected)
 
-        # unsorted samples
-        tensor = test_tensor_map().keys_to_samples("key_2", sort_samples=False)
+    def test_keys_to_samples_unsorted(self):
+        tensor = tensor_map().keys_to_samples("key_2", sort_samples=False)
 
         block = tensor.block(2)
-        self.assertEqual(block.samples.names, ("samples", "key_2"))
-        self.assertEqual(tuple(block.samples[0]), (0, 2))
-        self.assertEqual(tuple(block.samples[1]), (3, 2))
-        self.assertEqual(tuple(block.samples[2]), (6, 2))
-        self.assertEqual(tuple(block.samples[3]), (8, 2))
-        self.assertEqual(tuple(block.samples[4]), (0, 3))
-        self.assertEqual(tuple(block.samples[5]), (1, 3))
-        self.assertEqual(tuple(block.samples[6]), (2, 3))
-        self.assertEqual(tuple(block.samples[7]), (5, 3))
+        assert block.samples.names, ("samples", "key_2")
+        assert tuple(block.samples[0]) == (0, 2)
+        assert tuple(block.samples[1]) == (3, 2)
+        assert tuple(block.samples[2]) == (6, 2)
+        assert tuple(block.samples[3]) == (8, 2)
+        assert tuple(block.samples[4]) == (0, 3)
+        assert tuple(block.samples[5]) == (1, 3)
+        assert tuple(block.samples[6]) == (2, 3)
+        assert tuple(block.samples[7]) == (5, 3)
 
     def test_components_to_properties(self):
-        tensor = test_tensor_map().components_to_properties("components")
+        tensor = tensor_map().components_to_properties("components")
 
         block = tensor.block(0)
-        self.assertEqual(block.samples.names, ("samples",))
-        self.assertEqual(tuple(block.samples[0]), (0,))
-        self.assertEqual(tuple(block.samples[1]), (2,))
-        self.assertEqual(tuple(block.samples[2]), (4,))
+        assert block.samples.names == ("samples",)
+        assert tuple(block.samples[0]) == (0,)
+        assert tuple(block.samples[1]) == (2,)
+        assert tuple(block.samples[2]) == (4,)
 
-        self.assertEqual(block.components, [])
+        assert block.components == []
 
-        self.assertEqual(block.properties.names, ("components", "properties"))
-        self.assertEqual(tuple(block.properties[0]), (0, 0))
+        assert block.properties.names == ("components", "properties")
+        assert tuple(block.properties[0]) == (0, 0)
 
         block = tensor.block(3)
-        self.assertEqual(block.samples.names, ("samples",))
-        self.assertEqual(tuple(block.samples[0]), (0,))
-        self.assertEqual(tuple(block.samples[1]), (1,))
-        self.assertEqual(tuple(block.samples[2]), (2,))
-        self.assertEqual(tuple(block.samples[3]), (5,))
+        assert block.samples.names, ("samples",)
+        assert tuple(block.samples[0]) == (0,)
+        assert tuple(block.samples[1]) == (1,)
+        assert tuple(block.samples[2]) == (2,)
+        assert tuple(block.samples[3]) == (5,)
 
-        self.assertEqual(block.components, [])
+        assert block.components == []
 
-        self.assertEqual(block.properties.names, ("components", "properties"))
-        self.assertEqual(tuple(block.properties[0]), (0, 0))
-        self.assertEqual(tuple(block.properties[1]), (1, 0))
-        self.assertEqual(tuple(block.properties[2]), (2, 0))
-
-
-if __name__ == "__main__":
-    unittest.main()
+        assert block.properties.names == ("components", "properties")
+        assert tuple(block.properties[0]) == (0, 0)
+        assert tuple(block.properties[1]) == (1, 0)
+        assert tuple(block.properties[2]) == (2, 0)

--- a/python/tests/utils.py
+++ b/python/tests/utils.py
@@ -3,7 +3,7 @@ import numpy as np
 from equistore import Labels, TensorBlock, TensorMap
 
 
-def test_tensor_map():
+def tensor_map():
     """
     Create a dummy tensor map to be used in tests. This is the same one as the
     tensor map used in `tensor.rs` tests.
@@ -81,12 +81,12 @@ def test_tensor_map():
     return TensorMap(keys, [block_1, block_2, block_3, block_4])
 
 
-def test_large_tensor_map():
+def large_tensor_map():
     """
     Create a dummy tensor map of 16 blocks to be used in tests. This is the same
     tensor map used in `tensor.rs` tests.
     """
-    tensor = test_tensor_map()
+    tensor = tensor_map()
     block_list = [block.copy() for _, block in tensor]
 
     for i in range(8):

--- a/tox.ini
+++ b/tox.ini
@@ -17,21 +17,25 @@ passenv =
 allowlist_externals =
     bash
 
-
 [testenv:tests]
 # this environement runs Python tests
 
 deps =
     discover
     numpy
+    pytest
+    torch
 
 commands =
     bash -c "rm -rf ./dist"
     pip wheel --no-deps -w dist .
     bash -c "python -m pip install --force-reinstall --no-deps ./dist/equistore-*.whl"
 
+    # Run Python unittest tests
     discover -p "*.py" -s python/tests
 
+   # Run pytest tests
+    pytest
 
 [testenv:lint]
 # this environement lints the Python code with flake8 (code linter), black (code
@@ -48,8 +52,6 @@ commands =
     black --check --diff {toxinidir}/python {toxinidir}/setup.py
     isort --check-only --diff {toxinidir}/python {toxinidir}/setup.py
 
-
-
 [testenv:format]
 # this environement abuses tox to do actual formatting
 #
@@ -60,8 +62,6 @@ deps =
 commands =
     black {toxinidir}/python {toxinidir}/setup.py
     isort {toxinidir}/python {toxinidir}/setup.py
-
-
 
 [testenv:docs]
 # this environement builds the documentation with sphinx
@@ -74,8 +74,6 @@ commands =
     bash -c "python -m pip install --force-reinstall --no-deps ./dist/equistore-*.whl"
 
     sphinx-build {posargs:-E} -W -b html docs/src docs/build/html
-
-
 
 [testenv:build-python]
 # this environement makes sure one can build sdist and wheels for Python


### PR DESCRIPTION
This PR moves the Python core tests to `pytest`. The operations tests still use `unittests`. In addition, I added torch in test depencies for also running the data tests for torch. 


<!-- readthedocs-preview equistore start -->
----
:books: Documentation preview :books:: https://equistore--165.org.readthedocs.build/en/165/

<!-- readthedocs-preview equistore end -->