### PR TITLE
print can handle 0 samples

### DIFF
--- a/python/src/equistore/block.py
+++ b/python/src/equistore/block.py
@@ -113,12 +113,7 @@ class TensorBlock:
 
     def __repr__(self) -> str:
         s = "TensorBlock\n"
-        s += f"    samples ({len(self.samples)}): ["
-        for sname in self.samples.names[:-1]:
-            s += "'" + sname + "', "
-        if len(self.samples.names) > 0:
-            s += "'" + self.samples.names[-1] + "'"
-        s += "]"
+        s += f"    samples ({len(self.samples)}): {str(list(self.samples.names))}"
         s += "\n"
         s += "    components ("
         s += ", ".join([str(len(c)) for c in self.components])
@@ -129,18 +124,11 @@ class TensorBlock:
         if len(self.components) > 0:
             s = s[:-2]
         s += "]\n"
-        s += f"    properties ({len(self.properties)}): ["
-        for name in self.properties.names[:-1]:
-            s += "'" + name + "', "
-        if len(self.properties.names) > 0:
-            s += "'" + self.properties.names[-1] + "'"
-        s += "]\n"
+        s += f"    properties ({len(self.properties)}): "
+        s += f"{str(list(self.properties.names))}\n"
         s += "    gradients: "
         if len(self.gradients_list()) > 0:
-            s += "["
-            for gr in self.gradients_list()[:-1]:
-                s += "'{}', ".format(gr)
-            s += "'{}']".format(self.gradients_list()[-1])
+            s += f"{str(list(self.gradients_list()))}"
         else:
             s += "no"
 
@@ -296,12 +284,7 @@ class Gradient:
     def __repr__(self) -> str:
         s = "Gradient TensorBlock\n"
         s += "parameter: '{}'\n".format(self._name)
-        s += f"samples ({len(self.samples)}): ["
-        for sname in self.samples.names[:-1]:
-            s += "'" + sname + "', "
-        if len(self.samples.names) > 0:
-            s += "'" + self.samples.names[-1] + "'"
-        s += "]"
+        s += f"samples ({len(self.samples)}): {str(list(self.samples.names))}"
         s += "\n"
         s += "components ("
         s += ", ".join([str(len(c)) for c in self.components])
@@ -312,12 +295,7 @@ class Gradient:
         if len(self.components) > 0:
             s = s[:-2]
         s += "]\n"
-        s += f"properties ({len(self.properties)}): ["
-        for name in self.properties.names[:-1]:
-            s += "'" + name + "', "
-        if len(self.properties.names) > 0:
-            s += "'" + self.properties.names[-1] + "'"
-        s += "]"
+        s += f"properties ({len(self.properties)}): {str(list(self.properties.names))}"
 
         return s
 

--- a/python/src/equistore/block.py
+++ b/python/src/equistore/block.py
@@ -116,7 +116,9 @@ class TensorBlock:
         s += f"    samples ({len(self.samples)}): ["
         for sname in self.samples.names[:-1]:
             s += "'" + sname + "', "
-        s += "'" + self.samples.names[-1] + "']"
+        if len(self.samples.names) > 0:
+            s += "'" + self.samples.names[-1] + "'"
+        s += "]"
         s += "\n"
         s += "    components ("
         s += ", ".join([str(len(c)) for c in self.components])
@@ -130,7 +132,9 @@ class TensorBlock:
         s += f"    properties ({len(self.properties)}): ["
         for name in self.properties.names[:-1]:
             s += "'" + name + "', "
-        s += "'" + self.properties.names[-1] + "']\n"
+        if len(self.properties.names) > 0:
+            s += "'" + self.properties.names[-1] + "'"
+        s += "]\n"
         s += "    gradients: "
         if len(self.gradients_list()) > 0:
             s += "["
@@ -295,7 +299,9 @@ class Gradient:
         s += f"samples ({len(self.samples)}): ["
         for sname in self.samples.names[:-1]:
             s += "'" + sname + "', "
