### PR TITLE
Embedding asv benchmark framework

### DIFF
--- a/python/asv_benchmarks/asv-asvenv.conf.json
+++ b/python/asv_benchmarks/asv-asvenv.conf.json
@@ -1,0 +1,206 @@
+{
+    // The version of the config file format.  Do not change, unless
+    // you know what you are doing.
+    "version": 1,
+
+    // The name of the project being benchmarked
+    "project": "equistore",
+
+    // The project's homepage
+    "project_url": "https://lab-cosmo.github.io/equistore/latest/",
+
+    // The URL or local path of the source code repository for the
+    // project being benchmarked
+    "repo": "../../",
+
+    // The Python project's subdirectory in your repo.  If missing or
+    // the empty string, the project is assumed to be located at the root
+    // of the repository.
+    // Changes folder where commands are run to root
+    // ./python/asv_benchmarks/.asv/env/<COMMIT>/projects -> ./
+    "repo_subdir": "../../../../../../",
+
+    // Customizable commands for building, installing, and
+    // uninstalling the project. See asv.conf.json documentation.
+    // uninstall_command is run in env directory
+    "uninstall_command": [
+        "python -m pip uninstall -y {project}"
+    ],
+    "build_command": [
+        // deletes alse files in the ./dist folder
+        "python -c 'import os; None if os.path.exists(\"./dist\") else exit(); map(lambda filename : os.remove(\"./dist/\"+filename), os.listdir(\"./dist\"))'",
+        "pip wheel --no-deps -w dist ."
+    ],
+    "install_command": [
+        // DEBUG
+        //"python -c 'import os; print(os.listdir(\"./dist\"), flush=True)'",
+        //"python -c 'import os; print(os.getcwd(), flush=True)'",
+        "python -c 'import os; os.system(\"python -m pip install dist/\"+os.listdir(\"./dist\")[0])'",
+        // PR COMMENT regex are not supported so we need to do it with python
+        // DEBUG 
+        //"python -m pip install dist/equistore-0.1.0.dev201-py3-none-linux_x86_64.whl",
+        //"python -c 'import os; os.system(f'python -m pip install dist/{os.listdir(\"./dist\")[0]})",
+        //"python -c 'import os; os.rename(os.path.join(\"dist\", os.listdir(\"./dist\")[0]), \"./dist/equistore.whl\")'",
+        //"python -m pip install dist/equistore.whl"
+    ],
+
+    // List of branches to benchmark. If not provided, defaults to "master"
+    // (for git) or "default" (for mercurial).
+    // "branches": ["master"], // for git
+    // "branches": ["default"],    // for mercurial
+
+    // The DVCS being used.  If not set, it will be automatically
+    // determined from "repo" by looking at the protocol in the URL
+    // (if remote), or by looking for special directories, such as
+    // ".git" (if local).
+    // "dvcs": "git",
+
+    // The tool to use to create environments.  May be "conda",
+    // "virtualenv" or other value depending on the plugins in use.
+    // If missing or the empty string, the tool will be automatically
+    // determined by looking for tools on the PATH environment
+    // variable.
+    "environment_type": "virtualenv",
+
+    // timeout in seconds for installing any dependencies in environment
+    // defaults to 10 min
+    //"install_timeout": 600,
+
+    // the base URL to show a commit for the project.
+    "show_commit_url": "http://github.com/lab-cosmo/equistore/commit/",
+
+    // The Pythons you'd like to test against.  If not provided, defaults
+    // to the current version of Python used to run `asv`.
+    "pythons": ["3.8"],
+
+    // The list of conda channel names to be searched for benchmark
+    // dependency packages in the specified order
+    // "conda_channels": ["conda-forge", "defaults"],
+
+    // A conda environment file that is used for environment creation.
+    // "conda_environment_file": "environment.yml",
+
+    // The matrix of dependencies to test.  Each key of the "req"
+    // requirements dictionary is the name of a package (in PyPI) and
+    // the values are version numbers.  An empty list or empty string
+    // indicates to just test against the default (latest)
+    // version. null indicates that the package is to not be
+    // installed. If the package to be tested is only available from
+    // PyPi, and the 'environment_type' is conda, then you can preface
+    // the package name by 'pip+', and the package will be installed
+    // via pip (with all the conda available packages installed first,
+    // followed by the pip installed packages).
+    //
+    // The ``@env`` and ``@env_nobuild`` keys contain the matrix of
+    // environment variables to pass to build and benchmark commands.
+    // An environment will be created for every combination of the
+    // cartesian product of the "@env" variables in this matrix.
+    // Variables in "@env_nobuild" will be passed to every environment
+    // during the benchmark phase, but will not trigger creation of
+    // new environments.  A value of ``null`` means that the variable
+    // will not be set for the current combination.
+    //
+    // "matrix": {
+    //     "req": {
+    //         "numpy": ["1.6", "1.7"],
+    //         "six": ["", null],  // test with and without six installed
+    //         "pip+emcee": [""]   // emcee is only available for install with pip.
+    //     },
+    //     "env": {"ENV_VAR_1": ["val1", "val2"]},
+    //     "env_nobuild": {"ENV_VAR_2": ["val3", null]},
+    // },
+    "matrix": {
+        "req": {
+            "numpy": [],
+            "wget": []
+        }
+    },
+
+    // Combinations of libraries/python versions can be excluded/included
+    // from the set to test. Each entry is a dictionary containing additional
+    // key-value pairs to include/exclude.
+    //
+    // An exclude entry excludes entries where all values match. The
+    // values are regexps that should match the whole string.
+    //
+    // An include entry adds an environment. Only the packages listed
+    // are installed. The 'python' key is required. The exclude rules
+    // do not apply to includes.
+    //
+    // In addition to package names, the following keys are available:
+    //
+    // - python
+    //     Python version, as in the *pythons* variable above.
+    // - environment_type
+    //     Environment type, as above.
+    // - sys_platform
+    //     Platform, as in sys.platform. Possible values for the common
+    //     cases: 'linux2', 'win32', 'cygwin', 'darwin'.
+    // - req
+    //     Required packages
+    // - env
+    //     Environment variables
+    // - env_nobuild
+    //     Non-build environment variables
+    //
+    // "exclude": [
+    //     {"python": "3.2", "sys_platform": "win32"}, // skip py3.2 on windows
+    //     {"environment_type": "conda", "req": {"six": null}}, // don't run without six on conda
+    //     {"env": {"ENV_VAR_1": "val2"}}, // skip val2 for ENV_VAR_1
+    // ],
+    //
+    // "include": [
+    //     // additional env for python2.7
+    //     {"python": "2.7", "req": {"numpy": "1.8"}, "env_nobuild": {"FOO": "123"}},
+    //     // additional env if run on windows+conda
+    //     {"platform": "win32", "environment_type": "conda", "python": "2.7", "req": {"libpython": ""}},
+    // ],
+
+    // The directory (relative to the current directory) that benchmarks are
+    // stored in.  If not provided, defaults to "benchmarks"
+    // "benchmark_dir": "benchmarks",
+
+    // The directory (relative to the current directory) to cache the Python
+    // environments in.  If not provided, defaults to "env"
+    "env_dir": ".asv/env",
+
+    // The directory (relative to the current directory) that raw benchmark
+    // results are stored in.  If not provided, defaults to "results".
+    "results_dir": ".asv/results",
+
+    // The directory (relative to the current directory) that the html tree
+    // should be written to.  If not provided, defaults to "html".
+    "html_dir": ".asv/html",
+
+    // The number of characters to retain in the commit hashes.
+    // "hash_length": 8,
+
+    // `asv` will cache results of the recent builds in each
+    // environment, making them faster to install next time.  This is
+    // the number of builds to keep, per environment.
+    // "build_cache_size": 2,
+
+    // The commits after which the regression search in `asv publish`
+    // should start looking for regressions. Dictionary whose keys are
+    // regexps matching to benchmark names, and values corresponding to
+    // the commit (exclusive) after which to start looking for
+    // regressions.  The default is to start from the first commit
+    // with results. If the commit is `null`, regression detection is
+    // skipped for the matching benchmark.
+    //
+    // "regressions_first_commits": {
+    //    "some_benchmark": "352cdf",  // Consider regressions only after this commit
+    //    "another_benchmark": null,   // Skip regression detection altogether
+    // },
+
+    // The thresholds for relative change in results, after which `asv
+    // publish` starts reporting regressions. Dictionary of the same
+    // form as in ``regressions_first_commits``, with values
+    // indicating the thresholds.  If multiple entries match, the
+    // maximum is taken. If no entry matches, the default is 5%.
+    //
+    // "regressions_thresholds": {
+    //    "some_benchmark": 0.01,     // Threshold of 1%
+    //    "another_benchmark": 0.5,   // Threshold of 50%
+    // },
+}

