### PR TITLE
Pickling support by converting to numpy

### DIFF
--- a/python/src/equistore/block.py
+++ b/python/src/equistore/block.py
@@ -110,6 +110,12 @@ class TensorBlock:
         new_ptr = self._lib.eqs_block_copy(self._ptr)
         return TensorBlock._from_ptr(new_ptr, parent=None)
 
+    def __reduce__(self):
+        raise NotImplementedError(
+            "Pickling for TensorBlocks does not work. Please wrap it into a TensorMap"
+            " to save it."
+        )
+
     def copy(self) -> "TensorBlock":
         """
         Get a deep copy of this block, including all the (potentially non

--- a/python/src/equistore/io.py
+++ b/python/src/equistore/io.py
@@ -120,7 +120,7 @@ def save(path: str, tensor: TensorMap, use_numpy=False):
     if not path.endswith(".npz"):
         path += ".npz"
         warnings.warn(
-            msg=f"adding '.npz' extension, the file will be saved at '{path}'",
+            message=f"adding '.npz' extension, the file will be saved at '{path}'",
             stacklevel=1,
         )
 

--- a/python/tests/serialization.py
+++ b/python/tests/serialization.py
@@ -12,6 +12,10 @@ from equistore import TensorMap
 from . import utils
 
 
+# using tmpdir as pytest-built-in fixture
+# https://docs.pytest.org/en/7.1.x/how-to/tmp_path.html#the-tmpdir-and-tmpdir-factory-fixtures
+
+
 @pytest.fixture
 def tensor():
     return utils.tensor()
@@ -68,6 +72,20 @@ def test_save(use_numpy, tmpdir, tensor):
             assert_equal(data[f"{prefix}/data"], gradient.data)
             assert_equal(data[f"{prefix}/samples"], gradient.samples)
             assert_equal(data[f"{prefix}/components/0"], gradient.components[0])
+
+
+def test_save_warning(tmpdir, tensor):
+    # does not have .npz ending and causes warning
+    tmpfile = "serialize-test"
+
+    with pytest.warns() as record:
+        with tmpdir.as_cwd():
+            equistore.save(tmpfile, tensor)
+
+    assert (
+        str(record[0].message)
+        == f"adding '.npz' extension, the file will be saved at '{tmpfile}.npz'"
+    )
 
 
 if (sys.version_info.major >= 3) and (sys.version_info.minor >= 8):


### PR DESCRIPTION
First draft of pickling by converting everything to numpy arrays. Creates additional copies for conversion to numpy array, but when numpy arrays and pickle protocol 5 is used, no spurious copies should be made for the values. Need to check this. Also current test only works, because it only handles numpy arrays. I am sure with torch tensor it will fail (gradients are not converted)

<!-- readthedocs-preview equistore start -->
----
:books: Documentation preview :books:: https://equistore--238.org.readthedocs.build/en/238/

<!-- readthedocs-preview equistore end -->