### PR TITLE
RFC: Allow to convert floats with no fractional parts

### DIFF
--- a/python/src/equistore/labels.py
+++ b/python/src/equistore/labels.py
@@ -91,18 +91,21 @@ class Labels(np.ndarray):
                 "names parameter must have an entry for each column of the array"
             )
 
-        try:
+        # Check if real numbers have no fractional part. Allows to safely convert
+        # special floats (i.e `0.0`, `1.0` etc.) to ints without unwanted conversion
+        # information using `casting="unsafe"`.
+        if np.isreal(values) and np.all(np.mod(values, 1)):
             values = np.ascontiguousarray(
                 values.astype(
                     np.int32,
                     order="C",
-                    casting="same_kind",
+                    casting="unsafe",
                     subok=False,
                     copy=False,
                 )
             )
-        except TypeError as e:
-            raise TypeError("Labels values must be convertible to integers") from e
+        else:
+            raise TypeError("Labels values must be convertible to real integers")
 
         dtype = [(name, np.int32) for name in names]
 


### PR DESCRIPTION
Sometimes we create Labels with values using `np.zeros` or `np.ones`. By default, these functions return arrays of float but they are actually integers because they have a zero fractional part. A current soluition is to use `np.zeros(dtype=np.int32)`. 

Here, I extend the `Labels` value parsing to allow also these kinds of inputs without prior conversion. Now allowed inputs are

```python
int32_array = np.array([1], dtype=np.int32)
int64_array = np.array([1], dtype=np.int64)
float32_array = np.array([1], dtype=np.float32)
float64_array = np.array([1], dtype=np.float64)
bool_array = np.array([1], dtype=np.bool)
```

while these are not okay

```python
complex_array = np.array([1+2j])
float_fraction_array = np.array([1.1])
str_array = np.array(["foo"])
```

Do you think we want this and did I correctly construct the type checker? The latter is important because I changed the casting to unsafe and this could lead to weird results or error messages if not done correctly.

<!-- readthedocs-preview equistore start -->
----
:books: Documentation preview :books:: https://equistore--246.org.readthedocs.build/en/246/

<!-- readthedocs-preview equistore end -->