### PR TITLE
Remove dependency on py-litteral and pest

### DIFF
--- a/equistore-core/Cargo.toml
+++ b/equistore-core/Cargo.toml
@@ -21,7 +21,6 @@ once_cell = "1"
 smallvec = {version = "1", features = ["union"]}
 
 # implementation of the NPZ serialization format
-py_literal = {version = "0.4"}
 byteorder = {version = "1"}
 num-traits = {version = "0.2", default-features = false}
 zip = {version = "0.6", default-features = false}


### PR DESCRIPTION
These are used to implement the npz reader/writer for `equistore::io::save`/`equistore::io::load`, but are relatively heavy dependencies for what we do with them. Removing them shaves 20% out of equistore compile time.

Instead of the dependency, the code now uses a small handwritten parser for the couple of Python literals we need to read instead of a generated [pest](https://docs.rs/pest/latest/pest/) parser.

---

I had this branch sitting on my computer for a while, it might be time to merge it =)

<!-- readthedocs-preview equistore start -->
----
:books: Documentation preview :books:: https://equistore--240.org.readthedocs.build/en/240/

<!-- readthedocs-preview equistore end -->