### PR TITLE
Use tox external package support to only build the wheels only once

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -156,4 +156,4 @@ jobs:
           python -m pip install tox
 
       - name: python build tests
-        run: tox -e build-python
+        run: tox -e check-python-build

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -86,7 +86,7 @@ jobs:
       - name: install tests dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install tox black flake8
+          python -m pip install tox
 
       - name: run tests
         run: cargo test --all --target ${{ matrix.rust-target }} ${{ matrix.cargo-build-flags }}
@@ -133,7 +133,7 @@ jobs:
     name: check Python build
     strategy:
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
     steps:
       - uses: actions/checkout@v3
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -108,10 +108,15 @@ specific functionalities, for example:
     tox -e tests         # unit tests
     tox -e lint          # code style
     tox -e build-python  # python packaging
+
     tox -e format        # format all files
 
-The latter command ``tox -e format`` will use tox to do actual formatting
-instead of just testing it.
+The last command ``tox -e format`` will use tox to do actual formatting instead
+of just checking it.
+
+You can run only a subset of the tests with ``tox -e tests -- <test/file.py>``,
+replacing ``<test/file.py>`` with the path to the files you want to test, e.g.
+``tox -e tests -- python/tests/operations/abs.py``.
 
 .. _`cargo` : https://doc.rust-lang.org/cargo/
 .. _valgrind: https://valgrind.org/

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -18,7 +18,7 @@ on equistore:
   use a version provided by your operating system. We need at least Rust version
   1.61 to build equistore.
 - **Python**: you can install ``Python`` and ``pip`` from your operating system.
-  We require a Python version of at least 3.6.
+  We require a Python version of at least 3.7.
 - **tox**: a Python test runner, cf https://tox.readthedocs.io/en/latest/. You
   can install tox with ``pip install tox``.
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,19 +1,6 @@
-global-exclude *.pyc
-global-exclude .DS_Store
-
-prune docs
-
 recursive-include equistore-core *
 prune equistore-core/tests
-exclude Cargo.toml
-exclude Cargo.lock
 
 include pyproject.toml
 include AUTHORS
 include LICENSE
