### PR TITLE
Add a test checking the C API with valgrind

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,12 +20,13 @@ jobs:
             rust-target: x86_64-unknown-linux-gnu
             build-type: debug
 
-          # test without any feature (i.e static build + ndarray)
+          # test with all features (i.e static build + ndarray)
           - os: ubuntu-20.04
             rust-version: stable
             rust-target: x86_64-unknown-linux-gnu
             build-type: release
             cargo-build-flags: --release --all-features
+            do-valgrind: true
 
           # MSRV (Minimally Supported Rust Version)
           - os: ubuntu-20.04
@@ -75,6 +76,12 @@ jobs:
           toolchain: ${{ matrix.rust-version }}
           default: true
           target: ${{ matrix.rust-target }}
+
+      - name: install valgrind
+        if: matrix.do-valgrind
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y valgrind
 
       - name: install tests dependencies
         run: |

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -82,8 +82,13 @@ workflows. You can also run only a subset of tests with one of these commands:
 
 - ``cargo test`` runs everything
 - ``cargo test --test=<test-name>`` to run only the tests in ``tests/<test-name>.rs``;
-    - ``cargo test --test=python-api`` (or ``tox`` directly) to run Python tests only;
-    - ``cargo test --test=cpp-api`` to run the C/C++ API tests only;
+    - ``cargo test --test=python-api`` (or ``tox`` directly, see below) to run
+      Python tests only;
+    - ``cargo test --test=c-api-tests`` to run the C/C++ API tests only. For these
+      tests, if `valgrind`_ is installed, it will be used to check for memory
+      errors. You can disable this by setting the `EQUISTORE_DISABLE_VALGRIND`
+      environment variable to 1 (`export EQUISTORE_DISABLE_VALGRIND=1` for most
+      Linux/macOS shells);
 - ``cargo test --lib`` to run unit tests;
 - ``cargo test --doc`` to run documentation tests;
 - ``cargo bench --test`` compiles and run the benchmarks once, to quickly ensure
@@ -109,6 +114,7 @@ The latter command ``tox -e format`` will use tox to do actual formatting
 instead of just testing it.
 
 .. _`cargo` : https://doc.rust-lang.org/cargo/
+.. _valgrind: https://valgrind.org/
 
 Contributing to the documentation
 ---------------------------------
@@ -142,7 +148,7 @@ looks like the following.
     def func(value_1: float, value_2: int) -> float:
         r"""A one line summary sentence of the function.
 
-        Extensive multi-line summary of what is going in. Use single 
+        Extensive multi-line summary of what is going in. Use single
         backticks for parameters of the function like `width` and two ticks for
         values ``67``. You can link to classes :py:class:`equistore.Labels`. This
         also works for other classes and functions like :py:obj:`True`.

--- a/equistore-core/tests/cpp/CMakeLists.txt
+++ b/equistore-core/tests/cpp/CMakeLists.txt
@@ -23,12 +23,14 @@ add_subdirectory(external)
 
 find_program(VALGRIND valgrind)
 if (VALGRIND)
-    message(STATUS "Running tests using valgrind")
-    set(TEST_COMMAND
-        "${VALGRIND}" "--tool=memcheck" "--dsymutil=yes" "--error-exitcode=125"
-        "--leak-check=full" "--show-leak-kinds=definite,indirect,possible" "--track-origins=yes"
-        "--gen-suppressions=all"
-    )
+    if (NOT "$ENV{EQUISTORE_DISABLE_VALGRIND}" EQUAL "1")
+        message(STATUS "Running tests using valgrind")
+        set(TEST_COMMAND
+            "${VALGRIND}" "--tool=memcheck" "--dsymutil=yes" "--error-exitcode=125"
+            "--leak-check=full" "--show-leak-kinds=definite,indirect,possible" "--track-origins=yes"
+            "--gen-suppressions=all"
+        )
+    endif()
 else()
     set(TEST_COMMAND "")
 endif()

--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,8 @@ class bdist_egg_disabled(bdist_egg):
         sys.exit(
             "Aborting implicit building of eggs. "
             + "Use `pip install .` or `python setup.py bdist_wheel && pip "
-            + "install dist/equistore-*.whl` to install from source."
+            + "uninstall equistore -y && pip install dist/equistore-*.whl` "
+            + "to install from source."
         )
 
 


### PR DESCRIPTION
We do this in rascaline and I was persuaded we already did it here as well.

TODO: 
- [x] add a way to disable running tests with valgrind, as these can be a bit slow (@frostedoyster had a case in rascaline where they take upward of 30 min, let's hope it's not that bad on CI)

<!-- readthedocs-preview equistore start -->
----
:books: Documentation preview :books:: https://equistore--236.org.readthedocs.build/en/236/

<!-- readthedocs-preview equistore end -->