### PR TITLE
Check that we have at least one dimension in gradient samples

### DIFF
--- a/equistore-core/src/blocks.rs
+++ b/equistore-core/src/blocks.rs
@@ -295,6 +295,12 @@ impl TensorBlock {
             ))
         }
 
+        if samples.size() == 0 {
+            return Err(Error::InvalidParameter(
+                "gradients samples must have at least a 'sample' variable, we got none".into()
+            ))
+        }
+
         if samples.size() < 1 || samples.names()[0] != "sample" {
             return Err(Error::InvalidParameter(format!(
                 "'{}' is not valid for the first variable in the gradients \

--- a/python/tests/blocks.py
+++ b/python/tests/blocks.py
@@ -1,10 +1,32 @@
 import numpy as np
+import pytest
 from numpy.testing import assert_equal
 
+import equistore.status
 from equistore import Labels, TensorBlock
 
 
 class TestBlocks:
+    def test_gradient_no_sample_error(self):
+        block = TensorBlock(
+            values=np.full((3, 2), -1.0),
+            samples=Labels(["samples"], np.array([[0], [2], [4]], dtype=np.int32)),
+            components=[],
+            properties=Labels(["properties"], np.array([[5], [3]], dtype=np.int32)),
+        )
+
+        with pytest.raises(
+            equistore.status.EquistoreError,
+            match="""invalid parameter: gradients samples must have at least a """
+            """'sample' variable, we got none""",
+        ):
+            block.add_gradient(
+                "parameter",
+                data=np.zeros((0, 2)),
+                samples=Labels([], np.empty((0, 2), dtype=np.int32)),
+                components=[],
+            )
+
     def test_repr(self):
         block = TensorBlock(
             values=np.full((3, 2), -1.0),


### PR DESCRIPTION
This should fix the `internal error (this is likely a bug, please report it): index out of bounds: the len is 0 but the index is 0` when trying to add gradient with completely empty samples:

```py
block.add_gradient(
    "parameter",
    data=np.zeros((0, 2)),
    samples=Labels([], np.empty((0, 2), dtype=np.int32)),
    components=[],
)
```

<!-- readthedocs-preview equistore start -->
----
:books: Documentation preview :books:: https://equistore--169.org.readthedocs.build/en/169/

<!-- readthedocs-preview equistore end -->