--- a/python/asv_benchmarks/asv-toxenv.conf.json
+++ b/python/asv_benchmarks/asv-toxenv.conf.json
@@ -1,0 +1,184 @@
+{
+    // The version of the config file format.  Do not change, unless
+    // you know what you are doing.
+    "version": 1,
+
+    // The name of the project being benchmarked
+    "project": "equistore",
+
+    // The project's homepage
+    "project_url": "https://lab-cosmo.github.io/equistore/latest/",
+
+    // The URL or local path of the source code repository for the
+    // project being benchmarked
+    "repo": "../../",
+
+    // The Python project's subdirectory in your repo.  If missing or
+    // the empty string, the project is assumed to be located at the root
+    // of the repository.
+    "repo_subdir": "../../../../../../",
+
+    // Customizable commands for building, installing, and
+    // uninstalling the project. See asv.conf.json documentation.
+    //
+    // "install_command": ["in-dir={env_dir} python -mpip install {wheel_file}"],
+    // "uninstall_command": ["return-code=any python -mpip uninstall -y {project}"],
+    // "build_command": [
+    //     "python setup.py build",
+    //     "PIP_NO_BUILD_ISOLATION=false python -mpip wheel --no-deps --no-index -w {build_cache_dir} {build_dir}"
+    // ],
+
+    // List of branches to benchmark. If not provided, defaults to "master"
+    // (for git) or "default" (for mercurial).
+    // "branches": ["master"], // for git
+    // "branches": ["default"],    // for mercurial
+
+    // The DVCS being used.  If not set, it will be automatically
+    // determined from "repo" by looking at the protocol in the URL
+    // (if remote), or by looking for special directories, such as
+    // ".git" (if local).
+    // "dvcs": "git",
+
+    // The tool to use to create environments.  May be "conda",
+    // "virtualenv" or other value depending on the plugins in use.
+    // If missing or the empty string, the tool will be automatically
+    // determined by looking for tools on the PATH environment
+    // variable.
+    "environment_type": "virtualenv",
+
+    // timeout in seconds for installing any dependencies in environment
+    // defaults to 10 min
+    //"install_timeout": 600,
+
+    // the base URL to show a commit for the project.
+    "show_commit_url": "http://github.com/lab-cosmo/equistore/commit/",
+
+    // The Pythons you'd like to test against.  If not provided, defaults
+    // to the current version of Python used to run `asv`.
+    "pythons": ["3.8"],
+
+    // The list of conda channel names to be searched for benchmark
+    // dependency packages in the specified order
+    // "conda_channels": ["conda-forge", "defaults"],
+
+    // A conda environment file that is used for environment creation.
+    // "conda_environment_file": "environment.yml",
+
+    // The matrix of dependencies to test.  Each key of the "req"
+    // requirements dictionary is the name of a package (in PyPI) and
+    // the values are version numbers.  An empty list or empty string
+    // indicates to just test against the default (latest)
+    // version. null indicates that the package is to not be
+    // installed. If the package to be tested is only available from
+    // PyPi, and the 'environment_type' is conda, then you can preface
+    // the package name by 'pip+', and the package will be installed
+    // via pip (with all the conda available packages installed first,
+    // followed by the pip installed packages).
+    //
+    // The ``@env`` and ``@env_nobuild`` keys contain the matrix of
+    // environment variables to pass to build and benchmark commands.
+    // An environment will be created for every combination of the
+    // cartesian product of the "@env" variables in this matrix.
+    // Variables in "@env_nobuild" will be passed to every environment
+    // during the benchmark phase, but will not trigger creation of
+    // new environments.  A value of ``null`` means that the variable
+    // will not be set for the current combination.
+    //
+    // "matrix": {
+    //     "req": {
+    //         "numpy": ["1.6", "1.7"],
+    //         "six": ["", null],  // test with and without six installed
+    //         "pip+emcee": [""]   // emcee is only available for install with pip.
+    //     },
+    //     "env": {"ENV_VAR_1": ["val1", "val2"]},
+    //     "env_nobuild": {"ENV_VAR_2": ["val3", null]},
+    // },
+
+    // Combinations of libraries/python versions can be excluded/included
+    // from the set to test. Each entry is a dictionary containing additional
+    // key-value pairs to include/exclude.
+    //
+    // An exclude entry excludes entries where all values match. The
+    // values are regexps that should match the whole string.
+    //
+    // An include entry adds an environment. Only the packages listed
+    // are installed. The 'python' key is required. The exclude rules
+    // do not apply to includes.
+    //
+    // In addition to package names, the following keys are available:
+    //
+    // - python
+    //     Python version, as in the *pythons* variable above.
+    // - environment_type
+    //     Environment type, as above.
+    // - sys_platform
+    //     Platform, as in sys.platform. Possible values for the common
+    //     cases: 'linux2', 'win32', 'cygwin', 'darwin'.
+    // - req
+    //     Required packages
+    // - env
+    //     Environment variables
+    // - env_nobuild
+    //     Non-build environment variables
+    //
+    // "exclude": [
+    //     {"python": "3.2", "sys_platform": "win32"}, // skip py3.2 on windows
+    //     {"environment_type": "conda", "req": {"six": null}}, // don't run without six on conda
+    //     {"env": {"ENV_VAR_1": "val2"}}, // skip val2 for ENV_VAR_1
+    // ],
+    //
+    // "include": [
+    //     // additional env for python2.7
+    //     {"python": "2.7", "req": {"numpy": "1.8"}, "env_nobuild": {"FOO": "123"}},
+    //     // additional env if run on windows+conda
+    //     {"platform": "win32", "environment_type": "conda", "python": "2.7", "req": {"libpython": ""}},
+    // ],
+
+    // The directory (relative to the current directory) that benchmarks are
+    // stored in.  If not provided, defaults to "benchmarks"
+    // "benchmark_dir": "benchmarks",
+
+    // The directory (relative to the current directory) to cache the Python
+    // environments in.  If not provided, defaults to "env"
+    "env_dir": ".asv/env",
+
+    // The directory (relative to the current directory) that raw benchmark
+    // results are stored in.  If not provided, defaults to "results".
+    "results_dir": ".asv/results",
+
+    // The directory (relative to the current directory) that the html tree
+    // should be written to.  If not provided, defaults to "html".
+    "html_dir": ".asv/html",
+
+    // The number of characters to retain in the commit hashes.
+    // "hash_length": 8,
+
+    // `asv` will cache results of the recent builds in each
+    // environment, making them faster to install next time.  This is
+    // the number of builds to keep, per environment.
+    // "build_cache_size": 2,
+
+    // The commits after which the regression search in `asv publish`
+    // should start looking for regressions. Dictionary whose keys are
+    // regexps matching to benchmark names, and values corresponding to
+    // the commit (exclusive) after which to start looking for
+    // regressions.  The default is to start from the first commit
+    // with results. If the commit is `null`, regression detection is
+    // skipped for the matching benchmark.
+    //
+    // "regressions_first_commits": {
+    //    "some_benchmark": "352cdf",  // Consider regressions only after this commit
+    //    "another_benchmark": null,   // Skip regression detection altogether
+    // },
+
+    // The thresholds for relative change in results, after which `asv
+    // publish` starts reporting regressions. Dictionary of the same
+    // form as in ``regressions_first_commits``, with values
+    // indicating the thresholds.  If multiple entries match, the
+    // maximum is taken. If no entry matches, the default is 5%.
+    //
+    // "regressions_thresholds": {
+    //    "some_benchmark": 0.01,     // Threshold of 1%
+    //    "another_benchmark": 0.5,   // Threshold of 50%
+    // },
+}

