### PR TITLE
Use `keys_to_x` for join operation

### DIFF
--- a/python/src/equistore/operations/join.py
+++ b/python/src/equistore/operations/join.py
@@ -86,19 +86,28 @@ def join(tensor_maps: List[TensorMap], axis: str):
         keys_values += [(i,) + value for value in tensor.keys.tolist()]
 
         for _, block in tensor:
-            samples = block.samples
-            properties = block.properties
-
-            if axis == "properties" and not names_are_same:
+            # We would already raised an error if `axis == "samples"`. Therefore, we can
+            # neglect the check for `axis == "properties"`.
+            if names_are_same:
+                properties = block.properties
+            else:
                 properties = Labels(
-                    ["property"], np.arange(len(properties)).reshape(-1, 1)
+                    ["property"], np.arange(len(block.properties)).reshape(-1, 1)
                 )
 
-            new_block = TensorBlock(block.values, samples, block.components, properties)
+            new_block = TensorBlock(
+                values=block.values,
+                samples=block.samples,
+                components=block.components,
+                properties=properties,
+            )
 
             for parameter, gradient in block.gradients():
                 new_block.add_gradient(
-                    parameter, gradient.data, gradient.samples, gradient.components
+                    parameter=parameter,
+                    data=gradient.data,
+                    samples=gradient.samples,
+                    components=gradient.components,
                 )
 
             blocks.append(new_block)

--- a/python/src/equistore/operations/join.py
+++ b/python/src/equistore/operations/join.py
@@ -1,11 +1,11 @@
-from typing import List
 import functools
 import operator
+from typing import List
 
 import numpy as np
 
 from ..labels import Labels
-from ..tensor import TensorMap, TensorBlock
+from ..tensor import TensorBlock, TensorMap
 from .equal_metadata import _check_maps
 
 
@@ -17,8 +17,9 @@ def join(tensor_maps: List[TensorMap], axis: str):
     `properties` dimension and for ``axis='samples'`` they will be the along the
     samples dimension.
 
-    `join` will create an additional label `tensor` specifiying the original
-    index in the list of `tensor_maps`.
+    ``join`` will create an additional label `tensor` specifiying the original index in
+    the list of `tensor_maps`.  If `sample`/`property` names are not the same in all
+    `tensor_maps` they will be unified with a general name ``"property"``.
 
     :param tensormaps:
         sequence of :py:class:`TensorMap` for join
@@ -39,10 +40,6 @@ def join(tensor_maps: List[TensorMap], axis: str):
     if len(tensor_maps) < 1:
         raise ValueError("provide at least one `TensorMap` for joining")
 
