### PR TITLE
Allow join for a single TensorMap

### DIFF
--- a/python/src/equistore/operations/join.py
+++ b/python/src/equistore/operations/join.py
@@ -66,8 +66,14 @@ def join(tensor_maps: List[TensorMap], axis: str):
              than the input TensorMap.
     """
 
-    if len(tensor_maps) < 2 or not isinstance(tensor_maps, (list, tuple)):
-        raise ValueError("provide at least two `TensorMap`s for joining")
+    if not isinstance(tensor_maps, (list, tuple)):
+        raise TypeError("the `TensorMap`s to join must be provided as a list or a tuple")
+
+    if len(tensor_maps) < 1:
+        raise ValueError("provide at least one `TensorMap` for joining")
+    
+    if len(tensor_maps) == 1:
+        return tensor_maps[0]
 
     for ts_to_join in tensor_maps[1:]:
         _check_maps(tensor_maps[0], ts_to_join, "join")

--- a/python/src/equistore/operations/join.py
+++ b/python/src/equistore/operations/join.py
@@ -67,11 +67,13 @@ def join(tensor_maps: List[TensorMap], axis: str):
     """
 
     if not isinstance(tensor_maps, (list, tuple)):
-        raise TypeError("the `TensorMap`s to join must be provided as a list or a tuple")
+        raise TypeError(
+            "the `TensorMap`s to join must be provided as a list or a tuple"
+        )
 
     if len(tensor_maps) < 1:
         raise ValueError("provide at least one `TensorMap` for joining")
-    
+
     if len(tensor_maps) == 1:
         return tensor_maps[0]
 

--- a/python/tests/operations/join.py
+++ b/python/tests/operations/join.py
@@ -39,15 +39,26 @@ class TestJoinTensorMap(unittest.TestCase):
         )
         self.ps_first_block_extra_grad = TensorMap(keys_first_block, [block_extra_grad])
 
-    def test_single_tensormap(self):
-        """Test error raise if only one tensormap is provided."""
-        with self.assertRaises(ValueError) as err:
+    def test_wrong_type(self):
+        """Test if a wrong type (e.g., TensorMap) is provided."""
+        with self.assertRaises(TypeError) as err:
             equistore.join(self.ps, axis="properties")
-        self.assertIn("provide at least two", str(err.exception))
+        self.assertIn("list", str(err.exception))
+        self.assertIn("tuple", str(err.exception))
 
+    def test_single_tensormap(self):
+        """Test if only one TensorMap is provided."""
+        ps_joined = equistore.join([self.ps], axis="properties")
+        assert ps_joined is self.ps
+
+    def test_no_tensormaps(self):
+        """Test if an empty list or tuple is provided."""
         with self.assertRaises(ValueError) as err:
-            equistore.join([self.ps], axis="properties")
-        self.assertIn("provide at least two", str(err.exception))
+            equistore.join([], axis="properties")
+        self.assertIn("provide at least one", str(err.exception))
+        with self.assertRaises(ValueError) as err:
+            equistore.join((), axis="properties")
+        self.assertIn("provide at least one", str(err.exception))
 
     def test_join_properties(self):
         """Test public join function with three tensormaps along `properties`.


### PR DESCRIPTION
Very useful, for example, when batching calculations for memory reasons and joining the batches in the end. In that case, if there is only one batch, the join operation will not currently work

<!-- readthedocs-preview equistore start -->
----
:books: Documentation preview :books:: https://equistore--220.org.readthedocs.build/en/220/

<!-- readthedocs-preview equistore end -->