--- a/python/asv_benchmarks/benchmarks/operations.py
+++ b/python/asv_benchmarks/benchmarks/operations.py
@@ -1,0 +1,20 @@
+import equistore
+from equistore import TensorMap, TensorBlock, Labels
+import numpy as np
+print(equistore.__file__, flush=True)
+
+class JoinSuite:
+    def setup(self):
+        # PR COMMENT
+        #  this file is run in some tmp folder so 
+        #  I download it for now to simplify life
+        #  not intended to be merged
+        import wget
+        wget.download("https://github.com/lab-cosmo/equistore/raw/master/python/tests/data/qm7-power-spectrum.npz")
+        self.tensor = equistore.load(
+            "qm7-power-spectrum.npz",
+            use_numpy=True,
+        )
+
+    def time_equistore_join(self):
+        equistore.join([self.tensor, self.tensor], axis="properties")

--- a/tox.ini
+++ b/tox.ini
@@ -37,6 +37,52 @@ commands =
     # Run documentation tests
     pytest --doctest-modules --pyargs equistore
 
+[testenv:asv-toxenv]
+# this environement runs asv benchmarks
+
+deps =
+    asv
+    numpy
+    wget # PR COMMENT tmp dependency
+
+commands =
+    # tried to set up environment in asv,
+    # but asv does not support neither bash
+    # nor regex expressions which made it 
+    # hard to translate these comments
+    bash -c "rm -rf ./dist"
+    pip wheel --no-deps -w dist .
+    bash -c "python -m pip uninstall equistore -y"
+    bash -c "python -m pip install --no-deps ./dist/equistore-*.whl"
+    # Run benchmarks
+    # PR COMMENT can we make run also part of posargs? 
+    #   because the run comment must come before 
+    # PR COMMENT verbose will be removed for merge 
+    asv run --config python/asv_benchmarks/asv-toxenv.conf.json -e --python=same --verbose {posargs}
+
+[testenv:asv-asvenv]
+# this environement runs asv benchmarks
+
+deps =
+    asv
+    virtualenv
+    numpy
+    wget # PR COMMENT tmp dependency
+
+commands =
+    # tried to set up environment in asv,
+    # but asv does not support neither bash
+    # nor regex expressions which made it 
+    # hard to translate these comments
+    bash -c "rm -rf ./dist"
+    # Run benchmarks
+    # PR COMMENT can we make run also part of posargs? 
+    #   because the run comment must come before 
+    #asv {posargs1:run}--config python/asv_benchmarks/asv-asvenv.conf.json -e --verbose {posargs2}
+    #asv continuous --config python/asv_benchmarks/asv-asvenv.conf.json -e --verbose {posargs}
+    # PR COMMENT verbose will be removed for merge 
+    asv run --config python/asv_benchmarks/asv-asvenv.conf.json -e --verbose {posargs}
+
 [testenv:lint]
 # this environement lints the Python code with flake8 (code linter), black (code
 # formatter), and isort (sorting of imports)


