### PR TITLE
`drop_blocks()` - add a `copy` flag

### DIFF
--- a/python/src/equistore/operations/drop_blocks.py
+++ b/python/src/equistore/operations/drop_blocks.py
@@ -30,9 +30,7 @@ def drop_blocks(tensor: TensorMap, keys: Labels, copy: bool = False) -> TensorMa
             f"input `keys` must be a Labels object, got '{type(keys)}' instead"
         )
     if not isinstance(copy, bool):
-        raise TypeError(
-            f"`copy` flag must be a boolean, got '{type(copy)}' instead"
-        )
+        raise TypeError(f"`copy` flag must be a boolean, got '{type(copy)}' instead")
 
     if not np.all(tensor.keys.names == keys.names):
         raise ValueError(
@@ -57,18 +55,18 @@ def drop_blocks(tensor: TensorMap, keys: Labels, copy: bool = False) -> TensorMa
         for key in new_keys:
             # Create new block
             new_block = TensorBlock(
+                values=tensor[key].values,
                 samples=tensor[key].samples,
                 components=tensor[key].components,
                 properties=tensor[key].properties,
-                values=tensor[key].values,
             )
             # Add gradients
             for parameter, gradient in tensor[key].gradients():
                 new_block.add_gradient(
-                    parameter=param,
-                    samples=obj.samples,
-                    components=obj.components,
-                    data=obj.data,
+                    parameter=parameter,
+                    data=gradient.data,
+                    samples=gradient.samples,
+                    components=gradient.components,
                 )
             new_blocks.append(new_block)
 

--- a/python/src/equistore/operations/drop_blocks.py
+++ b/python/src/equistore/operations/drop_blocks.py
@@ -3,15 +3,15 @@ import numpy as np
 from equistore import Labels, TensorBlock, TensorMap
 
 
-def drop_blocks(tensor: TensorMap, keys: Labels, copy: bool = True) -> TensorMap:
+def drop_blocks(tensor: TensorMap, keys: Labels, copy: bool = False) -> TensorMap:
     """
     Drop specified key/block pairs from a TensorMap.
 
     :param tensor: the TensorMap to drop the key-block pair from.
     :param keys: a :py:class:`Labels` object containing the keys of the blocks
         to drop
-    :param copy: if ``True`` (default), the returned :py:class:`TensorMap` is
-        constructed by copying the blocks from the input `tensor`. If ``False``,
+    :param copy: if ``True``, the returned :py:class:`TensorMap` is constructed
+        by copying the blocks from the input `tensor`. If ``False`` (default),
         the values of the blocks in the output :py:class:`TensorMap` reference
         the same data as the input `tensor`. The latter can be useful for
         limiting memory usage, but should be used with caution when manipulating

--- a/python/src/equistore/operations/drop_blocks.py
+++ b/python/src/equistore/operations/drop_blocks.py
@@ -63,7 +63,7 @@ def drop_blocks(tensor: TensorMap, keys: Labels, copy: bool = False) -> TensorMa
                 values=tensor[key].values,
             )
             # Add gradients
-            for param, obj in tensor[key].gradients():
+            for parameter, gradient in tensor[key].gradients():
                 new_block.add_gradient(
                     parameter=param,
                     samples=obj.samples,

--- a/python/src/equistore/operations/drop_blocks.py
+++ b/python/src/equistore/operations/drop_blocks.py
@@ -27,7 +27,7 @@ def drop_blocks(tensor: TensorMap, keys: Labels, copy: bool = False) -> TensorMa
         )
     if not isinstance(keys, Labels):
         raise TypeError(
-            "The input `keys` must be a Labels object. " f"Got {type(keys)} instead."
+            f"input `keys` must be a Labels object, got '{type(keys)}' instead"
         )
     if not isinstance(copy, bool):
         raise TypeError(

--- a/python/src/equistore/operations/drop_blocks.py
+++ b/python/src/equistore/operations/drop_blocks.py
@@ -31,7 +31,7 @@ def drop_blocks(tensor: TensorMap, keys: Labels, copy: bool = False) -> TensorMa
         )
     if not isinstance(copy, bool):
         raise TypeError(
-            "The input `copy` flag must be a boolean. " f"Got {type(copy)} instead."
+            f"`copy` flag must be a boolean, got '{type(copy)}' instead"
         )
 
     if not np.all(tensor.keys.names == keys.names):

--- a/python/src/equistore/operations/drop_blocks.py
+++ b/python/src/equistore/operations/drop_blocks.py
@@ -23,7 +23,7 @@ def drop_blocks(tensor: TensorMap, keys: Labels, copy: bool = False) -> TensorMa
     # Check arg types
     if not isinstance(tensor, TensorMap):
         raise TypeError(
-            "The input `tensor` must be a TensorMap. " f"Got {type(tensor)} instead."
+            f"input `tensor` must be a TensorMap, got '{type(tensor)}' instead"
         )
     if not isinstance(keys, Labels):
         raise TypeError(

--- a/python/src/equistore/operations/drop_blocks.py
+++ b/python/src/equistore/operations/drop_blocks.py
@@ -20,11 +20,27 @@ def drop_blocks(tensor: TensorMap, keys: Labels, copy: bool = True) -> TensorMap
     :return: the input :py:class:`TensorMap` with the specified key/block pairs
         dropped.
     """
+    # Check arg types
+    if not isinstance(tensor, TensorMap):
+        raise TypeError(
+            "The input `tensor` must be a TensorMap. " f"Got {type(tensor)} instead."
+        )
+    if not isinstance(keys, Labels):
+        raise TypeError(
+            "The input `keys` must be a Labels object. " f"Got {type(keys)} instead."
+        )
+    if not isinstance(copy, bool):
+        raise TypeError(
+            "The input `copy` flag must be a boolean. " f"Got {type(copy)} instead."
+        )
+
     if not np.all(tensor.keys.names == keys.names):
         raise ValueError(
             "The input tensor's keys must have the same names as the specified"
             f" keys to drop. Should be {tensor.keys.names} but got {keys.names}"
         )
+
+    # Find the difference between key of the original tensor and those to drop
     diff = np.setdiff1d(keys, tensor.keys)
     if len(diff) > 0:
         raise ValueError(
@@ -32,6 +48,8 @@ def drop_blocks(tensor: TensorMap, keys: Labels, copy: bool = True) -> TensorMap
             f" Non-existent keys: {diff}"
         )
     new_keys = np.setdiff1d(tensor.keys, keys)
+
+    # Create the new TensorMap
     if copy:
         new_blocks = [tensor[key].copy() for key in new_keys]
     else:

--- a/python/tests/operations/drop_blocks.py
+++ b/python/tests/operations/drop_blocks.py
@@ -141,8 +141,8 @@ def test_copy_flag(test_tensor_map):
     # Define some keys to drop
     keys_to_drop = test_tensor_map.keys[:5]
 
-    # Drop blocks with default copy=True flag
-    new_tensor_copied = equistore.drop_blocks(test_tensor_map, keys_to_drop)
+    # Drop blocks with copy=True flag
+    new_tensor_copied = equistore.drop_blocks(test_tensor_map, keys_to_drop, copy=True)
 
     # Drop blocks with copy=False flag
     new_tensor_not_copied = equistore.drop_blocks(

--- a/python/tests/operations/drop_blocks.py
+++ b/python/tests/operations/drop_blocks.py
@@ -11,6 +11,9 @@ from equistore import Labels, TensorMap
 DATA_ROOT = os.path.join(os.path.dirname(__file__), "..", "data")
 
 
+# ===== Fixtures and helper functions =====
+
+
 @pytest.fixture
 def test_tensor_map() -> TensorMap:
     return equistore.io.load(
@@ -18,96 +21,6 @@ def test_tensor_map() -> TensorMap:
         # the npz is using DEFLATE compression, equistore only supports STORED
         use_numpy=True,
     )
-
-
-class TestDropBlock:
-    def test_drop_all(self, test_tensor_map):
-        # test the behavior when all the keys are dropped
-        # expected behavior: empty TensorMap
-        keys = test_tensor_map.keys
-        tensor = equistore.drop_blocks(test_tensor_map, keys)
-        empty_tensor = TensorMap(keys=Labels.empty(keys.names), blocks=[])
-        assert not (
-            equistore.equal(tensor, empty_tensor)
-        )  # TODO: reverse this once #175 is fixed
-
-    def test_drop_first(self, test_tensor_map):
-        # test the behavior when the first key is dropped
-        ref_keys = test_tensor_map.keys[1:]
-        ref_blocks = [test_tensor_map[key].copy() for key in ref_keys]
-        ref_tensor = TensorMap(ref_keys, ref_blocks)
-
-        key_to_drop = test_tensor_map.keys[:1]
-        new_tensor = equistore.drop_blocks(test_tensor_map, key_to_drop)
-        assert equistore.equal(new_tensor, ref_tensor)
-        check_consistency(test_tensor_map, new_tensor)
-
-    def test_drop_last(self, test_tensor_map):
-        # test the behavior when the last key is dropped
-        ref_keys = test_tensor_map.keys[:-1]
-        ref_blocks = [test_tensor_map[key].copy() for key in ref_keys]
-        ref_tensor = TensorMap(ref_keys, ref_blocks)
-
-        key_to_drop = test_tensor_map.keys[-1:]
-        new_tensor = equistore.drop_blocks(test_tensor_map, key_to_drop)
-        assert equistore.equal(new_tensor, ref_tensor)
-        check_consistency(test_tensor_map, new_tensor)
-
-    def test_drop_random(self, test_tensor_map):
-        # test the behavior when an existing  random key is dropped
-        number_blocks = len(test_tensor_map.blocks())
-        index_to_remove = np.random.randint(1, number_blocks - 1)
-
-        names = test_tensor_map.keys.names
-        values = []
-        for i in range(index_to_remove):
-            values += [tuple(test_tensor_map.keys[i])]
-        for i in range(index_to_remove + 1, number_blocks):
-            values += [tuple(test_tensor_map.keys[i])]
-        values = np.array(values)
-        ref_keys = Labels(names, values)
-        ref_blocks = [test_tensor_map[key].copy() for key in ref_keys]
-        ref_tensor = TensorMap(ref_keys, ref_blocks)
-
-        key_to_drop = Labels(
-            test_tensor_map.keys[index_to_remove].dtype.names,
-            np.array([tuple(test_tensor_map.keys[index_to_remove])]),
-        )
-        new_tensor = equistore.drop_blocks(test_tensor_map, key_to_drop)
-        assert equistore.equal(new_tensor, ref_tensor)
-        check_consistency(test_tensor_map, new_tensor)
-
-    def test_drop_two_random_keys(self, test_tensor_map):
-        # test the behavior when two random keys are dropped
-        number_blocks = len(test_tensor_map.blocks())
-        indices_to_drop = np.random.randint(0, number_blocks, 2)
-        keys_to_drop = test_tensor_map.keys[indices_to_drop]
-
-        ref_keys = np.setdiff1d(test_tensor_map.keys, keys_to_drop)
-        ref_blocks = [test_tensor_map[key].copy() for key in ref_keys]
-        ref_tensor = TensorMap(ref_keys, ref_blocks)
-
-        new_tensor = equistore.drop_blocks(test_tensor_map, keys_to_drop)
-        assert equistore.equal(new_tensor, ref_tensor)
-        check_consistency(test_tensor_map, new_tensor)
-
-    def test_drop_nothing(self, test_tensor_map):
-        # test when an emty key is dropped
-        empty_key = Labels.empty(test_tensor_map.keys.names)
-        new_tensor = equistore.drop_blocks(test_tensor_map, empty_key)
-        assert new_tensor == test_tensor_map
-
-    def test_not_existent(self, test_tensor_map):
-        # test when keys that don't appear in the TensorMap are dropped
-        non_existent_key = Labels(
-            test_tensor_map.keys.names, np.array([[-1, -1, -1], [0, 0, 0]])
-        )
-        error_msg = (
-            "some keys in `keys` are not present in `tensor`."
-            f" Non-existent keys: {non_existent_key}"
-        )
-        with pytest.raises(ValueError, match=re.escape(error_msg)):
-            equistore.drop_blocks(test_tensor_map, non_existent_key)
 
 
 def check_consistency(tensor1: TensorMap, tensor2: TensorMap):
@@ -119,3 +32,139 @@ def check_consistency(tensor1: TensorMap, tensor2: TensorMap):
     for key in keys:
         if tensor2[key] != tensor1[key]:
             raise ValueError(f"the blocks indexed by key {key} are not equivalent")
+
+
+# ===== Tests =====
+
+
+def test_drop_all(test_tensor_map):
+    # test the behavior when all the keys are dropped
+    # expected behavior: empty TensorMap
+    keys = test_tensor_map.keys
+    tensor = equistore.drop_blocks(test_tensor_map, keys)
+    empty_tensor = TensorMap(keys=Labels.empty(keys.names), blocks=[])
+    assert not (
+        equistore.equal(tensor, empty_tensor)
+    )  # TODO: reverse this once #175 is fixed
+
+
+def test_drop_first(test_tensor_map):
+    # test the behavior when the first key is dropped
+    ref_keys = test_tensor_map.keys[1:]
+    ref_blocks = [test_tensor_map[key].copy() for key in ref_keys]
+    ref_tensor = TensorMap(ref_keys, ref_blocks)
+
+    key_to_drop = test_tensor_map.keys[:1]
+    new_tensor = equistore.drop_blocks(test_tensor_map, key_to_drop)
+    assert equistore.equal(new_tensor, ref_tensor)
+    check_consistency(test_tensor_map, new_tensor)
+
+
+def test_drop_last(test_tensor_map):
+    # test the behavior when the last key is dropped
+    ref_keys = test_tensor_map.keys[:-1]
+    ref_blocks = [test_tensor_map[key].copy() for key in ref_keys]
+    ref_tensor = TensorMap(ref_keys, ref_blocks)
+
+    key_to_drop = test_tensor_map.keys[-1:]
+    new_tensor = equistore.drop_blocks(test_tensor_map, key_to_drop)
+    assert equistore.equal(new_tensor, ref_tensor)
+    check_consistency(test_tensor_map, new_tensor)
+
+
+def test_drop_random(test_tensor_map):
+    # test the behavior when an existing  random key is dropped
+    number_blocks = len(test_tensor_map.blocks())
+    index_to_remove = np.random.randint(1, number_blocks - 1)
+
+    names = test_tensor_map.keys.names
+    values = []
+    for i in range(index_to_remove):
+        values += [tuple(test_tensor_map.keys[i])]
+    for i in range(index_to_remove + 1, number_blocks):
+        values += [tuple(test_tensor_map.keys[i])]
+    values = np.array(values)
+    ref_keys = Labels(names, values)
+    ref_blocks = [test_tensor_map[key].copy() for key in ref_keys]
+    ref_tensor = TensorMap(ref_keys, ref_blocks)
+
+    key_to_drop = Labels(
+        test_tensor_map.keys[index_to_remove].dtype.names,
+        np.array([tuple(test_tensor_map.keys[index_to_remove])]),
+    )
+    new_tensor = equistore.drop_blocks(test_tensor_map, key_to_drop)
+    assert equistore.equal(new_tensor, ref_tensor)
+    check_consistency(test_tensor_map, new_tensor)
+
+
+def test_drop_two_random_keys(test_tensor_map):
+    # test the behavior when two random keys are dropped
+    number_blocks = len(test_tensor_map.blocks())
+    indices_to_drop = np.random.randint(0, number_blocks, 2)
+    keys_to_drop = test_tensor_map.keys[indices_to_drop]
+
+    ref_keys = np.setdiff1d(test_tensor_map.keys, keys_to_drop)
+    ref_blocks = [test_tensor_map[key].copy() for key in ref_keys]
+    ref_tensor = TensorMap(ref_keys, ref_blocks)
+
+    new_tensor = equistore.drop_blocks(test_tensor_map, keys_to_drop)
+    assert equistore.equal(new_tensor, ref_tensor)
+    check_consistency(test_tensor_map, new_tensor)
+
+
+def test_drop_nothing(test_tensor_map):
+    # test when an emty key is dropped
+    empty_key = Labels.empty(test_tensor_map.keys.names)
+    new_tensor = equistore.drop_blocks(test_tensor_map, empty_key)
+    assert new_tensor == test_tensor_map
+
+
+def test_not_existent(test_tensor_map):
+    # test when keys that don't appear in the TensorMap are dropped
+    non_existent_key = Labels(
+        test_tensor_map.keys.names, np.array([[-1, -1, -1], [0, 0, 0]])
+    )
+    error_msg = (
+        "some keys in `keys` are not present in `tensor`."
+        f" Non-existent keys: {non_existent_key}"
+    )
+    with pytest.raises(ValueError, match=re.escape(error_msg)):
+        equistore.drop_blocks(test_tensor_map, non_existent_key)
+
+
+def test_copy_flag(test_tensor_map):
+    """
+    Checks that settings the copy flag to true or false gives the same result.
+    Also checks that inplace modifications of the underlying data doesn't affect
+    the copied returned tensor, but it does for the uncopied version.
+    """
+    # Define some keys to drop
+    keys_to_drop = test_tensor_map.keys[:5]
+
+    # Drop blocks with default copy=True flag
+    new_tensor_copied = equistore.drop_blocks(test_tensor_map, keys_to_drop)
+
+    # Drop blocks with copy=False flag
+    new_tensor_not_copied = equistore.drop_blocks(
+        test_tensor_map, keys_to_drop, copy=False
+    )
+
+    # Check that the resulting tensormaps are equal whether or not they are
+    # copied
+    assert equistore.equal(new_tensor_copied, new_tensor_not_copied)
+    # check_consistency(new_tensor_copied, new_tensor_not_copied)
+
+    # Now modify the original tensor's block values in place
+    for block in test_tensor_map.blocks():
+        block.values[:] += 3.14
+
+    # The copied tensor's values should not have been edited
+    for key in new_tensor_copied.keys:
+        assert np.all(new_tensor_copied[key].values != test_tensor_map[key].values)
+
+    # But the uncopied tensor's values should have been
+    for key in new_tensor_not_copied.keys:
+        assert np.all(new_tensor_not_copied[key].values == test_tensor_map[key].values)
+        assert np.all(
+            new_tensor_not_copied[key].values == new_tensor_copied[key].values[:] + 3.14
+        )

--- a/python/tests/operations/equal_metadata.py
+++ b/python/tests/operations/equal_metadata.py
@@ -10,6 +10,9 @@ from equistore import Labels, TensorBlock, TensorMap, equal_metadata
 DATA_ROOT = os.path.join(os.path.dirname(__file__), "..", "data")
 
 
+# ===== Fixtures =====
+
+
 @pytest.fixture
 def test_tensor_map_1() -> TensorMap:
     return equistore.io.load(
@@ -105,207 +108,219 @@ def tensor_map() -> TensorMap:
     return TensorMap(keys, [block_1, block_2, block_3, block_4])
 
 
-class TestEqualMetaData:
-    def test_self(self, test_tensor_map_1):
-        # check if the metadata of the same tensor are equal
-        assert equal_metadata(test_tensor_map_1, test_tensor_map_1)
+# ===== Tests =====
 
-    def test_two_tesnors(self, test_tensor_map_1, test_tensor_map_2):
-        # check if the metadata of two tensor maps are equal
-        assert not equal_metadata(test_tensor_map_1, test_tensor_map_2)
 
-    def test_after_drop(self, test_tensor_map_1):
-        # check if dropping an existing block changes the metadata
-        new_key = Labels(
-            test_tensor_map_1.keys.names, np.array([tuple(test_tensor_map_1.keys[0])])
+def test_self(test_tensor_map_1):
+    # check if the metadata of the same tensor are equal
+    assert equal_metadata(test_tensor_map_1, test_tensor_map_1)
+
+
+def test_two_tensors(test_tensor_map_1, test_tensor_map_2):
+    # check if the metadata of two tensor maps are equal
+    assert not equal_metadata(test_tensor_map_1, test_tensor_map_2)
+
+
+def test_after_drop(test_tensor_map_1):
+    # check if dropping an existing block changes the metadata
+    new_key = Labels(
+        test_tensor_map_1.keys.names, np.array([tuple(test_tensor_map_1.keys[0])])
+    )
+    new_tesnor = equistore.drop_blocks(test_tensor_map_1, new_key)
+    assert not equal_metadata(test_tensor_map_1, new_tesnor)
+
+
+def test_single_nonexisting_meta(test_tensor_map_1, test_tensor_map_2):
+    # check behavior if non existing metadata is provided
+    # wrong metadata key alone
+    wrong_meta = "species"
+    error_message = f"Invalid metadata to check: {wrong_meta}"
+    with pytest.raises(ValueError, match=error_message):
+        equal_metadata(
+            tensor_1=test_tensor_map_1,
+            tensor_2=test_tensor_map_1,
+            check=[wrong_meta],
         )
-        new_tesnor = equistore.drop_blocks(test_tensor_map_1, new_key)
-        assert not equal_metadata(test_tensor_map_1, new_tesnor)
+    with pytest.raises(ValueError, match=error_message):
+        equal_metadata(
+            tensor_1=test_tensor_map_1,
+            tensor_2=test_tensor_map_2,
+            check=[wrong_meta],
+        )
+    # wrong metadata key with another correct one
+    correct_meta = "properties"
+    with pytest.raises(ValueError, match=error_message):
+        equal_metadata(
+            tensor_1=test_tensor_map_1,
+            tensor_2=test_tensor_map_1,
+            check=[correct_meta, wrong_meta],
+        )
+    with pytest.raises(ValueError, match=error_message):
+        equal_metadata(
+            tensor_1=test_tensor_map_1,
+            tensor_2=test_tensor_map_2,
+            check=[correct_meta, wrong_meta],
+        )
 
-    def test_single_nonexisting_meta(self, test_tensor_map_1, test_tensor_map_2):
-        # check behavior if non existing metadata is provided
-        # wrong metadata key alone
-        wrong_meta = "species"
-        error_message = f"Invalid metadata to check: {wrong_meta}"
-        with pytest.raises(ValueError, match=error_message):
-            equal_metadata(
-                tensor_1=test_tensor_map_1,
-                tensor_2=test_tensor_map_1,
-                check=[wrong_meta],
-            )
-        with pytest.raises(ValueError, match=error_message):
-            equal_metadata(
-                tensor_1=test_tensor_map_1,
-                tensor_2=test_tensor_map_2,
-                check=[wrong_meta],
-            )
-        # wrong metadata key with another correct one
-        correct_meta = "properties"
-        with pytest.raises(ValueError, match=error_message):
-            equal_metadata(
-                tensor_1=test_tensor_map_1,
-                tensor_2=test_tensor_map_1,
-                check=[correct_meta, wrong_meta],
-            )
-        with pytest.raises(ValueError, match=error_message):
-            equal_metadata(
-                tensor_1=test_tensor_map_1,
-                tensor_2=test_tensor_map_2,
-                check=[correct_meta, wrong_meta],
-            )
 
-    def test_changing_tensor_key_order(self, test_tensor_map_1):
-        # check changing the key order
-        keys = test_tensor_map_1.keys
-        new_keys = keys[::-1]
-        new_blocks = [test_tensor_map_1[key].copy() for key in new_keys]
-        new_tensor = TensorMap(keys=new_keys, blocks=new_blocks)
-        assert equal_metadata(test_tensor_map_1, new_tensor)
+def test_changing_tensor_key_order(test_tensor_map_1):
+    # check changing the key order
+    keys = test_tensor_map_1.keys
+    new_keys = keys[::-1]
+    new_blocks = [test_tensor_map_1[key].copy() for key in new_keys]
+    new_tensor = TensorMap(keys=new_keys, blocks=new_blocks)
+    assert equal_metadata(test_tensor_map_1, new_tensor)
 
-    def test_changing_samples_key_order(self, test_tensor_map_1):
-        # changing the order of the values of the samples should yield False
-        new_blocks = []
-        for key in test_tensor_map_1.keys:
-            block = test_tensor_map_1[key].copy()
-            samples = block.samples[::-1]
+
+def test_changing_samples_key_order(test_tensor_map_1):
+    # changing the order of the values of the samples should yield False
+    new_blocks = []
+    for key in test_tensor_map_1.keys:
+        block = test_tensor_map_1[key].copy()
+        samples = block.samples[::-1]
+        new_block = TensorBlock(
+            values=block.values,
+            samples=samples,
+            properties=block.properties,
+            components=block.components,
+        )
+        for param, obj in block.gradients():
+            new_block.add_gradient(
+                parameter=param,
+                samples=obj.samples,
+                components=obj.components,
+                data=obj.data,
+            )
+        new_blocks.append(new_block)
+
+    new_tensor = TensorMap(keys=test_tensor_map_1.keys, blocks=new_blocks)
+    assert not equal_metadata(test_tensor_map_1, new_tensor)
+
+
+def test_changing_properties_key_order(test_tensor_map_1):
+    # changing the order of the values of the properties should yield False
+    new_blocks = []
+    for key in test_tensor_map_1.keys:
+        block = test_tensor_map_1[key].copy()
+        properties = block.properties[::-1]
+        new_block = TensorBlock(
+            values=block.values,
+            samples=block.samples,
+            properties=properties,
+            components=block.components,
+        )
+        for param, obj in block.gradients():
+            new_block.add_gradient(
+                parameter=param,
+                samples=obj.samples,
+                components=obj.components,
+                data=obj.data,
+            )
+        new_blocks.append(new_block)
+
+    new_tensor = TensorMap(keys=test_tensor_map_1.keys, blocks=new_blocks)
+    assert not equal_metadata(test_tensor_map_1, new_tensor)
+
+
+def test_add_components_key_order(tensor_map):
+    # changing the order of the values of the components should yield False
+    new_blocks = []
+    for key in tensor_map.keys:
+        block = tensor_map[key].copy()
+        components = [comp[::-1] for comp in block.components]
+        new_block = TensorBlock(
+            values=block.values,
+            samples=block.samples,
+            properties=block.properties,
+            components=components,
+        )
+        for param, obj in block.gradients():
+            new_block.add_gradient(
+                parameter=param,
+                samples=obj.samples,
+                components=components,
+                data=obj.data,
+            )
+        new_blocks.append(new_block)
+
+    new_tensor = TensorMap(keys=tensor_map.keys, blocks=new_blocks)
+    assert not equal_metadata(tensor_map, new_tensor)
+
+
+def test_remove_last_sample(tensor_map):
+    # removing the last sample should yield False
+    new_blocks = []
+    for key in tensor_map.keys:
+        block = tensor_map[key].copy()
+        new_block = TensorBlock(
+            values=block.values[:-1],
+            samples=block.samples[:-1],
+            properties=block.properties,
+            components=block.components,
+        )
+        for param, obj in block.gradients():
+            new_block.add_gradient(
+                parameter=param,
+                samples=obj.samples[:-1],
+                components=obj.components,
+                data=obj.data[:-1],
+            )
+        new_blocks.append(new_block)
+
+    new_tensor = TensorMap(keys=tensor_map.keys, blocks=new_blocks)
+    assert not equal_metadata(tensor_map, new_tensor)
+
+
+def test_remove_last_property(tensor_map):
+    # removing the last property should yield False
+    new_blocks = []
+    for key in tensor_map.keys:
+        block = tensor_map[key].copy()
+        new_block = TensorBlock(
+            values=block.values[..., :-1],
+            samples=block.samples,
+            properties=block.properties[..., :-1],
+            components=block.components,
+        )
+        for param, obj in block.gradients():
+            new_block.add_gradient(
+                parameter=param,
+                samples=obj.samples,
+                components=obj.components,
+                data=obj.data[..., :-1],
+            )
+        new_blocks.append(new_block)
+
+    new_tensor = TensorMap(keys=tensor_map.keys, blocks=new_blocks)
+    assert not equal_metadata(tensor_map, new_tensor)
+
+
+def test_remove_last_component(tensor_map):
+    # removing the last component should yield False
+    new_blocks = []
+    for key in tensor_map.keys:
+        block = tensor_map[key].copy()
+
+        can_remove = np.all([len(c) > 2 for c in block.components])
+
+        if can_remove:
+            components = [c[:-1] for c in block.components]
             new_block = TensorBlock(
-                values=block.values,
-                samples=samples,
-                properties=block.properties,
-                components=block.components,
-            )
-            for param, obj in block.gradients():
-                new_block.add_gradient(
-                    parameter=param,
-                    samples=obj.samples,
-                    components=obj.components,
-                    data=obj.data,
-                )
-            new_blocks.append(new_block)
-
-        new_tensor = TensorMap(keys=test_tensor_map_1.keys, blocks=new_blocks)
-        assert not equal_metadata(test_tensor_map_1, new_tensor)
-
-    def test_changing_properties_key_order(self, test_tensor_map_1):
-        # changing the order of the values of the properties should yield False
-        new_blocks = []
-        for key in test_tensor_map_1.keys:
-            block = test_tensor_map_1[key].copy()
-            properties = block.properties[::-1]
-            new_block = TensorBlock(
-                values=block.values,
-                samples=block.samples,
-                properties=properties,
-                components=block.components,
-            )
-            for param, obj in block.gradients():
-                new_block.add_gradient(
-                    parameter=param,
-                    samples=obj.samples,
-                    components=obj.components,
-                    data=obj.data,
-                )
-            new_blocks.append(new_block)
-
-        new_tensor = TensorMap(keys=test_tensor_map_1.keys, blocks=new_blocks)
-        assert not equal_metadata(test_tensor_map_1, new_tensor)
-
-    def test_add_components_key_order(self, tensor_map):
-        # changing the order of the values of the components should yield False
-        new_blocks = []
-        for key in tensor_map.keys:
-            block = tensor_map[key].copy()
-            components = [comp[::-1] for comp in block.components]
-            new_block = TensorBlock(
-                values=block.values,
+                values=block.values[:, :-1],
                 samples=block.samples,
                 properties=block.properties,
                 components=components,
             )
-            for param, obj in block.gradients():
+            for parameter, gradient in block.gradients():
                 new_block.add_gradient(
-                    parameter=param,
-                    samples=obj.samples,
-                    components=components,
-                    data=obj.data,
-                )
-            new_blocks.append(new_block)
-
-        new_tensor = TensorMap(keys=tensor_map.keys, blocks=new_blocks)
-        assert not equal_metadata(tensor_map, new_tensor)
-
-    def test_remove_last_sample(self, tensor_map):
-        # removing the last sample should yield False
-        new_blocks = []
-        for key in tensor_map.keys:
-            block = tensor_map[key].copy()
-            new_block = TensorBlock(
-                values=block.values[:-1],
-                samples=block.samples[:-1],
-                properties=block.properties,
-                components=block.components,
-            )
-            for param, obj in block.gradients():
-                new_block.add_gradient(
-                    parameter=param,
-                    samples=obj.samples[:-1],
-                    components=obj.components,
-                    data=obj.data[:-1],
-                )
-            new_blocks.append(new_block)
-
-        new_tensor = TensorMap(keys=tensor_map.keys, blocks=new_blocks)
-        assert not equal_metadata(tensor_map, new_tensor)
-
-    def test_remove_last_property(self, tensor_map):
-        # removing the last property should yield False
-        new_blocks = []
-        for key in tensor_map.keys:
-            block = tensor_map[key].copy()
-            new_block = TensorBlock(
-                values=block.values[..., :-1],
-                samples=block.samples,
-                properties=block.properties[..., :-1],
-                components=block.components,
-            )
-            for param, obj in block.gradients():
-                new_block.add_gradient(
-                    parameter=param,
-                    samples=obj.samples,
-                    components=obj.components,
-                    data=obj.data[..., :-1],
-                )
-            new_blocks.append(new_block)
-
-        new_tensor = TensorMap(keys=tensor_map.keys, blocks=new_blocks)
-        assert not equal_metadata(tensor_map, new_tensor)
-
-    def test_remove_last_component(self, tensor_map):
-        # removing the last component should yield False
-        new_blocks = []
-        for key in tensor_map.keys:
-            block = tensor_map[key].copy()
-
-            can_remove = np.all([len(c) > 2 for c in block.components])
-
-            if can_remove:
-                components = [c[:-1] for c in block.components]
-                new_block = TensorBlock(
-                    values=block.values[:, :-1],
-                    samples=block.samples,
-                    properties=block.properties,
+                    parameter=parameter,
+                    data=gradient.data[:, :-1],
+                    samples=gradient.samples,
                     components=components,
                 )
-                for parameter, gradient in block.gradients():
-                    new_block.add_gradient(
-                        parameter=parameter,
-                        data=gradient.data[:, :-1],
-                        samples=gradient.samples,
-                        components=components,
-                    )
-            else:
-                new_block = block.copy()
-            new_blocks.append(new_block)
+        else:
+            new_block = block.copy()
+        new_blocks.append(new_block)
 
-        new_tensor = TensorMap(keys=tensor_map.keys, blocks=new_blocks)
-        assert not equal_metadata(tensor_map, new_tensor)
+    new_tensor = TensorMap(keys=tensor_map.keys, blocks=new_blocks)
+    assert not equal_metadata(tensor_map, new_tensor)


### PR DESCRIPTION
This flag dictates whether or not the underlying data of the input TensorBlocks (and Gradients) should be copied for the returned TensorMap.

Setting to False, the the new TensorMap is constructed with a reference to the original data. This of course could be unsafe if the user manipulates via one reference and unknowingly changes the other. However, the advantage for the careful user is that a large increase in memory usage is not created.

Default value is set to False.

Also done in this PR (and not in a separate one, for no good reason) was a removal of the test class in the test script unique_metadata.py

<!-- readthedocs-preview equistore start -->
----
:books: Documentation preview :books:: https://equistore--248.org.readthedocs.build/en/248/

<!-- readthedocs-preview equistore end -->