### PR TITLE
Allow to only install one of static/shared library

### DIFF
--- a/equistore-core/CMakeLists.txt
+++ b/equistore-core/CMakeLists.txt
@@ -29,7 +29,20 @@ project(equistore
     LANGUAGES C # we need to declare a language to access CMAKE_SIZEOF_VOID_P later
 )
 
-option(BUILD_SHARED_LIBS "Build a shared library instead of a static one" ON)
+
+# We follow the standard CMake convention of using BUILD_SHARED_LIBS to provide
+# either a shared or static library as a default target. But since cargo always
+# builds both versions by default, we also install both versions by default.
+# `EQUISTORE_INSTALL_BOTH_STATIC_SHARED=OFF` allow to disable this behavior, and
+# only install the file corresponding to `BUILD_SHARED_LIBS=ON/OFF`.
+#
+# BUILD_SHARED_LIBS controls the `equistore` cmake target, making it an alias of
+# either `equistore::static` or `equistore::shared`. This is mainly relevant
+# when using equistore from another cmake project, either as a submodule or from
+# an installed library (see cmake/equistore-config.cmake)
+option(BUILD_SHARED_LIBS "Use a shared library by default instead of a static one" ON)
+option(EQUISTORE_INSTALL_BOTH_STATIC_SHARED "Install both shared and static libraries" ON)
+
 set(LIB_INSTALL_DIR "lib" CACHE PATH "Path relative to CMAKE_INSTALL_PREFIX where to install libraries")
 set(INCLUDE_INSTALL_DIR "include" CACHE PATH "Path relative to CMAKE_INSTALL_PREFIX where to install headers")
 set(RUST_BUILD_TARGET "" CACHE STRING "Cross-compilation target for rust code. Leave empty to build for the host")
@@ -141,7 +154,8 @@ else()
     set(CARGO_RUSTC_ARGS "")
 endif()
 
-if (EQUISTORE_BUILD_FOR_PYTHON AND ${CARGO_VERSION} VERSION_GREATER "1.59")
+# TODO: introduce a generic RUST_FLAGS variable and use that instead
+if (EQUISTORE_BUILD_FOR_PYTHON)
     # strip dynamic library for smaller wheels to download/install
     set(CARGO_RUSTC_ARGS "${CARGO_RUSTC_ARGS};-Cstrip=symbols")
 endif()
@@ -216,8 +230,15 @@ configure_file(
 )
 
 install(FILES ${EQUISTORE_HEADERS} DESTINATION ${INCLUDE_INSTALL_DIR})
