### PR TITLE
Port join tests to pytest

### DIFF
--- a/python/tests/operations/join.py
+++ b/python/tests/operations/join.py
@@ -1,7 +1,8 @@
-import unittest
 from os import path
 
 import numpy as np
+import pytest
+from numpy.testing import assert_equal
 
 import equistore
 from equistore import Labels, TensorBlock, TensorMap
@@ -10,171 +11,190 @@ from equistore import Labels, TensorBlock, TensorMap
 DATA_ROOT = path.join(path.dirname(__file__), "..", "data")
 
 
-class TestJoinTensorMap(unittest.TestCase):
-    def setUp(self):
-        self.ps = equistore.load(
-            path.join(DATA_ROOT, "qm7-power-spectrum.npz"), use_numpy=True
+class TestJoinTensorMap:
+    @pytest.fixture
+    def tensor(self):
+        tensor = equistore.load(
+            path.join(DATA_ROOT, "qm7-power-spectrum.npz"),
+            use_numpy=True,
         )
-        self.se = equistore.load(
-            path.join(DATA_ROOT, "qm7-spherical-expansion.npz"), use_numpy=True
-        )
-        self.first_block = self.ps.block(0)
 
         # Test if Tensormaps have at least one gradient. This avoids dropping gradient
         # tests silently by removing gradients from the reference data
-        self.assertIn("positions", self.ps.block(0).gradients_list())
-        self.assertIn("positions", self.se.block(0).gradients_list())
+        assert "positions" in tensor.block(0).gradients_list()
 
-        keys_first_block = Labels(
-            names=self.ps.keys.names,
-            values=np.array(self.ps.keys[0].tolist()).reshape(1, -1),
+        return tensor
+
+    @pytest.fixture
+    def components_tensor(self):
+        components_tensor = equistore.load(
+            path.join(DATA_ROOT, "qm7-spherical-expansion.npz"),
+            use_numpy=True,
         )
 
-        self.ps_first_block = TensorMap(keys_first_block, [self.first_block.copy()])
+        # Test if Tensormaps have at least one gradient. This avoids dropping gradient
+        # tests silently by removing gradients from the reference data
+        assert "positions" in components_tensor.block(0).gradients_list()
 
-        block_extra_grad = self.first_block.copy()
-        gradient = self.ps.block(0).gradient("positions")
+        return components_tensor
+
+    @pytest.fixture
+    def first_block(self, tensor):
+        return tensor.block(0)
+
+    @pytest.fixture
+    def tensor_first_block(self, tensor, first_block):
+        keys_first_block = Labels(
+            names=tensor.keys.names,
+            values=np.array(tensor.keys[0].tolist()).reshape(1, -1),
+        )
+
+        return TensorMap(keys_first_block, [first_block.copy()])
+
+    @pytest.fixture
+    def tensor_first_block_extra_grad(self, tensor, first_block):
+        block_extra_grad = first_block.copy()
+        gradient = tensor.block(0).gradient("positions")
         block_extra_grad.add_gradient(
             "foo", gradient.data, gradient.samples, gradient.components
         )
-        self.ps_first_block_extra_grad = TensorMap(keys_first_block, [block_extra_grad])
 
-    def test_wrong_type(self):
+        keys_first_block = Labels(
+            names=tensor.keys.names,
+            values=np.array(tensor.keys[0].tolist()).reshape(1, -1),
+        )
+
+        return TensorMap(keys_first_block, [block_extra_grad])
+
+    def test_wrong_type(self, tensor):
         """Test if a wrong type (e.g., TensorMap) is provided."""
-        with self.assertRaises(TypeError) as err:
-            equistore.join(self.ps, axis="properties")
-        self.assertIn("list", str(err.exception))
-        self.assertIn("tuple", str(err.exception))
+        with pytest.raises(TypeError, match="list or a tuple"):
+            equistore.join(tensor, axis="properties")
 
-    def test_single_tensormap(self):
+    def test_single_tensormap(self, tensor):
         """Test if only one TensorMap is provided."""
-        ps_joined = equistore.join([self.ps], axis="properties")
-        assert ps_joined is self.ps
+        tensor_joined = equistore.join([tensor], axis="properties")
+        assert tensor_joined is tensor
 
-    def test_no_tensormaps(self):
+    @pytest.mark.parametrize("tensor", ([], ()))
+    def test_no_tensormaps(self, tensor):
         """Test if an empty list or tuple is provided."""
-        with self.assertRaises(ValueError) as err:
-            equistore.join([], axis="properties")
-        self.assertIn("provide at least one", str(err.exception))
-        with self.assertRaises(ValueError) as err:
-            equistore.join((), axis="properties")
-        self.assertIn("provide at least one", str(err.exception))
+        with pytest.raises(ValueError, match="provide at least one"):
+            equistore.join(tensor, axis="properties")
 
-    def test_join_properties(self):
+    def test_join_properties(self, tensor):
         """Test public join function with three tensormaps along `properties`.
 
         We check for the values below."""
 
-        ps_joined = equistore.join([self.ps, self.ps, self.ps], axis="properties")
+        tensor_joined = equistore.join([tensor, tensor, tensor], axis="properties")
 
         # test property names
-        names = self.ps.block(0).properties.names
-        self.assertEqual(ps_joined.block(0).properties.names, ("tensor",) + names)
+        names = tensor.block(0).properties.names
+        assert tensor_joined.block(0).properties.names == ("tensor",) + names
 
         # test property values
-        tensor_prop = np.unique(ps_joined.block(0).properties["tensor"])
-        self.assertEqual(set(tensor_prop), set((0, 1, 2)))
+        tensor_prop = np.unique(tensor_joined.block(0).properties["tensor"])
+        assert set(tensor_prop) == set((0, 1, 2))
 
-    def test_join_samples(self):
+    def test_join_samples(self, tensor):
         """Test public join function with three tensormaps along `samples`."""
-        ps_joined = equistore.join([self.ps, self.ps, self.ps], axis="samples")
+        tensor_joined = equistore.join([tensor, tensor, tensor], axis="samples")
 
         # test sample values
-        self.assertEqual(
-            len(ps_joined.block(0).samples), 3 * len(self.ps.block(0).samples)
-        )
+        assert len(tensor_joined.block(0).samples) == 3 * len(tensor.block(0).samples)
 
-    def test_join_error(self):
+    def test_join_error(self, tensor):
         """Test error with unknown `axis` keyword."""
-        with self.assertRaises(ValueError) as err:
-            equistore.join([self.ps, self.ps, self.ps], axis="foo")
-        self.assertIn("values for the `axis` parameter", str(err.exception))
+        with pytest.raises(ValueError, match="values for the `axis` parameter"):
+            equistore.join([tensor, tensor, tensor], axis="foo")
 
-    def test_join_properties_values(self):
+    def test_join_properties_values(self, tensor, first_block):
         """Test values for joining along `properties`."""
-        ts_1 = equistore.slice(self.ps, properties=self.first_block.properties[:1])
-        ts_2 = equistore.slice(self.ps, properties=self.first_block.properties[1:])
+        ts_1 = equistore.slice(tensor, properties=first_block.properties[:1])
+        ts_2 = equistore.slice(tensor, properties=first_block.properties[1:])
 
         ts_joined = equistore.join([ts_1, ts_2], axis="properties")
-        self.assertTrue(equistore.allclose(ts_joined, self.ps))
+        (equistore.allclose_raise(ts_joined, tensor))
 
-    def test_join_properties_different_samples(self):
+    def test_join_properties_different_samples(self, tensor_first_block, first_block):
         """Test error raise if `samples` are not the same."""
-        tm = equistore.slice(self.ps_first_block, samples=self.first_block.samples[:1])
+        tm = equistore.slice(tensor_first_block, samples=first_block.samples[:1])
 
-        with self.assertRaises(ValueError) as err:
-            equistore.join([self.ps_first_block, tm], axis="properties")
-        self.assertIn("samples", str(err.exception))
+        with pytest.raises(ValueError, match="samples"):
+            equistore.join([tensor_first_block, tm], axis="properties")
 
-    def test_join_properties_different_components(self):
+    def test_join_properties_different_components(self, components_tensor):
         """Test error raise if `components` are not the same."""
-        se_c2p = self.se.components_to_properties(["spherical_harmonics_m"])
-        se = equistore.load(
-            path.join(DATA_ROOT, "qm7-spherical-expansion.npz"), use_numpy=True
+        components_tensor_c2p = components_tensor.copy().components_to_properties(
+            ["spherical_harmonics_m"]
         )
-        with self.assertRaises(ValueError) as err:
-            equistore.join([se_c2p, se], axis="properties")
-        self.assertIn("components", str(err.exception))
-
-    def test_join_properties_different_gradients(self):
-        """Test error raise if `gradients` are not the same."""
-        with self.assertRaises(ValueError) as err:
+        with pytest.raises(ValueError, match="components"):
             equistore.join(
-                [self.ps_first_block, self.ps_first_block_extra_grad], axis="properties"
+                [components_tensor_c2p, components_tensor], axis="properties"
             )
-        self.assertIn("gradient", str(err.exception))
 
-    def test_join_samples_values(self):
+    def test_join_properties_different_gradients(
+        self, tensor_first_block, tensor_first_block_extra_grad
+    ):
+        """Test error raise if `gradients` are not the same."""
+        with pytest.raises(ValueError, match="gradient"):
+            equistore.join(
+                [tensor_first_block, tensor_first_block_extra_grad], axis="properties"
+            )
+
+    def test_join_samples_values(self, tensor, first_block):
         """Test values for joining along `samples`."""
         keys = Labels(
-            names=self.ps.keys.names,
-            values=np.array(self.ps.keys[0].tolist()).reshape(1, -1),
+            names=tensor.keys.names,
+            values=np.array(tensor.keys[0].tolist()).reshape(1, -1),
         )
 
-        tm = TensorMap(keys, [self.first_block.copy()])
-        ts_1 = equistore.slice(tm, samples=self.first_block.samples[:1])
-        ts_2 = equistore.slice(tm, samples=self.first_block.samples[1:])
+        tm = TensorMap(keys, [first_block.copy()])
+        ts_1 = equistore.slice(tm, samples=first_block.samples[:1])
+        ts_2 = equistore.slice(tm, samples=first_block.samples[1:])
 
         ts_joined = equistore.join([ts_1, ts_2], axis="samples")
-        self.assertTrue(equistore.allclose(tm, ts_joined))
+        equistore.allclose_raise(tm, ts_joined)
 
-    def test_join_samples_different_properties(self):
+    def test_join_samples_different_properties(self, tensor_first_block, first_block):
         """Test error raise if `proprties` are not the same."""
-        tm = equistore.slice(
-            self.ps_first_block, properties=self.first_block.properties[:1]
-        )
+        tm = equistore.slice(tensor_first_block, properties=first_block.properties[:1])
 
-        with self.assertRaises(ValueError) as err:
-            equistore.join([self.ps_first_block, tm], axis="samples")
-        self.assertIn("properties", str(err.exception))
+        with pytest.raises(ValueError, match="properties"):
+            equistore.join([tensor_first_block, tm], axis="samples")
 
-    def test_join_samples_different_components(self):
+    def test_join_samples_different_components(self, components_tensor):
         """Test error raise if `components` are not the same."""
-        se_c2p = self.se.components_to_properties(["spherical_harmonics_m"])
-        se = equistore.load(
-            path.join(DATA_ROOT, "qm7-spherical-expansion.npz"), use_numpy=True
+        components_tensor_c2p = components_tensor.copy().components_to_properties(
+            ["spherical_harmonics_m"]
         )
-        with self.assertRaises(ValueError) as err:
-            equistore.join([se_c2p, se], axis="samples")
-        self.assertIn("components", str(err.exception))
 
-    def test_join_samples_different_gradients(self):
+        with pytest.raises(ValueError, match="components"):
+            equistore.join([components_tensor_c2p, components_tensor], axis="samples")
+
+    def test_join_samples_different_gradients(
+        self, tensor_first_block, tensor_first_block_extra_grad
+    ):
         """Test error raise if `gradients` are not the same."""
-        with self.assertRaises(ValueError) as err:
+        with pytest.raises(ValueError, match="gradient"):
             equistore.join(
-                [self.ps_first_block, self.ps_first_block_extra_grad], axis="samples"
+                [tensor_first_block, tensor_first_block_extra_grad], axis="samples"
             )
-        self.assertIn("gradient", str(err.exception))
 
 
-class TestJoinLabels(unittest.TestCase):
+class TestJoinLabels:
     """Test edge cases of label joining."""
 
-    def setUp(self):
-        self.sample_labels = Labels(names=["prop"], values=np.arange(2).reshape(-1, 1))
-        self.keys = Labels(names=["prop"], values=np.arange(1).reshape(-1, 1))
+    @pytest.fixture
+    def sample_labels(self):
+        return Labels(names=["prop"], values=np.arange(2).reshape(-1, 1))
 
-    def test_same_names_same_values(self):
+    @pytest.fixture
+    def keys(self):
+        return Labels(names=["prop"], values=np.arange(1).reshape(-1, 1))
+
+    def test_same_names_same_values(self, sample_labels, keys):
         """Test Label joining using labels with same names but same values."""
 
         names = ("structure", "prop_1")
@@ -182,17 +202,17 @@ class TestJoinLabels(unittest.TestCase):
 
         block = TensorBlock(
             values=np.zeros([2, 5]),
-            samples=self.sample_labels,
+            samples=sample_labels,
             components=[],
             properties=property_labels,
         )
 
-        tm = TensorMap(self.keys, [block])
+        tm = TensorMap(keys, [block])
         joined_tm = equistore.join([tm, tm], axis="properties")
 
         joined_labels = joined_tm.block(0).properties
 
-        self.assertEqual(joined_labels.names, ("tensor",) + names)
+        assert joined_labels.names == ("tensor",) + names
 
         ref = np.array(
             [
@@ -209,9 +229,9 @@ class TestJoinLabels(unittest.TestCase):
             ]
         )
 
-        self.assertTrue(np.equal(joined_labels.tolist(), ref).all())
+        assert_equal(joined_labels.tolist(), ref)
 
-    def test_same_names_unique_values(self):
+    def test_same_names_unique_values(self, sample_labels, keys):
         """Test Label joining using labels with same names and unique values."""
         names = ("structure", "prop_1")
         property_labels_1 = Labels(names, np.vstack([np.arange(5), np.arange(5)]).T)
@@ -221,33 +241,31 @@ class TestJoinLabels(unittest.TestCase):
 
         block_1 = TensorBlock(
             values=np.zeros([2, 5]),
-            samples=self.sample_labels,
+            samples=sample_labels,
             components=[],
             properties=property_labels_1,
         )
 
         block_2 = TensorBlock(
             values=np.zeros([2, 5]),
-            samples=self.sample_labels,
+            samples=sample_labels,
             components=[],
             properties=property_labels_2,
         )
 
         joined_tm = equistore.join(
-            [TensorMap(self.keys, [block_1]), TensorMap(self.keys, [block_2])],
+            [TensorMap(keys, [block_1]), TensorMap(keys, [block_2])],
             axis="properties",
         )
 
         joined_labels = joined_tm.block(0).properties
 
-        self.assertEqual(joined_labels.names, ("structure", "prop_1"))
-        self.assertTrue(
-            np.equal(
-                joined_labels.tolist(), np.vstack([np.arange(10), np.arange(10)]).T
-            ).all()
+        assert joined_labels.names == ("structure", "prop_1")
+        assert_equal(
+            joined_labels.tolist(), np.vstack([np.arange(10), np.arange(10)]).T
         )
 
-    def test_different_names(self):
+    def test_different_names(self, sample_labels, keys):
         """Test Label joining using labels with different names."""
         values = np.vstack([np.arange(5), np.arange(5)]).T
         property_labels_1 = Labels(("structure", "prop_1"), -values)
@@ -255,26 +273,26 @@ class TestJoinLabels(unittest.TestCase):
 
         block_1 = TensorBlock(
             values=np.zeros([2, 5]),
-            samples=self.sample_labels,
+            samples=sample_labels,
             components=[],
             properties=property_labels_1,
         )
 
         block_2 = TensorBlock(
             values=np.zeros([2, 5]),
-            samples=self.sample_labels,
+            samples=sample_labels,
             components=[],
             properties=property_labels_2,
         )
 
         joined_tm = equistore.join(
-            [TensorMap(self.keys, [block_1]), TensorMap(self.keys, [block_2])],
+            [TensorMap(keys, [block_1]), TensorMap(keys, [block_2])],
             axis="properties",
         )
 
         joined_labels = joined_tm.block(0).properties
 
-        self.assertEqual(joined_labels.names, ("tensor", "property"))
+        assert joined_labels.names == ("tensor", "property")
 
         ref = np.array(
             [
@@ -291,9 +309,9 @@ class TestJoinLabels(unittest.TestCase):
             ]
         )
 
-        self.assertTrue(np.equal(joined_labels.tolist(), ref).all())
+        assert_equal(joined_labels.tolist(), ref)
 
-    def test_different_names_different_length(self):
+    def test_different_names_different_length(self, sample_labels, keys):
         """Test Label joining using labels with different names and different length."""
         property_labels_1 = Labels(
             ("structure", "prop_1"), np.vstack(2 * [np.arange(5)]).T
@@ -304,26 +322,26 @@ class TestJoinLabels(unittest.TestCase):
 
         block_1 = TensorBlock(
             values=np.zeros([2, 5]),
-            samples=self.sample_labels,
+            samples=sample_labels,
             components=[],
             properties=property_labels_1,
         )
 
         block_2 = TensorBlock(
             values=np.zeros([2, 5]),
-            samples=self.sample_labels,
+            samples=sample_labels,
             components=[],
             properties=property_labels_2,
         )
 
         joined_tm = equistore.join(
-            [TensorMap(self.keys, [block_1]), TensorMap(self.keys, [block_2])],
+            [TensorMap(keys, [block_1]), TensorMap(keys, [block_2])],
             axis="properties",
         )
 
         joined_labels = joined_tm.block(0).properties
 
-        self.assertEqual(joined_labels.names, ("tensor", "property"))
+        assert joined_labels.names == ("tensor", "property")
 
         ref = np.array(
             [
@@ -340,8 +358,4 @@ class TestJoinLabels(unittest.TestCase):
             ]
         )
 
-        self.assertTrue(np.equal(joined_labels.tolist(), ref).all())
-
-
-if __name__ == "__main__":
-    unittest.main()
+        assert_equal(joined_labels.tolist(), ref)


### PR DESCRIPTION
As a starting point to address #195 and #203 this PR ports the tests of `join` to pytest.

<!-- readthedocs-preview equistore start -->
----
:books: Documentation preview :books:: https://equistore--221.org.readthedocs.build/en/221/

<!-- readthedocs-preview equistore end -->