### PR TITLE
Add toggleprompt button to html docs

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,6 @@
 sphinx >=4.4
 sphinx_autodoc_typehints
+sphinx-toggleprompt
 pygments >=2.9
 breathe >=4.33
 furo

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -57,6 +57,7 @@ extensions = [
     "sphinx.ext.viewcode",
     "sphinx.ext.autodoc",
     "sphinx.ext.intersphinx",
+    "sphinx_toggleprompt",
     "breathe",
 ]
 


### PR DESCRIPTION
The `toggleprompt` adds a button on the upper left of each example block to remove the `>>>` inputs. This is very useful when copying more complex examples.

<!-- readthedocs-preview equistore start -->
----
:books: Documentation preview :books:: https://equistore--234.org.readthedocs.build/en/234/

<!-- readthedocs-preview equistore end -->