-install(FILES ${EQUISTORE_SHARED_LOCATION} DESTINATION ${LIB_INSTALL_DIR})
-install(FILES ${EQUISTORE_STATIC_LOCATION} DESTINATION ${LIB_INSTALL_DIR})
+
+if (EQUISTORE_INSTALL_BOTH_STATIC_SHARED OR BUILD_SHARED_LIBS)
+    install(FILES ${EQUISTORE_SHARED_LOCATION} DESTINATION ${LIB_INSTALL_DIR})
+endif()
+
+if (EQUISTORE_INSTALL_BOTH_STATIC_SHARED OR NOT BUILD_SHARED_LIBS)
+    install(FILES ${EQUISTORE_STATIC_LOCATION} DESTINATION ${LIB_INSTALL_DIR})
+endif()
+
 install(FILES
     ${PROJECT_BINARY_DIR}/equistore-config-version.cmake
     ${PROJECT_BINARY_DIR}/equistore-config.cmake

--- a/equistore-core/cmake/equistore-config.in.cmake
+++ b/equistore-core/cmake/equistore-config.in.cmake
@@ -8,44 +8,82 @@ endif()
 
 enable_language(CXX)
 
-add_library(equistore::shared SHARED IMPORTED GLOBAL)
-add_library(equistore::static STATIC IMPORTED GLOBAL)
+set(EQUISTORE_SHARED_LOCATION ${PACKAGE_PREFIX_DIR}/@LIB_INSTALL_DIR@/@EQUISTORE_SHARED_LIB_NAME@)
+set(EQUISTORE_STATIC_LOCATION ${PACKAGE_PREFIX_DIR}/@LIB_INSTALL_DIR@/@EQUISTORE_STATIC_LIB_NAME@)
+set(EQUISTORE_INCLUDE ${PACKAGE_PREFIX_DIR}/@INCLUDE_INSTALL_DIR@/)
 
-set_target_properties(equistore::shared PROPERTIES
-    IMPORTED_LOCATION ${PACKAGE_PREFIX_DIR}/@LIB_INSTALL_DIR@/@EQUISTORE_SHARED_LIB_NAME@
-    INTERFACE_INCLUDE_DIRECTORIES ${PACKAGE_PREFIX_DIR}/@INCLUDE_INSTALL_DIR@/
-)
-
-set_target_properties(equistore::static PROPERTIES
-    IMPORTED_LOCATION ${PACKAGE_PREFIX_DIR}/@LIB_INSTALL_DIR@/@EQUISTORE_STATIC_LIB_NAME@
-    INTERFACE_INCLUDE_DIRECTORIES ${PACKAGE_PREFIX_DIR}/@INCLUDE_INSTALL_DIR@/
-)
-
-if (${CMAKE_VERSION} VERSION_GREATER_EQUAL 3.11)
-    # we can not set compile features for imported targets before cmake 3.11
-    # users will have to manually request C++11
-    target_compile_features(equistore::shared INTERFACE cxx_std_11)
-    target_compile_features(equistore::static INTERFACE cxx_std_11)
+if (NOT EXISTS ${EQUISTORE_INCLUDE}/equistore.h OR NOT EXISTS ${EQUISTORE_INCLUDE}/equistore.hpp)
+    message(FATAL_ERROR "could not find equistore headers in '${EQUISTORE_INCLUDE}', please re-install equistore")
 endif()
 
 
-if (${CMAKE_VERSION} VERSION_GREATER_EQUAL 3.11)
-    # The default library for external users should be the shared one
-    add_library(equistore ALIAS equistore::shared)
+# Shared library target
+if (@EQUISTORE_INSTALL_BOTH_STATIC_SHARED@ OR @BUILD_SHARED_LIBS@)
+    if (NOT EXISTS ${EQUISTORE_SHARED_LOCATION})
+        message(FATAL_ERROR "could not find equistore library at '${EQUISTORE_SHARED_LOCATION}', please re-install equistore")
+    endif()
+
+    add_library(equistore::shared SHARED IMPORTED GLOBAL)
+    set_target_properties(equistore::shared PROPERTIES
+        IMPORTED_LOCATION ${EQUISTORE_SHARED_LOCATION}
+        INTERFACE_INCLUDE_DIRECTORIES ${EQUISTORE_INCLUDE}
+    )
+
+    if (${CMAKE_VERSION} VERSION_GREATER_EQUAL 3.11)
+        # we can not set compile features for imported targets before cmake 3.11
+        # users will have to manually request C++11
+        target_compile_features(equistore::shared INTERFACE cxx_std_11)
+    endif()
+endif()
+
+
+# Static library target
+if (@EQUISTORE_INSTALL_BOTH_STATIC_SHARED@ OR NOT @BUILD_SHARED_LIBS@)
+    if (NOT EXISTS ${EQUISTORE_STATIC_LOCATION})
+        message(FATAL_ERROR "could not find equistore library at '${EQUISTORE_STATIC_LOCATION}', please re-install equistore")
+    endif()
+
+    add_library(equistore::static STATIC IMPORTED GLOBAL)
+    set_target_properties(equistore::static PROPERTIES
+        IMPORTED_LOCATION ${EQUISTORE_STATIC_LOCATION}
+        INTERFACE_INCLUDE_DIRECTORIES ${EQUISTORE_INCLUDE}
+    )
+
+    if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+        set(THREADS_PREFER_PTHREAD_FLAG ON)
+        find_package(Threads REQUIRED)
+        # the rust standard lib uses pthread and libdl on linux
+        target_link_libraries(equistore::static INTERFACE Threads::Threads dl)
+
+        # num_bigint uses fmod
+        target_link_libraries(equistore::static INTERFACE m)
+    endif()
+
+    if (${CMAKE_VERSION} VERSION_GREATER_EQUAL 3.11)
+        # we can not set compile features for imported targets before cmake 3.11
+        # users will have to manually request C++11
+        target_compile_features(equistore::static INTERFACE cxx_std_11)
+    endif()
+endif()
+
+
+# Export either the shared or static library as the equistore target
+if (@BUILD_SHARED_LIBS@)
+    if (${CMAKE_VERSION} VERSION_GREATER_EQUAL 3.11)
+        add_library(equistore ALIAS equistore::shared)
+    else()
+        # CMake 3.10 (default on Ubuntu 20.04) does not support ALIAS for IMPORTED
+        # libraries
+        add_library(equistore INTERFACE)
+        target_link_libraries(equistore INTERFACE equistore::shared)
+    endif()
 else()
-    # CMake 3.10 (default on Ubuntu 20.04) does not support ALIAS for IMPORTED
-    # libraries
-    add_library(equistore INTERFACE)
-    target_link_libraries(equistore INTERFACE equistore::shared)
-endif()
-
-
-if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
-    set(THREADS_PREFER_PTHREAD_FLAG ON)
-    find_package(Threads REQUIRED)
-    # the rust standard lib uses pthread and libdl on linux
-    target_link_libraries(equistore::static INTERFACE Threads::Threads dl)
-
-    # num_bigint uses fmod
-    target_link_libraries(equistore::static INTERFACE m)
+    if (${CMAKE_VERSION} VERSION_GREATER_EQUAL 3.11)
+        add_library(equistore ALIAS equistore::static)
+    else()
+        # CMake 3.10 (default on Ubuntu 20.04) does not support ALIAS for IMPORTED
+        # libraries
+        add_library(equistore INTERFACE)
+        target_link_libraries(equistore INTERFACE equistore::static)
+    endif()
 endif()

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ class cmake_ext(build_ext):
             f"-DCMAKE_INSTALL_PREFIX={install_dir}",
             f"-DCMAKE_BUILD_TYPE={EQUISTORE_BUILD_TYPE}",
             "-DBUILD_SHARED_LIBS=ON",
+            "-DEQUISTORE_INSTALL_BOTH_STATIC_SHARED=OFF",
             "-DEQUISTORE_BUILD_FOR_PYTHON=ON",
         ]
 


### PR DESCRIPTION
And only install the shared one for Python wheels. The wheel goes from ~7MiB to ~500kiB for me with this change.

<!-- readthedocs-preview equistore start -->
----
:books: Documentation preview :books:: https://equistore--181.org.readthedocs.build/en/181/

<!-- readthedocs-preview equistore end -->