-        s += "'" + self.samples.names[-1] + "']"
+        if len(self.samples.names) > 0:
+            s += "'" + self.samples.names[-1] + "'"
+        s += "]"
         s += "\n"
         s += "components ("
         s += ", ".join([str(len(c)) for c in self.components])
@@ -309,7 +315,9 @@ class Gradient:
         s += f"properties ({len(self.properties)}): ["
         for name in self.properties.names[:-1]:
             s += "'" + name + "', "
-        s += "'" + self.properties.names[-1] + "']"
+        if len(self.properties.names) > 0:
+            s += "'" + self.properties.names[-1] + "'"
+        s += "]"
 
         return s
 

--- a/python/tests/blocks.py
+++ b/python/tests/blocks.py
@@ -41,6 +41,51 @@ class TestBlocks:
     gradients: no"""
         assert block.__repr__() == expected
 
+    def test_repr_zero_samples(self):
+        block = TensorBlock(
+            values=np.zeros((0, 2)),
+            samples=Labels([], np.empty((0, 2), dtype=np.int32)),
+            components=[],
+            properties=Labels(["properties"], np.array([[5], [3]], dtype=np.int32)),
+        )
+        expected = """TensorBlock
+    samples (0): []
+    components (): []
+    properties (2): ['properties']
+    gradients: no"""
+        self.assertTrue(block.__repr__() == expected)
+
+    def test_repr_zero_samples_gradient(self):
+        block = TensorBlock(
+            values=np.full((3, 2), -1.0),
+            samples=Labels(["samples"], np.array([[0], [2], [4]], dtype=np.int32)),
+            components=[],
+            properties=Labels(["properties"], np.array([[5], [3]], dtype=np.int32)),
+        )
+        block.add_gradient(
+            "parameter",
+            data=np.zeros((0, 2)),
+            samples=Labels(["sample"], np.empty((0, 2), dtype=np.int32)),
+            components=[],
+        )
+
+        expected_block = """TensorBlock
+    samples (3): ['samples']
+    components (): []
+    properties (2): ['properties']
+    gradients: ['parameter']"""
+
+        self.assertTrue(block.__repr__() == expected_block)
+
+        expected_grad = """Gradient TensorBlock
+parameter: 'parameter'
+samples (0): ['sample']
+components (): []
+properties (2): ['properties']"""
+
+        gradient = block.gradient("parameter")
+        self.assertTrue(gradient.__repr__() == expected_grad)
+
     def test_block_no_components(self):
         block = TensorBlock(
             values=np.full((3, 2), -1.0),

--- a/python/tests/blocks.py
+++ b/python/tests/blocks.py
@@ -53,7 +53,7 @@ class TestBlocks:
     components (): []
     properties (2): ['properties']
     gradients: no"""
-        self.assertTrue(block.__repr__() == expected)
+        assert block.__repr__() == expected
 
     def test_repr_zero_samples_gradient(self):
         block = TensorBlock(
@@ -75,7 +75,7 @@ class TestBlocks:
     properties (2): ['properties']
     gradients: ['parameter']"""
 
-        self.assertTrue(block.__repr__() == expected_block)
+        assert block.__repr__() == expected_block
 
         expected_grad = """Gradient TensorBlock
 parameter: 'parameter'
@@ -84,7 +84,7 @@ components (): []
 properties (2): ['properties']"""
 
         gradient = block.gradient("parameter")
-        self.assertTrue(gradient.__repr__() == expected_grad)
+        assert gradient.__repr__() == expected_grad
 
     def test_block_no_components(self):
         block = TensorBlock(


### PR DESCRIPTION
fixes the last issue of #129.

now 
```python
block = TensorBlock(
            values=np.zeros((0, 2)),
            samples=Labels([], np.empty((0, 2), dtype=np.int32)),
            components=[],
            properties=Labels(["properties"], np.array([[5], [3]], dtype=np.int32)),
        )
```
gives 
```python
TensorBlock
    samples (0): []
    components (): []
    properties (2): ['properties']
    gradients: no
```

<!-- readthedocs-preview equistore start -->
----
:books: Documentation preview :books:: https://equistore--166.org.readthedocs.build/en/166/

<!-- readthedocs-preview equistore end -->