-
-prune python/tests
-prune python/*.egg-info
-
-
-exclude tox.ini

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,6 @@ classifiers =
     Operating System :: Microsoft :: Windows,
     Programming Language :: Python,
     Programming Language :: Python :: 3,
-    Programming Language :: Python :: 3.6,
     Programming Language :: Python :: 3.7,
     Programming Language :: Python :: 3.8,
     Programming Language :: Python :: 3.9,
@@ -35,7 +34,7 @@ classifiers =
 zip_safe = False
 install_requires = numpy
 packages = find:
-python_requires = >=3.6
+python_requires = >=3.7
 package_dir =
     = python/src
 

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ class universal_wheel(bdist_wheel):
     # When building the wheel, the `wheel` package assumes that if we have a
     # binary extension then we are linking to `libpython.so`; and thus the wheel
     # is only usable with a single python version. This is not the case for
-    # here, and the wheel will be compatible with any Python >=3.6. This is
+    # here, and the wheel will be compatible with any Python >=3.7. This is
     # tracked in https://github.com/pypa/wheel/issues/185, but until then we
     # manually override the wheel tag.
     def get_tag(self):

--- a/tox.ini
+++ b/tox.ini
@@ -37,7 +37,7 @@ deps =
 
 commands =
    # Run unit tests
-    pytest
+    pytest {posargs}
 
     # Run documentation tests
     pytest --doctest-modules --pyargs equistore

--- a/tox.ini
+++ b/tox.ini
@@ -5,42 +5,48 @@ envlist =
     tests
     lint
 
+
 [testenv]
-# `skip_install = True` avoids rebuilding and installing all rust dependencies
-# which is especially useful for local testing.
-skip_install = True
+package = external
+package_env = build-equistore
+
+
+[testenv:build-equistore]
+# This environment is only used to build the wheels which are then re-used by
+# all other environments requiring equistore to be installed
 passenv =
     EQUISTORE_BUILD_TYPE
     RUST*
     CARGO*
 
-allowlist_externals =
-    bash
+deps =
+    setuptools
+    wheel
+    cmake
+
+commands =
+    pip wheel . --no-build-isolation --no-deps --check-build-dependencies --wheel-dir {envtmpdir}/dist
+
 
 [testenv:tests]
-# this environement runs Python tests
-
+# this environement runs the tests of the equistore Python package
 deps =
     pytest
     numpy
     torch
 
 commands =
-    bash -c "rm -rf ./dist"
-    pip wheel --no-deps -w dist .
-    bash -c "python -m pip uninstall equistore -y"
-    bash -c "python -m pip install --no-deps ./dist/equistore-*.whl"
-
    # Run unit tests
     pytest
 
     # Run documentation tests
     pytest --doctest-modules --pyargs equistore
 
+
 [testenv:lint]
 # this environement lints the Python code with flake8 (code linter), black (code
 # formatter), and isort (sorting of imports)
-
+package = skip
 deps =
     flake8
     flake8-bugbear
@@ -52,10 +58,12 @@ commands =
     black --check --diff {toxinidir}/python {toxinidir}/setup.py
     isort --check-only --diff {toxinidir}/python {toxinidir}/setup.py
 
+
 [testenv:format]
 # this environement abuses tox to do actual formatting
 #
 # Users can run `tox -e format` to run formatting on all files
+package = skip
 deps =
     black
     isort
@@ -63,35 +71,38 @@ commands =
     black {toxinidir}/python {toxinidir}/setup.py
     isort {toxinidir}/python {toxinidir}/setup.py
 
+
 [testenv:docs]
 # this environement builds the documentation with sphinx
 deps =
     -r docs/requirements.txt
 
 commands =
-    bash -c "rm -rf ./dist"
-    pip wheel --no-deps -w dist .
-    bash -c "python -m pip uninstall equistore -y"
-    bash -c "python -m pip install --no-deps ./dist/equistore-*.whl"
-
     sphinx-build {posargs:-E} -W -b html docs/src docs/build/html
 
-[testenv:build-python]
+
+[testenv:check-python-build]
 # this environement makes sure one can build sdist and wheels for Python
+package = skip
 deps =
+    # build time dependencies
     setuptools
     wheel
+    cmake
+    # twine it a tool to check sdist and wheels metadata
     twine
 
+allowlist_externals = bash
 commands =
     # check building sdist and wheels from a checkout
-    python setup.py sdist
-    python setup.py bdist_wheel
-    twine check dist/*.tar.gz
-    twine check dist/*.whl
+    python setup.py sdist --dist-dir {envtmpdir}/dist
+    python setup.py bdist_wheel --dist-dir {envtmpdir}/dist
+    twine check {envtmpdir}/dist/*.tar.gz
+    twine check {envtmpdir}/dist/*.whl
 
     # check building wheels from the sdist
-    bash -c "python -m pip wheel --verbose dist/equistore-*.tar.gz -w dist/test"
+    bash -c "python -m pip wheel --verbose {envtmpdir}/dist/equistore-*.tar.gz -w {envtmpdir}/dist/test"
+
 
 [flake8]
 max_line_length = 88

--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,5 @@
 [tox]
+min_version = 4.0
 # these are the default environments, i.e. the list of tests running when you
 # execute `tox` in the command-line without anything else
 envlist =


### PR DESCRIPTION
Also add a way to only run a subset of tests and document it.

This PR is nice to have on master, but will help quite a lot for #233, where we need an environment with a fresh build of both equistore and equistore_torch

<!-- readthedocs-preview equistore start -->
----
:books: Documentation preview :books:: https://equistore--237.org.readthedocs.build/en/237/

<!-- readthedocs-preview equistore end -->