### PR DESCRIPTION
Result from discussion in issue #134 and PR #203 

I implemented two ways one an set up asv (both usable from tox using asv-toxenv and asv-asvenv, one uses the current python venv which allows us to use the tox venv, the other uses the venv defined in the asv-asvenv.conf.json file. The second way allows us to run benchmarks for certain branches or commits which I find to be a super useful feature, since you can also run on commits that did not have  asv set up. This we cannot do with the conf file used in asv-toxenv.

One can run the benchmarks for all commits in a branch 
```
tox -e asv-asvenv -- <branch>
```
or more useful to run it for one commit (even before the asv was installed)
```
tox -e asv-asvenv -- <commit>^!
```

Somehow it is not installing the equistore correctly for different commits. The file path is always in most recent commit id for me
 ```
/home/alexgo/lib/equistore/python/asv_benchmarks/.asv/env/257290e6b526ec9a4c873ad6daa76c75466a3d08/lib/python3.8/site-packages/equistore/__init__.py
````
if I use
```
tox -e asv-asvenv -- --verbose ad76728666daaf4cdf7dd94e9b22fabaae011a9b^!
```


<!-- readthedocs-preview equistore start -->
----
:books: Documentation preview :books:: https://equistore--229.org.readthedocs.build/en/229/

<!-- readthedocs-preview equistore end -->