### PR TITLE
Convert `stack` dispatch operations to `concatenate`

### DIFF
--- a/python/src/equistore/operations/_dispatch.py
+++ b/python/src/equistore/operations/_dispatch.py
@@ -196,32 +196,23 @@ def nan_to_num(X, nan=0.0, posinf=None, neginf=None):
         raise TypeError(UNKNOWN_ARRAY_TYPE)
 
 
-def hstack(arrays):
-    """Stack horizontally a group of arrays.
+def concatenate(arrays, axis):
+    """
+    Concatenate a group of arrays along a given axis.
 
-    This function has the same behavior as ``numpy.hstack(arrays)``.
+    This function has the same behavior as ``numpy.concatenate(arrays, axis)``
+    and ``torch.concatenate(arrays, axis)``.
+
+    Passing `axis` as ``0`` is equivalent to :py:func:`numpy.vstack`, ``1`` to
+    :py:func:`numpy.hstack`, and ``2`` to :py:func:`numpy.dstack`, though any
+    axis index > 0 is valid.
     """
     if isinstance(arrays[0], np.ndarray):
         _check_all_same_type(arrays, np.ndarray)
-        return np.hstack(arrays)
+        return np.concatenate(arrays, axis)
     elif isinstance(arrays[0], TorchTensor):
         _check_all_same_type(arrays, TorchTensor)
-        return torch.hstack(arrays)
-    else:
-        raise TypeError(UNKNOWN_ARRAY_TYPE)
-
-
-def vstack(arrays):
-    """Stack vertically a group of arrays.
-
-    This function has the same behavior as ``numpy.vstack(arrays)``.
-    """
-    if isinstance(arrays[0], np.ndarray):
-        _check_all_same_type(arrays, np.ndarray)
-        return np.vstack(arrays)
-    elif isinstance(arrays[0], TorchTensor):
-        _check_all_same_type(arrays, TorchTensor)
-        return torch.vstack(arrays)
+        return torch.concatenate(arrays, axis)
     else:
         raise TypeError(UNKNOWN_ARRAY_TYPE)
 

--- a/python/src/equistore/operations/divide.py
+++ b/python/src/equistore/operations/divide.py
@@ -108,7 +108,7 @@ def _divide_block_block(block1: TensorBlock, block2: TensorBlock) -> TensorBlock
                 / block2.values[isample] ** 2
                 + gradient1.data[isample_grad1] / block2.values[isample]
             )
-        values_grad = _dispatch.vstack(values_grad)
+        values_grad = _dispatch.concatenate(values_grad, axis=0)
 
         result_block.add_gradient(
             parameter1,

--- a/python/src/equistore/operations/join.py
+++ b/python/src/equistore/operations/join.py
@@ -147,7 +147,7 @@ def _join_blocks_along_properties(blocks: List[TensorBlock]) -> TensorBlock:
 
     properties = _join_labels([block.properties for block in blocks])
     result_block = TensorBlock(
-        values=_dispatch.hstack([block.values for block in blocks]),
+        values=_dispatch.concatenate([block.values for block in blocks], axis=1),
         samples=first_block.samples,
         components=first_block.components,
         properties=properties,
@@ -200,7 +200,7 @@ def _join_blocks_along_samples(blocks: List[TensorBlock]) -> TensorBlock:
         _check_same_gradients(first_block, block, ["components", "properties"], fname)
 
     result_block = TensorBlock(
-        values=_dispatch.vstack([block.values for block in blocks]),
+        values=_dispatch.concatenate([block.values for block in blocks], axis=0),
         samples=_join_labels([block.samples for block in blocks]),
         components=first_block.components,
         properties=first_block.properties,
@@ -219,7 +219,7 @@ def _join_blocks_along_samples(blocks: List[TensorBlock]) -> TensorBlock:
             samples[:, 0] += 1 + gradient_samples[-1][:, 0].max()
             gradient_samples.append(samples)
 
-        gradient_data = _dispatch.vstack(gradient_data)
+        gradient_data = _dispatch.concatenate(gradient_data, axis=0)
         gradient_samples = np.vstack(gradient_samples)
 
         gradients_samples = Labels(first_gradient.samples.names, gradient_samples)

--- a/python/src/equistore/operations/lstsq.py
+++ b/python/src/equistore/operations/lstsq.py
@@ -80,11 +80,11 @@ def _lstsq_block(X: TensorBlock, Y: TensorBlock, rcond, driver) -> TensorBlock:
 
     for parameter, X_gradient in X.gradients():
         X_gradient_data = X_gradient.data.reshape(-1, X_n_properties)
-        X_values = _dispatch.vstack((X_values, X_gradient_data))
+        X_values = _dispatch.concatenate((X_values, X_gradient_data), axis=0)
 
         Y_gradient = Y.gradient(parameter)
         Y_gradient_data = Y_gradient.data.reshape(-1, Y_n_properties)
-        Y_values = _dispatch.vstack((Y_values, Y_gradient_data))
+        Y_values = _dispatch.concatenate((Y_values, Y_gradient_data), axis=0)
 
     weights = _dispatch.lstsq(X_values, Y_values, rcond=rcond, driver=driver)
 

--- a/python/src/equistore/operations/multiply.py
+++ b/python/src/equistore/operations/multiply.py
@@ -106,7 +106,7 @@ def _multiply_block_block(block1: TensorBlock, block2: TensorBlock) -> TensorBlo
                 block1.values[isample] * gradient2.data[isample_grad2]
                 + gradient1.data[isample_grad1] * block2.values[isample]
             )
-        values_grad = _dispatch.vstack(values_grad)
+        values_grad = _dispatch.concatenate(values_grad, axis=0)
 
         result_block.add_gradient(
             parameter1,

--- a/python/src/equistore/operations/pow.py
+++ b/python/src/equistore/operations/pow.py
@@ -64,7 +64,7 @@ def _pow_block_constant(block: TensorBlock, constant: float) -> TensorBlock:
             )
             ** (constant - 1)
         )
-        values_grad = _dispatch.vstack(values_grad)
+        values_grad = _dispatch.concatenate(values_grad, axis=0)
 
         result_block.add_gradient(
             parameter,

--- a/python/src/equistore/operations/solve.py
+++ b/python/src/equistore/operations/solve.py
@@ -144,11 +144,11 @@ def _solve_block(X: TensorBlock, Y: TensorBlock) -> TensorBlock:
 
     for parameter, X_gradient in X.gradients():
         X_gradient_data = X_gradient.data.reshape(-1, X_n_properties)
-        X_values = _dispatch.vstack((X_values, X_gradient_data))
+        X_values = _dispatch.concatenate((X_values, X_gradient_data), axis=0)
 
         Y_gradient = Y.gradient(parameter)
         Y_gradient_data = Y_gradient.data.reshape(-1, Y_n_properties)
-        Y_values = _dispatch.vstack((Y_values, Y_gradient_data))
+        Y_values = _dispatch.concatenate((Y_values, Y_gradient_data), axis=0)
 
     weights = _dispatch.solve(X_values, Y_values)
 


### PR DESCRIPTION
numpy vstack, hstack, and dstack operations essentially wrap a `concatenate` operation along axes 0, 1, and 2, respectively. For TensorMaps with multiple components dimensions this nomenclature can be confusing. 

This PR removes explicit calls to `_dispatch.xstack`, replacing them with `_dispatch.concatenate`, requiring the axis to be passed by hand. This should help avoid bugs in the future, such as in #195.

<!-- readthedocs-preview equistore start -->
----
:books: Documentation preview :books:: https://equistore--224.org.readthedocs.build/en/224/

<!-- readthedocs-preview equistore end -->