### PR TITLE
Disable shallow copies of TensorMap/TensorBlock

### DIFF
--- a/python/src/equistore/block.py
+++ b/python/src/equistore/block.py
@@ -101,6 +101,11 @@ class TensorBlock:
             if self._parent is None:
                 self._lib.eqs_block_free(self._actual_ptr)
 
+    def __copy__(self):
+        raise ValueError(
+            "shallow copies of TensorBlock are not possible, use a deepcopy instead"
+        )
+
     def __deepcopy__(self, _memodict):
         new_ptr = self._lib.eqs_block_copy(self._ptr)
         return TensorBlock._from_ptr(new_ptr, parent=None)

--- a/python/src/equistore/tensor.py
+++ b/python/src/equistore/tensor.py
@@ -72,6 +72,11 @@ class TensorMap:
         if hasattr(self, "_lib") and self._lib is not None and hasattr(self, "_ptr"):
             self._lib.eqs_tensormap_free(self._ptr)
 
+    def __copy__(self):
+        raise ValueError(
+            "shallow copies of TensorMap are not possible, use a deepcopy instead"
+        )
+
     def __deepcopy__(self, _memodict):
         new_ptr = self._lib.eqs_tensormap_copy(self._ptr)
         return TensorMap._from_ptr(new_ptr)

--- a/python/tests/blocks.py
+++ b/python/tests/blocks.py
@@ -1,3 +1,5 @@
+import copy
+
 import numpy as np
 import pytest
 from numpy.testing import assert_equal
@@ -194,19 +196,35 @@ properties (2): ['properties']"""
             ],
             properties=Labels(["properties"], np.array([[5], [3]], dtype=np.int32)),
         )
-        copy = block.copy()
+
+        # using TensorBlock.copy
+        clone = block.copy()
         block_values_id = id(block.values)
 
         del block
 
-        assert id(copy.values) != block_values_id
+        assert id(clone.values) != block_values_id
 
-        assert_equal(copy.values, np.full((3, 3, 2), 2.0))
-        assert copy.samples.names == ("samples",)
-        assert len(copy.samples) == 3
-        assert tuple(copy.samples[0]) == (0,)
-        assert tuple(copy.samples[1]) == (2,)
-        assert tuple(copy.samples[2]) == (4,)
+        assert_equal(clone.values, np.full((3, 3, 2), 2.0))
+        assert clone.samples.names == ("samples",)
+        assert len(clone.samples) == 3
+        assert tuple(clone.samples[0]) == (0,)
+        assert tuple(clone.samples[1]) == (2,)
+        assert tuple(clone.samples[2]) == (4,)
+
+        # using copy.deepcopy
+        other_clone = clone.copy()
+        block_values_id = id(clone.values)
+
+        del clone
+
+        assert id(other_clone.values) != block_values_id
+        assert_equal(other_clone.values, np.full((3, 3, 2), 2.0))
+
+    def test_shallow_copy_error(self, block):
+        msg = "shallow copies of TensorBlock are not possible, use a deepcopy instead"
+        with pytest.raises(ValueError, match=msg):
+            copy.copy(block)
 
     def test_eq(self, block):
         assert equistore.equal_block(block, block) == (block == block)

--- a/python/tests/tensor.py
+++ b/python/tests/tensor.py
@@ -1,3 +1,5 @@
+import copy
+
 import numpy as np
 import pytest
 from numpy.testing import assert_equal
@@ -16,14 +18,28 @@ class TestTensorMap:
         return large_tensor_map()
 
     def test_copy(self, tensor):
-        copy = tensor.copy()
+        # Using TensorMap.copy
+        clone = tensor.copy()
         block_1_values_id = id(tensor.block(0).values)
 
         del tensor
 
-        assert id(copy.block(0).values) != block_1_values_id
+        assert id(clone.block(0).values) != block_1_values_id
+        assert_equal(clone.block(0).values, np.full((3, 1, 1), 1.0))
 
-        assert_equal(copy.block(0).values, np.full((3, 1, 1), 1.0))
+        # Using copy.deepcopy
+        other_clone = copy.deepcopy(clone)
+        block_1_values_id = id(clone.block(0).values)
+
+        del clone
+
+        assert id(other_clone.block(0).values) != block_1_values_id
+        assert_equal(other_clone.block(0).values, np.full((3, 1, 1), 1.0))
+
+    def test_shallow_copy_error(self, tensor):
+        msg = "shallow copies of TensorMap are not possible, use a deepcopy instead"
+        with pytest.raises(ValueError, match=msg):
+            copy.copy(tensor)
 
     def test_keys(self, tensor):
         assert tensor.keys.names == ("key_1", "key_2")


### PR DESCRIPTION
They will result in double free, since two Python objects now refer to the same C pointer.

This fixes the issue in https://github.com/lab-cosmo/equistore/issues/134#issuecomment-1477760811 by making this test raise an exception instead of trying to double free the pointer.

This should only impact people trying to use `copy.copy` to make copies, instead of `TensorMap.copy` or `copy.deepcopy`.

<!-- readthedocs-preview equistore start -->
----
:books: Documentation preview :books:: https://equistore--226.org.readthedocs.build/en/226/

<!-- readthedocs-preview equistore end -->