### PR TITLE
Make sure to uninstall existing python package in tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -29,7 +29,8 @@ deps =
 commands =
     bash -c "rm -rf ./dist"
     pip wheel --no-deps -w dist .
-    bash -c "python -m pip install --force-reinstall --no-deps ./dist/equistore-*.whl"
+    bash -c "python -m pip uninstall equistore -y"
+    bash -c "python -m pip install --no-deps ./dist/equistore-*.whl"
 
     # Run Python unittest tests
     discover -p "*.py" -s python/tests
@@ -71,7 +72,8 @@ deps =
 commands =
     bash -c "rm -rf ./dist"
     pip wheel --no-deps -w dist .
-    bash -c "python -m pip install --force-reinstall --no-deps ./dist/equistore-*.whl"
+    bash -c "python -m pip uninstall equistore -y"
+    bash -c "python -m pip install --no-deps ./dist/equistore-*.whl"
 
     sphinx-build {posargs:-E} -W -b html docs/src docs/build/html
 


### PR DESCRIPTION
Otherwise we would just add new files in the package without removing previous ones. This was causing @jwa7 to see tests passing locally while failing in CI in #178 

<!-- readthedocs-preview equistore start -->
----
:books: Documentation preview :books:: https://equistore--180.org.readthedocs.build/en/180/

<!-- readthedocs-preview equistore end -->