### PR TITLE
Make Labels contiguous before passing them to equistore-core

### DIFF
--- a/python/src/equistore/labels.py
+++ b/python/src/equistore/labels.py
@@ -262,7 +262,12 @@ def _eqs_labels_view(array):
     labels.internal_ptr_ = None
     labels.names = names
     labels.size = len(array.names)
-    labels.values = array.ctypes.data_as(ctypes.POINTER(ctypes.c_int32))
+
+    # We need to make sure the data is C-contiguous to take a pointer to it
+    contiguous = np.ascontiguousarray(array)
+    ptr = contiguous.ctypes.data_as(ctypes.POINTER(ctypes.c_int32))
+
+    labels.values = ptr
     labels.count = array.shape[0]
 
     return labels

--- a/python/tests/labels.py
+++ b/python/tests/labels.py
@@ -171,3 +171,18 @@ class TestLabels:
         label = Labels.empty(names)
         assert label.names == names
         assert len(label) == 0
+
+    def test_labels_contiguous(self):
+        labels = Labels(
+            names=["a", "b"],
+            values=np.arange(32, dtype=np.int32).reshape(-1, 2),
+        )
+
+        labels = labels[::-1]
+        ptr = labels._as_eqs_labels_t().values
+
+        shape = (len(labels), len(labels.names))
+        array = np.ctypeslib.as_array(ptr, shape=shape)
+        array = array.view(dtype=labels.dtype).reshape(-1)
+
+        assert np.all(array == labels)


### PR DESCRIPTION
Fix #188 

<!-- readthedocs-preview equistore start -->
----
:books: Documentation preview :books:: https://equistore--189.org.readthedocs.build/en/189/

<!-- readthedocs-preview equistore end -->