-    if axis == "samples":
-        common_labels_names = _get_common_labels_names()
-    elif axis == "properties":
-        pass
     if axis not in ("samples", "properties"):
         raise ValueError(
             "Only `'properties'` or `'samples'` are "
@@ -55,29 +52,48 @@ def join(tensor_maps: List[TensorMap], axis: str):
     for ts_to_join in tensor_maps[1:]:
         _check_maps(tensor_maps[0], ts_to_join, "join")
 
-    keys_names = tensor_maps[0].keys.names + ("tensor",)
+    # Deduce if sample/property names are the same in all tensor_maps.
+    # If this is not the case we have to change unify the corresponding labels later.
+    if axis == "samples":
+        names_list = [tensor.sample_names for tensor in tensor_maps]
+
+    elif axis == "properties":
+        names_list = [tensor.property_names for tensor in tensor_maps]
+
+    # We use functools to flatten a list of sublists::
+    #
+    #   [('a', 'b', 'c'), ('a', 'b')] -> ['a', 'b', 'c', 'a', 'b']
+    #
+    # A nested list with sublist of different shapes can not be handled by np.unique.
+    unique_names = np.unique(functools.reduce(operator.concat, names_list))
+
+    # Label names are unique: We can do an equal check only checking the lengths.
+    names_are_same = np.all(
+        len(unique_names) == np.array([len(names) for names in names_list])
+    )
+
+    keys_names = ("tensor",) + tensor_maps[0].keys.names
     keys_values = []
     blocks = []
 
     for i, tensor in enumerate(tensor_maps):
-        keys_values += [value + (i,) for value in tensor.keys.tolist()]
+        keys_values += [(i,) + value for value in tensor.keys.tolist()]
 
         for _, block in tensor:
-            if axis == "samples":
-                block = TensorBlock(
-                    block.values,
-                    block.samples,
-                    block.components,
-                    block.properties,
-                )
-            else:
-                block = TensorBlock(
-                    block.values,
-                    block.samples,
-                    block.components,
-                    block.properties,
-                )
+            samples = block.samples
+            properties = block.properties
 
+            if not names_are_same:
+                if axis == "samples":
+                    samples = Labels(
+                        ["property"], np.arange(len(samples)).reshape(-1, 1)
+                    )
+                else:
+                    properties = Labels(
+                        ["property"], np.arange(len(properties)).reshape(-1, 1)
+                    )
+
+            block = TensorBlock(block.values, samples, block.components, properties)
             blocks.append(block)
 
     keys = Labels(names=keys_names, values=np.array(keys_values))
@@ -92,59 +108,3 @@ def join(tensor_maps: List[TensorMap], axis: str):
     # remove the `tensor` label entry after joining.
 
     return tensor_joined
-
-def _get_common_str(labels: List[List[str]) -> List[str]:
-    names_list = [label.names for label in labels]
-
-    # We use functools to flatten a list of sublists::
-    #
-    #   [('a', 'b', 'c'), ('a', 'b')] -> ['a', 'b', 'c', 'a', 'b']
-    #
-    # A nested list with sublist of different shapes can not be handled by np.unique.
-    unique_names = np.unique(functools.reduce(operator.concat, names_list))
-
-    # Label names are unique: We can do an equal check only checking the lengths.
-    names_are_same = np.all(
-        len(unique_names) == np.array([len(names) for names in names_list])
-    )
-
-    if names_are_same:
-        return names_list[0]
-    else:
-        return ["property"]
-
-
-def _join_labels(labels: List[Labels]) -> Labels:
-    """Join a sequence of :py:class:`Labels`"""
-    names_list = [label.names for label in labels]
-    values_list = [label.tolist() for label in labels]
-    tensor_values = np.repeat(
-        a=np.arange(len(values_list)), repeats=[len(value) for value in values_list]
-    )
-
-    # We use functools to flatten a list of sublists::
-    #
-    #   [('a', 'b', 'c'), ('a', 'b')] -> ['a', 'b', 'c', 'a', 'b']
-    #
-    # A nested list with sublist of different shapes can not be handled by np.unique.
-    unique_names = np.unique(functools.reduce(operator.concat, names_list))
-
-    # Label names are unique: We can do an equal check only checking the lengths.
-    names_are_same = np.all(
-        len(unique_names) == np.array([len(names) for names in names_list])
-    )
-
-    if names_are_same:
-        unique_values = np.unique(np.vstack(values_list), axis=0)
-        values_are_unique = len(unique_values) == len(np.vstack(values_list))
-        if values_are_unique:
-            new_names = names_list[0]
-            new_values = np.vstack(values_list)
-        else:
-            new_names = list(names_list[0])
-            new_values = np.vstack(values_list)
-    else:
-        new_names = ["property"]
-        new_values = np.hstack([np.arange(len(values)) for values in values_list])
-
-    return Labels(names=new_names, values=new_values)

--- a/python/src/equistore/operations/join.py
+++ b/python/src/equistore/operations/join.py
@@ -1,69 +1,34 @@
+from typing import List
 import functools
 import operator
-from typing import List
 
 import numpy as np
 
-from ..block import TensorBlock
 from ..labels import Labels
-from ..tensor import TensorMap
-from . import _dispatch
-from .equal_metadata import _check_blocks, _check_maps, _check_same_gradients
+from ..tensor import TensorMap, TensorBlock
+from .equal_metadata import _check_maps
 
 
 def join(tensor_maps: List[TensorMap], axis: str):
     """Join a sequence of :py:class:`TensorMap` along an axis.
 
     The ``axis`` parameter specifies the type join. For example, if
-    ``axis='properties'`` it will be the joined along the properties of the
-    TensorMaps and if ``axis='samples'`` it will be the along the samples.
+    ``axis='properties'`` it will be the `tensor_maps` will be joined along the
+    `properties` dimension and for ``axis='samples'`` they will be the along the
+    samples dimension.
 
-    Possible clashes of the meta data like the property names are resolved by
-    one of the three following strategies:
+    `join` will create an additional label `tensor` specifiying the original
+    index in the list of `tensor_maps`.
 
-    1. If the names are the same and the values are unique we keep the names and
-       join the values vertically::
+    :param tensormaps:
+        sequence of :py:class:`TensorMap` for join
+    :param axis:
+        A string indicating how the tensormaps are stacked. Allowed
+        values are ``'properties'`` or ``'samples'``.
 
-        labels_1 = ["n"], [0, 2, 3] labels_2 = ["n"], [1, 4, 5]
-
-       will lead to::
-
-        joined_labels = ["n"],
-                       [0, 2, 3, 1, 4, 5]
-
-    2. If the names are the same but the values are not unique a new dimension
-       ``"tensor"`` is added to the names::
-
-            labels_1 = ["n"], [0, 2, 3]
-            labels_2 = ["n"], [0, 2]
-
-       will lead to:
-
-            joined_labels = ["tensor", "n"],
-                            [[0, 0], [0, 2], [0, 3], [1, 0], [1, 2]]
-
-       In ``joined_labels`` the label values ``[0, 0], [0, 2], [0, 3]``
-       correspond to ``properties_1`` ``[1, 0], [1, 2]`` correspond to
-       ``properties_2``.
-
-    3. If names of the labels are different we change the names to ("tensor",
-       "property"). This case is only supposed to happen when joining in the
-       property dimension, hence the choice of names. For example::
-
-            properties_1 = ["a"], [0, 2, 3]
-            properties_2 = ["b", "c"], [[0, 0], [1, 2]]
-
-       will lead to:
-
-            joined_properties = ["tensor", "property"],
-                         [[0, 0], [0, 1], [0, 2], [1, 0], [1, 1]]
-
-    :param tensormaps: sequence of :py:class:`TensorMap` for join
-    :param axis: A string indicating how the tensormaps are stacked. Allowed
-                 values are ``'properties'`` or ``'samples'``.
-
-    :return: The stacked :py:class:`TensorMap` with more properties or samples
-             than the input TensorMap.
+    :return tensor_joined:
+        The stacked :py:class:`TensorMap` with more properties or samples
+        than the input TensorMap.
     """
 
     if not isinstance(tensor_maps, (list, tuple)):
@@ -74,27 +39,79 @@ def join(tensor_maps: List[TensorMap], axis: str):
     if len(tensor_maps) < 1:
         raise ValueError("provide at least one `TensorMap` for joining")
 
+    if axis == "samples":
+        common_labels_names = _get_common_labels_names()
+    elif axis == "properties":
+        pass
+    if axis not in ("samples", "properties"):
+        raise ValueError(
+            "Only `'properties'` or `'samples'` are "
+            "valid values for the `axis` parameter."
+        )
+
     if len(tensor_maps) == 1:
         return tensor_maps[0]
 
     for ts_to_join in tensor_maps[1:]:
         _check_maps(tensor_maps[0], ts_to_join, "join")
 
+    keys_names = tensor_maps[0].keys.names + ("tensor",)
+    keys_values = []
     blocks = []
-    for key in tensor_maps[0].keys:
-        blocks_to_join = [ts.block(key) for ts in tensor_maps]
 
-        if axis == "properties":
-            blocks.append(_join_blocks_along_properties(blocks_to_join))
-        elif axis == "samples":
-            blocks.append(_join_blocks_along_samples(blocks_to_join))
-        else:
-            raise ValueError(
-                "Only `'properties'` or `'samples'` are "
-                "valid values for the `axis` parameter."
-            )
+    for i, tensor in enumerate(tensor_maps):
+        keys_values += [value + (i,) for value in tensor.keys.tolist()]
 
-    return TensorMap(tensor_maps[0].keys, blocks)
+        for _, block in tensor:
+            if axis == "samples":
+                block = TensorBlock(
+                    block.values,
+                    block.samples,
+                    block.components,
+                    block.properties,
+                )
+            else:
+                block = TensorBlock(
+                    block.values,
+                    block.samples,
+                    block.components,
+                    block.properties,
+                )
+
+            blocks.append(block)
+
+    keys = Labels(names=keys_names, values=np.array(keys_values))
+    tensor = TensorMap(keys=keys, blocks=blocks)
+
+    if axis == "samples":
+        tensor_joined = tensor.keys_to_samples("tensor")
+    else:
+        tensor_joined = tensor.keys_to_properties("tensor")
+
+    # TODO: once we have functions to manipulate meta data we can try to
+    # remove the `tensor` label entry after joining.
+
+    return tensor_joined
+
+def _get_common_str(labels: List[List[str]) -> List[str]:
+    names_list = [label.names for label in labels]
+
+    # We use functools to flatten a list of sublists::
+    #
+    #   [('a', 'b', 'c'), ('a', 'b')] -> ['a', 'b', 'c', 'a', 'b']
+    #
+    # A nested list with sublist of different shapes can not be handled by np.unique.
+    unique_names = np.unique(functools.reduce(operator.concat, names_list))
+
+    # Label names are unique: We can do an equal check only checking the lengths.
+    names_are_same = np.all(
+        len(unique_names) == np.array([len(names) for names in names_list])
+    )
+
+    if names_are_same:
+        return names_list[0]
+    else:
+        return ["property"]
 
 
 def _join_labels(labels: List[Labels]) -> Labels:
@@ -124,111 +141,10 @@ def _join_labels(labels: List[Labels]) -> Labels:
             new_names = names_list[0]
             new_values = np.vstack(values_list)
         else:
-            new_names = ["tensor"] + list(names_list[0])
-            new_values = np.hstack(
-                [tensor_values.reshape(-1, 1), np.vstack(values_list)]
-            )
+            new_names = list(names_list[0])
+            new_values = np.vstack(values_list)
     else:
-        new_names = ["tensor", "property"]
-        property_values = np.hstack([np.arange(len(values)) for values in values_list])
-        new_values = np.vstack([tensor_values, property_values]).T
+        new_names = ["property"]
+        new_values = np.hstack([np.arange(len(values)) for values in values_list])
 
     return Labels(names=new_names, values=new_values)
-
-
-def _join_blocks_along_properties(blocks: List[TensorBlock]) -> TensorBlock:
-    """Join a sequence of :py:class:`TensorBlock` along their properties."""
-    first_block = blocks[0]
-
-    fname = "_join_blocks_along_properties"
-    for block in blocks[1:]:
-        _check_blocks(first_block, block, ["components", "samples"], fname)
-        _check_same_gradients(first_block, block, ["components", "samples"], fname)
-
-    properties = _join_labels([block.properties for block in blocks])
-    result_block = TensorBlock(
-        values=_dispatch.hstack([block.values for block in blocks]),
-        samples=first_block.samples,
-        components=first_block.components,
-        properties=properties,
-    )
-
-    for parameter, first_gradient in first_block.gradients():
-        # Different blocks might contain different gradient samples
-        gradient_sample_values = np.unique(
-            np.hstack([block.gradient(parameter).samples for block in blocks])
-        ).tolist()
-        gradient_samples = Labels(
-            names=first_gradient.samples.names, values=np.array(gradient_sample_values)
-        )
-
-        gradient_data = np.zeros(
-            (len(gradient_samples),)
-            + first_gradient.data.shape[1:-1]
-            + (len(properties),)
-        )
-
-        properties_start = 0
-        for block in blocks:
-            gradient = block.gradient(parameter)
-
-            # find the correct sample position to put the data
-            for i_grad, sample_grad in enumerate(gradient.samples):
-                i_sample = gradient_samples.position(sample_grad)
-                gradient_data[
-                    i_sample,
-                    ...,
-                    properties_start : properties_start + len(gradient.properties),
-                ] = gradient.data[i_grad]
-
-            properties_start += len(gradient.properties)
-
-        result_block.add_gradient(
-            parameter, gradient_data, gradient_samples, first_gradient.components
-        )
-
-    return result_block
-
-
-def _join_blocks_along_samples(blocks: List[TensorBlock]) -> TensorBlock:
-    """Join a sequence of :py:class:`TensorBlock` along their samples."""
-    first_block = blocks[0]
-
-    fname = "_join_blocks_along_samples"
-    for block in blocks[1:]:
-        _check_blocks(first_block, block, ["components", "properties"], fname)
-        _check_same_gradients(first_block, block, ["components", "properties"], fname)
-
-    result_block = TensorBlock(
-        values=_dispatch.vstack([block.values for block in blocks]),
-        samples=_join_labels([block.samples for block in blocks]),
-        components=first_block.components,
-        properties=first_block.properties,
-    )
-
-    for parameter, first_gradient in first_block.gradients():
-        gradient_data = [first_gradient.data]
-        gradient_samples = [np.array(first_gradient.samples.tolist())]
-
-        for block in blocks[1:]:
-            gradient = block.gradient(parameter)
-            gradient_data.append(gradient.data)
-
-            samples = np.array(gradient.samples.tolist())
-            # update the "sample" dimension in gradient samples
-            samples[:, 0] += 1 + gradient_samples[-1][:, 0].max()
-            gradient_samples.append(samples)
-
-        gradient_data = _dispatch.vstack(gradient_data)
-        gradient_samples = np.vstack(gradient_samples)
-
-        gradients_samples = Labels(first_gradient.samples.names, gradient_samples)
-
-        result_block.add_gradient(
-            parameter,
-            gradient_data,
-            gradients_samples,
-            first_gradient.components,
-        )
-
-    return result_block

--- a/python/src/equistore/operations/join.py
+++ b/python/src/equistore/operations/join.py
@@ -71,6 +71,13 @@ def join(tensor_maps: List[TensorMap], axis: str):
         len(unique_names) == np.array([len(names) for names in names_list])
     )
 
+    # It's fine to loose metadata on the property axis, less so on the sample axis!
+    if axis == "samples" and not names_are_same:
+        raise ValueError(
+            "Sample names are not the same! Joining along samples with unequal sample "
+            "names can lead to severre error."
+        )
+
     keys_names = ("tensor",) + tensor_maps[0].keys.names
     keys_values = []
     blocks = []
@@ -82,15 +89,10 @@ def join(tensor_maps: List[TensorMap], axis: str):
             samples = block.samples
             properties = block.properties
 
-            if not names_are_same:
-                if axis == "samples":
-                    samples = Labels(
-                        ["property"], np.arange(len(samples)).reshape(-1, 1)
-                    )
-                else:
-                    properties = Labels(
-                        ["property"], np.arange(len(properties)).reshape(-1, 1)
-                    )
+            if axis == "properties" and not names_are_same:
+                properties = Labels(
+                    ["property"], np.arange(len(properties)).reshape(-1, 1)
+                )
 
             new_block = TensorBlock(block.values, samples, block.components, properties)
 

--- a/python/src/equistore/operations/join.py
+++ b/python/src/equistore/operations/join.py
@@ -92,8 +92,14 @@ def join(tensor_maps: List[TensorMap], axis: str):
                         ["property"], np.arange(len(properties)).reshape(-1, 1)
                     )
 
-            block = TensorBlock(block.values, samples, block.components, properties)
-            blocks.append(block)
+            new_block = TensorBlock(block.values, samples, block.components, properties)
+
+            for parameter, gradient in block.gradients():
+                new_block.add_gradient(
+                    parameter, gradient.data, gradient.samples, gradient.components
+                )
+
+            blocks.append(new_block)
 
     keys = Labels(names=keys_names, values=np.array(keys_values))
     tensor = TensorMap(keys=keys, blocks=blocks)

--- a/python/tests/operations/join.py
+++ b/python/tests/operations/join.py
@@ -1,7 +1,8 @@
-import unittest
 from os import path
 
 import numpy as np
+import pytest
+from numpy.testing import assert_equal
 
 import equistore
 from equistore import Labels, TensorBlock, TensorMap
@@ -10,171 +11,190 @@ from equistore import Labels, TensorBlock, TensorMap
 DATA_ROOT = path.join(path.dirname(__file__), "..", "data")
 
 
-class TestJoinTensorMap(unittest.TestCase):
-    def setUp(self):
-        self.ps = equistore.load(
-            path.join(DATA_ROOT, "qm7-power-spectrum.npz"), use_numpy=True
+class TestJoinTensorMap:
+    @pytest.fixture
+    def tensor(self):
+        tensor = equistore.load(
+            path.join(DATA_ROOT, "qm7-power-spectrum.npz"),
+            use_numpy=True,
         )
-        self.se = equistore.load(
-            path.join(DATA_ROOT, "qm7-spherical-expansion.npz"), use_numpy=True
-        )
-        self.first_block = self.ps.block(0)
 
         # Test if Tensormaps have at least one gradient. This avoids dropping gradient
         # tests silently by removing gradients from the reference data
-        self.assertIn("positions", self.ps.block(0).gradients_list())
-        self.assertIn("positions", self.se.block(0).gradients_list())
+        assert "positions" in tensor.block(0).gradients_list()
 
-        keys_first_block = Labels(
-            names=self.ps.keys.names,
-            values=np.array(self.ps.keys[0].tolist()).reshape(1, -1),
+        return tensor
+
+    @pytest.fixture
+    def components_tensor(self):
+        components_tensor = equistore.load(
+            path.join(DATA_ROOT, "qm7-spherical-expansion.npz"),
+            use_numpy=True,
         )
 
-        self.ps_first_block = TensorMap(keys_first_block, [self.first_block.copy()])
+        # Test if Tensormaps have at least one gradient. This avoids dropping gradient
+        # tests silently by removing gradients from the reference data
+        assert "positions" in components_tensor.block(0).gradients_list()
 
-        block_extra_grad = self.first_block.copy()
-        gradient = self.ps.block(0).gradient("positions")
+        return components_tensor
+
+    @pytest.fixture
+    def first_block(self, tensor):
+        return tensor.block(0)
+
+    @pytest.fixture
+    def tensor_first_block(self, tensor, first_block):
+        keys_first_block = Labels(
+            names=tensor.keys.names,
+            values=np.array(tensor.keys[0].tolist()).reshape(1, -1),
+        )
+
+        return TensorMap(keys_first_block, [first_block.copy()])
+
+    @pytest.fixture
+    def tensor_first_block_extra_grad(self, tensor, first_block):
+        block_extra_grad = first_block.copy()
+        gradient = tensor.block(0).gradient("positions")
         block_extra_grad.add_gradient(
             "foo", gradient.data, gradient.samples, gradient.components
         )
-        self.ps_first_block_extra_grad = TensorMap(keys_first_block, [block_extra_grad])
 
-    def test_wrong_type(self):
+        keys_first_block = Labels(
+            names=tensor.keys.names,
+            values=np.array(tensor.keys[0].tolist()).reshape(1, -1),
+        )
+
+        return TensorMap(keys_first_block, [block_extra_grad])
+
+    def test_wrong_type(self, tensor):
         """Test if a wrong type (e.g., TensorMap) is provided."""
-        with self.assertRaises(TypeError) as err:
-            equistore.join(self.ps, axis="properties")
-        self.assertIn("list", str(err.exception))
-        self.assertIn("tuple", str(err.exception))
+        with pytest.raises(TypeError, match="list or a tuple"):
+            equistore.join(tensor, axis="properties")
 
-    def test_single_tensormap(self):
+    def test_single_tensormap(self, tensor):
         """Test if only one TensorMap is provided."""
-        ps_joined = equistore.join([self.ps], axis="properties")
-        assert ps_joined is self.ps
+        tensor_joined = equistore.join([tensor], axis="properties")
+        assert tensor_joined is tensor
 
-    def test_no_tensormaps(self):
+    @pytest.mark.parametrize("tensor", ([], ()))
+    def test_no_tensormaps(self, tensor):
         """Test if an empty list or tuple is provided."""
-        with self.assertRaises(ValueError) as err:
-            equistore.join([], axis="properties")
-        self.assertIn("provide at least one", str(err.exception))
-        with self.assertRaises(ValueError) as err:
-            equistore.join((), axis="properties")
-        self.assertIn("provide at least one", str(err.exception))
+        with pytest.raises(ValueError, match="provide at least one"):
+            equistore.join(tensor, axis="properties")
 
-    def test_join_properties(self):
+    def test_join_properties(self, tensor):
         """Test public join function with three tensormaps along `properties`.
 
         We check for the values below."""
 
-        ps_joined = equistore.join([self.ps, self.ps, self.ps], axis="properties")
+        tensor_joined = equistore.join([tensor, tensor, tensor], axis="properties")
 
         # test property names
-        names = self.ps.block(0).properties.names
-        self.assertEqual(ps_joined.block(0).properties.names, ("tensor",) + names)
+        names = tensor.block(0).properties.names
+        assert tensor_joined.block(0).properties.names == ("tensor",) + names
 
         # test property values
-        tensor_prop = np.unique(ps_joined.block(0).properties["tensor"])
-        self.assertEqual(set(tensor_prop), set((0, 1, 2)))
+        tensor_prop = np.unique(tensor_joined.block(0).properties["tensor"])
+        assert set(tensor_prop) == set((0, 1, 2))
 
-    def test_join_samples(self):
+    def test_join_samples(self, tensor):
         """Test public join function with three tensormaps along `samples`."""
-        ps_joined = equistore.join([self.ps, self.ps, self.ps], axis="samples")
+        tensor_joined = equistore.join([tensor, tensor, tensor], axis="samples")
 
         # test sample values
-        self.assertEqual(
-            len(ps_joined.block(0).samples), 3 * len(self.ps.block(0).samples)
-        )
+        assert len(tensor_joined.block(0).samples) == 3 * len(tensor.block(0).samples)
 
-    def test_join_error(self):
+    def test_join_error(self, tensor):
         """Test error with unknown `axis` keyword."""
-        with self.assertRaises(ValueError) as err:
-            equistore.join([self.ps, self.ps, self.ps], axis="foo")
-        self.assertIn("values for the `axis` parameter", str(err.exception))
+        with pytest.raises(ValueError, match="values for the `axis` parameter"):
+            equistore.join([tensor, tensor, tensor], axis="foo")
 
-    def test_join_properties_values(self):
+    def test_join_properties_values(self, tensor, first_block):
         """Test values for joining along `properties`."""
-        ts_1 = equistore.slice(self.ps, properties=self.first_block.properties[:1])
-        ts_2 = equistore.slice(self.ps, properties=self.first_block.properties[1:])
+        ts_1 = equistore.slice(tensor, properties=first_block.properties[:1])
+        ts_2 = equistore.slice(tensor, properties=first_block.properties[1:])
 
         ts_joined = equistore.join([ts_1, ts_2], axis="properties")
-        self.assertTrue(equistore.allclose(ts_joined, self.ps))
+        (equistore.allclose_raise(ts_joined, tensor))
 
-    def test_join_properties_different_samples(self):
+    def test_join_properties_different_samples(self, tensor_first_block, first_block):
         """Test error raise if `samples` are not the same."""
-        tm = equistore.slice(self.ps_first_block, samples=self.first_block.samples[:1])
+        tm = equistore.slice(tensor_first_block, samples=first_block.samples[:1])
 
-        with self.assertRaises(ValueError) as err:
-            equistore.join([self.ps_first_block, tm], axis="properties")
-        self.assertIn("samples", str(err.exception))
+        with pytest.raises(ValueError, match="samples"):
+            equistore.join([tensor_first_block, tm], axis="properties")
 
-    def test_join_properties_different_components(self):
+    def test_join_properties_different_components(self, components_tensor):
         """Test error raise if `components` are not the same."""
-        se_c2p = self.se.components_to_properties(["spherical_harmonics_m"])
-        se = equistore.load(
-            path.join(DATA_ROOT, "qm7-spherical-expansion.npz"), use_numpy=True
+        components_tensor_c2p = components_tensor.copy().components_to_properties(
+            ["spherical_harmonics_m"]
         )
-        with self.assertRaises(ValueError) as err:
-            equistore.join([se_c2p, se], axis="properties")
-        self.assertIn("components", str(err.exception))
-
-    def test_join_properties_different_gradients(self):
-        """Test error raise if `gradients` are not the same."""
-        with self.assertRaises(ValueError) as err:
+        with pytest.raises(ValueError, match="components"):
             equistore.join(
-                [self.ps_first_block, self.ps_first_block_extra_grad], axis="properties"
+                [components_tensor_c2p, components_tensor], axis="properties"
             )
-        self.assertIn("gradient", str(err.exception))
 
-    def test_join_samples_values(self):
+    def test_join_properties_different_gradients(
+        self, tensor_first_block, tensor_first_block_extra_grad
+    ):
+        """Test error raise if `gradients` are not the same."""
+        with pytest.raises(ValueError, match="gradient"):
+            equistore.join(
+                [tensor_first_block, tensor_first_block_extra_grad], axis="properties"
+            )
+
+    def test_join_samples_values(self, tensor, first_block):
         """Test values for joining along `samples`."""
         keys = Labels(
-            names=self.ps.keys.names,
-            values=np.array(self.ps.keys[0].tolist()).reshape(1, -1),
+            names=tensor.keys.names,
+            values=np.array(tensor.keys[0].tolist()).reshape(1, -1),
         )
 
-        tm = TensorMap(keys, [self.first_block.copy()])
-        ts_1 = equistore.slice(tm, samples=self.first_block.samples[:1])
-        ts_2 = equistore.slice(tm, samples=self.first_block.samples[1:])
+        tm = TensorMap(keys, [first_block.copy()])
+        ts_1 = equistore.slice(tm, samples=first_block.samples[:1])
+        ts_2 = equistore.slice(tm, samples=first_block.samples[1:])
 
         ts_joined = equistore.join([ts_1, ts_2], axis="samples")
-        self.assertTrue(equistore.allclose(tm, ts_joined))
+        equistore.allclose_raise(tm, ts_joined)
 
-    def test_join_samples_different_properties(self):
+    def test_join_samples_different_properties(self, tensor_first_block, first_block):
         """Test error raise if `proprties` are not the same."""
-        tm = equistore.slice(
-            self.ps_first_block, properties=self.first_block.properties[:1]
-        )
+        tm = equistore.slice(tensor_first_block, properties=first_block.properties[:1])
 
-        with self.assertRaises(ValueError) as err:
-            equistore.join([self.ps_first_block, tm], axis="samples")
-        self.assertIn("properties", str(err.exception))
+        with pytest.raises(ValueError, match="properties"):
+            equistore.join([tensor_first_block, tm], axis="samples")
 
-    def test_join_samples_different_components(self):
+    def test_join_samples_different_components(self, components_tensor):
         """Test error raise if `components` are not the same."""
-        se_c2p = self.se.components_to_properties(["spherical_harmonics_m"])
-        se = equistore.load(
-            path.join(DATA_ROOT, "qm7-spherical-expansion.npz"), use_numpy=True
+        components_tensor_c2p = components_tensor.copy().components_to_properties(
+            ["spherical_harmonics_m"]
         )
-        with self.assertRaises(ValueError) as err:
-            equistore.join([se_c2p, se], axis="samples")
-        self.assertIn("components", str(err.exception))
 
-    def test_join_samples_different_gradients(self):
+        with pytest.raises(ValueError, match="components"):
+            equistore.join([components_tensor_c2p, components_tensor], axis="samples")
+
+    def test_join_samples_different_gradients(
+        self, tensor_first_block, tensor_first_block_extra_grad
+    ):
         """Test error raise if `gradients` are not the same."""
-        with self.assertRaises(ValueError) as err:
+        with pytest.raises(ValueError, match="gradient"):
             equistore.join(
-                [self.ps_first_block, self.ps_first_block_extra_grad], axis="samples"
+                [tensor_first_block, tensor_first_block_extra_grad], axis="samples"
             )
-        self.assertIn("gradient", str(err.exception))
 
 
-class TestJoinLabels(unittest.TestCase):
+class TestJoinLabels:
     """Test edge cases of label joining."""
 
-    def setUp(self):
-        self.sample_labels = Labels(names=["prop"], values=np.arange(2).reshape(-1, 1))
-        self.keys = Labels(names=["prop"], values=np.arange(1).reshape(-1, 1))
+    @pytest.fixture
+    def sample_labels(self):
+        return Labels(names=["prop"], values=np.arange(2).reshape(-1, 1))
 
-    def test_same_names_same_values(self):
+    @pytest.fixture
+    def keys(self):
+        return Labels(names=["prop"], values=np.arange(1).reshape(-1, 1))
+
+    def test_same_names_same_values(self, sample_labels, keys):
         """Test Label joining using labels with same names but same values."""
 
         names = ("structure", "prop_1")
@@ -182,17 +202,17 @@ class TestJoinLabels(unittest.TestCase):
 
         block = TensorBlock(
             values=np.zeros([2, 5]),
-            samples=self.sample_labels,
+            samples=sample_labels,
             components=[],
             properties=property_labels,
         )
 
-        tm = TensorMap(self.keys, [block])
+        tm = TensorMap(keys, [block])
         joined_tm = equistore.join([tm, tm], axis="properties")
 
         joined_labels = joined_tm.block(0).properties
 
-        self.assertEqual(joined_labels.names, ("tensor",) + names)
+        assert joined_labels.names == ("tensor",) + names
 
         ref = np.array(
             [
@@ -209,9 +229,9 @@ class TestJoinLabels(unittest.TestCase):
             ]
         )
 
-        self.assertTrue(np.equal(joined_labels.tolist(), ref).all())
+        assert_equal(joined_labels.tolist(), ref)
 
-    def test_same_names_unique_values(self):
+    def test_same_names_unique_values(self, sample_labels, keys):
         """Test Label joining using labels with same names and unique values."""
         names = ("structure", "prop_1")
         property_labels_1 = Labels(names, np.vstack([np.arange(5), np.arange(5)]).T)
@@ -221,33 +241,31 @@ class TestJoinLabels(unittest.TestCase):
 
         block_1 = TensorBlock(
             values=np.zeros([2, 5]),
-            samples=self.sample_labels,
+            samples=sample_labels,
             components=[],
             properties=property_labels_1,
         )
 
         block_2 = TensorBlock(
             values=np.zeros([2, 5]),
-            samples=self.sample_labels,
+            samples=sample_labels,
             components=[],
             properties=property_labels_2,
         )
 
         joined_tm = equistore.join(
-            [TensorMap(self.keys, [block_1]), TensorMap(self.keys, [block_2])],
+            [TensorMap(keys, [block_1]), TensorMap(keys, [block_2])],
             axis="properties",
         )
 
         joined_labels = joined_tm.block(0).properties
 
-        self.assertEqual(joined_labels.names, ("structure", "prop_1"))
-        self.assertTrue(
-            np.equal(
-                joined_labels.tolist(), np.vstack([np.arange(10), np.arange(10)]).T
-            ).all()
+        assert joined_labels.names == ("structure", "prop_1")
+        assert_equal(
+            joined_labels.tolist(), np.vstack([np.arange(10), np.arange(10)]).T
         )
 
-    def test_different_names(self):
+    def test_different_names(self, sample_labels, keys):
         """Test Label joining using labels with different names."""
         values = np.vstack([np.arange(5), np.arange(5)]).T
         property_labels_1 = Labels(("structure", "prop_1"), -values)
@@ -255,26 +273,26 @@ class TestJoinLabels(unittest.TestCase):
 
         block_1 = TensorBlock(
             values=np.zeros([2, 5]),
-            samples=self.sample_labels,
+            samples=sample_labels,
             components=[],
             properties=property_labels_1,
         )
 
         block_2 = TensorBlock(
             values=np.zeros([2, 5]),
-            samples=self.sample_labels,
+            samples=sample_labels,
             components=[],
             properties=property_labels_2,
         )
 
         joined_tm = equistore.join(
-            [TensorMap(self.keys, [block_1]), TensorMap(self.keys, [block_2])],
+            [TensorMap(keys, [block_1]), TensorMap(keys, [block_2])],
             axis="properties",
         )
 
         joined_labels = joined_tm.block(0).properties
 
-        self.assertEqual(joined_labels.names, ("tensor", "property"))
+        assert joined_labels.names == ("tensor", "property")
 
         ref = np.array(
             [
@@ -291,9 +309,9 @@ class TestJoinLabels(unittest.TestCase):
             ]
         )
 
-        self.assertTrue(np.equal(joined_labels.tolist(), ref).all())
+        assert_equal(joined_labels.tolist(), ref)
 
-    def test_different_names_different_length(self):
+    def test_different_names_different_length(self, sample_labels, keys):
         """Test Label joining using labels with different names and different length."""
         property_labels_1 = Labels(
             ("structure", "prop_1"), np.vstack(2 * [np.arange(5)]).T
@@ -304,26 +322,26 @@ class TestJoinLabels(unittest.TestCase):
 
         block_1 = TensorBlock(
             values=np.zeros([2, 5]),
-            samples=self.sample_labels,
+            samples=sample_labels,
             components=[],
             properties=property_labels_1,
         )
 
         block_2 = TensorBlock(
             values=np.zeros([2, 5]),
-            samples=self.sample_labels,
+            samples=sample_labels,
             components=[],
             properties=property_labels_2,
         )
 
         joined_tm = equistore.join(
-            [TensorMap(self.keys, [block_1]), TensorMap(self.keys, [block_2])],
+            [TensorMap(keys, [block_1]), TensorMap(keys, [block_2])],
             axis="properties",
         )
 
         joined_labels = joined_tm.block(0).properties
 
-        self.assertEqual(joined_labels.names, ("tensor", "property"))
+        assert joined_labels.names == ("tensor", "property")
 
         ref = np.array(
             [
@@ -340,8 +358,4 @@ class TestJoinLabels(unittest.TestCase):
             ]
         )
 
-        self.assertTrue(np.equal(joined_labels.tolist(), ref).all())
-
-
-if __name__ == "__main__":
-    unittest.main()
+        assert_equal(joined_labels.tolist(), ref)


### PR DESCRIPTION
Fixes #195 and #159

Instead of reimplementing everything from scratch `join` now uses the `keys_to_properties` or `keys_to_samples` methods for joining a list of TensorMaps. This does solve the two issues, simplifies the code and leads to a 7-8 times speedup compared to the current master branch:

```python
tensor = equistore.load(
    os.path.join("../python/tests/data/qm7-power-spectrum.npz"), use_numpy=True
)

%timeit join([tensor,tensor], axis="properties")
```

`5.03 ms ± 82.1 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)`


```python
%timeit equistore.join([tensor,tensor], axis="properties")
```

`37.1 ms ± 336 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)`

The only drawback is that we now have a `tensor` label after the joining. I think this is acceptable for now. I added a TODO and we can try to simplify the labels once we have labels operations. 


<!-- readthedocs-preview equistore start -->
----
:books: Documentation preview :books:: https://equistore--222.org.readthedocs.build/en/222/

<!-- readthedocs-preview equistore end -->