### PR TITLE
Try to fix docs permission errors

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,10 +7,6 @@ on:
   pull_request:
     # Check all PR
 
-# We need write permission on PR to post the RTD link
-permissions:
-  pull-requests: write
-
 jobs:
   build-and-publish:
     runs-on: ubuntu-20.04
@@ -54,9 +50,3 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./gh-pages/
           force_orphan: true
-
-      - if: github.event_name == 'pull_request'
-        name: Post link to RTD
-        uses: readthedocs/actions/preview@v1
-        with:
-          project-slug: "equistore"

--- a/.github/workflows/documentation-links.yml
+++ b/.github/workflows/documentation-links.yml
@@ -1,0 +1,17 @@
+name: readthedocs/actions
+
+on:
+  pull_request_target:
+    types:
+      - opened
+
+permissions:
+  pull-requests: write
+
+jobs:
+  documentation-links:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: readthedocs/actions/preview@v1
+        with:
+          project-slug: equistore


### PR DESCRIPTION
The job pushing documentation to gh-pages is broken right now (https://github.com/lab-cosmo/equistore/actions/runs/4341978102/jobs/7582234507), I suspect this is because of the tentative permission fix from #163. This PR tries to workaroud the issue in another way, having a separate workflow for posting the link