### PR TITLE
Spring cleaning for tests and operations

### DIFF
--- a/docs/src/reference/operations/logic/equal.rst
+++ b/docs/src/reference/operations/logic/equal.rst
@@ -8,3 +8,5 @@ equal
 .. autofunction:: equistore.equal_block
 
 .. autofunction:: equistore.equal_block_raise
+
+.. autofunction:: equistore.NotEqualError

--- a/python/scripts/generate-declarations.py
+++ b/python/scripts/generate-declarations.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 import os
-import sys
 
 from pycparser import c_ast, parse_file
 

--- a/python/src/equistore/block.py
+++ b/python/src/equistore/block.py
@@ -210,7 +210,9 @@ class TensorBlock:
         Get the gradient of the block ``values``  with respect to the
         given ``parameter``.
 
-        Here is an example of how to use this method:
+        :param parameter: check for gradients with respect to this ``parameter``
+            (e.g. ``positions``, ``cell``, ...)
+
         >>> import numpy as np
         >>> from equistore import TensorBlock, Labels
         >>> block_1 = TensorBlock(
@@ -250,9 +252,6 @@ class TensorBlock:
         samples (2): ['sample']
         components (6, 1): ['cell', 'components']
         properties (1): ['properties']
-
-        :param parameter: check for gradients with respect to this ``parameter``
-            (e.g. ``positions``, ``cell``, ...)
         """
         if not self.has_gradient(parameter):
             raise ValueError(
@@ -270,7 +269,13 @@ class TensorBlock:
         """
         Add a set of gradients with respect to ``parameters`` in this block.
 
-        Here is an example of how to use this method:
+        :param parameter: add gradients with respect to this ``parameter`` (e.g.
+            ``positions``, ``cell``, ...)
+        :param data: the gradient array, of shape ``(gradient_samples,
+            components, properties)``, where the properties labels are the same
+            as the values' properties labels.
+        :param samples: labels describing the gradient samples
+        :param components: labels describing the gradient components
 
         >>> import numpy as np
         >>> from equistore import TensorBlock, Labels
@@ -292,14 +297,6 @@ class TensorBlock:
             components (1): ['components']
             properties (1): ['properties']
             gradients: ['position']
-
-        :param parameter: add gradients with respect to this ``parameter`` (e.g.
-            ``positions``, ``cell``, ...)
-        :param data: the gradient array, of shape ``(gradient_samples,
-            components, properties)``, where the properties labels are the same
-            as the values' properties labels.
-        :param samples: labels describing the gradient samples
-        :param components: labels describing the gradient components
         """
         if self._parent is not None:
             raise ValueError(

--- a/python/src/equistore/operations/__init__.py
+++ b/python/src/equistore/operations/__init__.py
@@ -6,29 +6,29 @@ and can be used to build Machine Learning models.
 These functions can handle data stored either in numpy arrays or Torch tensor,
 and automatically dispatch to the right function for a given TensorMap.
 """
-from .abs import abs  # noqa
-from .add import add  # noqa
-from .allclose import (  # noqa
+from .abs import abs
+from .add import add
+from .allclose import (
     allclose,
     allclose_block,
     allclose_block_raise,
     allclose_raise,
 )
-from .block_from_array import block_from_array  # noqa
-from .divide import divide  # noqa
-from .dot import dot  # noqa
+from .block_from_array import block_from_array
+from .divide import divide
+from .dot import dot
 from .drop_blocks import drop_blocks
-from .empty_like import empty_like, empty_like_block  # noqa
-from .equal import equal, equal_block, equal_block_raise, equal_raise  # noqa
-from .equal_metadata import equal_metadata  # noqa
-from .join import join  # noqa
-from .lstsq import lstsq  # noqa
-from .multiply import multiply  # noqa
-from .one_hot import one_hot  # noqa
-from .ones_like import ones_like, ones_like_block  # noqa
-from .random_like import random_uniform_like, random_uniform_like_block  # noqa
-from .pow import pow  # noqa
-from .reduce_over_samples import (  # noqa
+from .empty_like import empty_like, empty_like_block
+from .equal import equal, equal_block, equal_block_raise, equal_raise
+from .equal_metadata import equal_metadata
+from .join import join
+from .lstsq import lstsq
+from .multiply import multiply
+from .one_hot import one_hot
+from .ones_like import ones_like, ones_like_block
+from .random_like import random_uniform_like, random_uniform_like_block
+from .pow import pow
+from .reduce_over_samples import (
     mean_over_samples,
     mean_over_samples_block,
     std_over_samples,
@@ -38,13 +38,13 @@ from .reduce_over_samples import (  # noqa
     var_over_samples,
     var_over_samples_block,
 )
-from .remove_gradients import remove_gradients  # noqa
-from .slice import slice, slice_block  # noqa
-from .solve import solve  # noqa
-from .split import split, split_block  # nopa
-from .subtract import subtract  # noqa
-from .unique_metadata import unique_metadata, unique_metadata_block  # noqa
-from .zeros_like import zeros_like, zeros_like_block  # noqa
+from .remove_gradients import remove_gradients
+from .slice import slice, slice_block
+from .solve import solve
+from .split import split, split_block
+from .subtract import subtract
+from .unique_metadata import unique_metadata, unique_metadata_block
+from .zeros_like import zeros_like, zeros_like_block
 
 __all__ = [
     "abs",

--- a/python/src/equistore/operations/__init__.py
+++ b/python/src/equistore/operations/__init__.py
@@ -19,7 +19,7 @@ from .divide import divide
 from .dot import dot
 from .drop_blocks import drop_blocks
 from .empty_like import empty_like, empty_like_block
-from .equal import equal, equal_block, equal_block_raise, equal_raise
+from .equal import equal, equal_block, equal_block_raise, equal_raise, NotEqualError
 from .equal_metadata import equal_metadata
 from .join import join
 from .lstsq import lstsq
@@ -47,6 +47,7 @@ from .unique_metadata import unique_metadata, unique_metadata_block
 from .zeros_like import zeros_like, zeros_like_block
 
 __all__ = [
+    "NotEqualError",
     "abs",
     "add",
     "allclose",

--- a/python/src/equistore/operations/_dispatch.py
+++ b/python/src/equistore/operations/_dispatch.py
@@ -264,8 +264,9 @@ def zeros_like(array, shape=None, requires_grad=False):
     Create an array filled with zeros, with the given ``shape``, and similar
     dtype, device and other options as ``array``.
 
-    If ``shape`` is ``None``, the array shape is used instead. ``requires_grad``
-    is only used for torch tensors, and set the corresponding value.
+    If ``shape`` is :py:obj:`None`, the array shape is used instead.
+    ``requires_grad`` is only used for torch tensors, and set the corresponding
+    value on the returned array.
 
     This is the equivalent to ``np.zeros_like(array, shape=shape)``.
     """
@@ -291,8 +292,9 @@ def ones_like(array, shape=None, requires_grad=False):
     Create an array filled with ones, with the given ``shape``, and similar
     dtype, device and other options as ``array``.
 
-    If ``shape`` is ``None``, the array shape is used instead. ``requires_grad``
-    is only used for torch tensors, and set the corresponding value.
+    If ``shape`` is :py:obj:`None`, the array shape is used instead.
+    ``requires_grad`` is only used for torch tensors, and set the corresponding
+    value on the returned array.
 
     This is the equivalent to ``np.ones_like(array, shape=shape)``.
     """
@@ -318,8 +320,9 @@ def empty_like(array, shape=None, requires_grad=False):
     Create an uninitialized array, with the given ``shape``, and similar dtype,
     device and other options as ``array``.
 
-    If ``shape`` is ``None``, the array shape is used instead. ``requires_grad``
-    is only used for torch tensors, and set the corresponding value.
+    If ``shape`` is :py:obj:`None`, the array shape is used instead.
+    ``requires_grad`` is only used for torch tensors, and set the corresponding
+    value on the returned array.
 
     This is the equivalent to ``np.empty_like(array, shape=shape)``.
     """
@@ -374,8 +377,9 @@ def rand_like(array, shape=None, requires_grad=False):
     in the ``[0, 1)`` interval, with the given ``shape``, and similar dtype,
     device and other options as ``array``.
 
-    If ``shape`` is ``None``, the array shape is used instead. ``requires_grad``
-    is only used for torch tensors, and set the corresponding value.
+    If ``shape`` is :py:obj:`None`, the array shape is used instead.
+    ``requires_grad`` is only used for torch tensors, and set the corresponding
+    value on the returned array.
     """
 
     if isinstance(array, np.ndarray):

--- a/python/src/equistore/operations/add.py
+++ b/python/src/equistore/operations/add.py
@@ -2,7 +2,7 @@ from typing import Union
 
 from ..block import TensorBlock
 from ..tensor import TensorMap
-from .equal_metadata import _check_blocks, _check_maps, _check_same_gradients
+from .equal_metadata import _check_blocks, _check_same_gradients, _check_same_keys
 
 
 def add(A: TensorMap, B: Union[float, TensorMap]) -> TensorMap:
@@ -33,7 +33,7 @@ def add(A: TensorMap, B: Union[float, TensorMap]) -> TensorMap:
 
     blocks = []
     if isinstance(B, TensorMap):
-        _check_maps(A, B, "add")
+        _check_same_keys(A, B, "add")
         for key in A.keys:
             blockA = A[key]
             blockB = B[key]

--- a/python/src/equistore/operations/allclose.py
+++ b/python/src/equistore/operations/allclose.py
@@ -17,19 +17,19 @@ def allclose(
     """
     Compare two :py:class:`TensorMap`.
 
-    This function returns ``True`` if the two tensors have the same keys
+    This function returns :py:obj:`True` if the two tensors have the same keys
     (potentially in different order) and all the :py:class:`TensorBlock` have
     the same (and in the same order) samples, components, properties, and their
     values matrices pass the numpy-like ``allclose`` test with the provided
     ``rtol``, and ``atol``.
 
     The :py:class:`TensorMap` contains gradient data, then this function only
-    returns ``True`` if all the gradients also have the same samples,
+    returns :py:obj:`True` if all the gradients also have the same samples,
     components, properties and their data matrices pass the numpy-like
     ``allclose`` test with the provided ``rtol``, and ``atol``.
 
     In practice this function calls :py:func:`allclose_raise`, returning
-    ``True`` if no exception is raised, ``False`` otherwise.
+    :py:obj:`True` if no exception is raised, :py:obj:`False` otherwise.
 
     :param tensor_1: first :py:class:`TensorMap`
     :param tensor_2: second :py:class:`TensorMap`
@@ -252,7 +252,7 @@ def allclose_block(
     """
     Compare two :py:class:`TensorBlock`.
 
-    This function returns ``True`` if the two :py:class:`TensorBlock` have the
+    This function returns :py:obj:`True` if the two :py:class:`TensorBlock` have the
     same samples, components, properties and their values matrices must pass the
     numpy-like ``allclose`` test with the provided ``rtol``, and ``atol``.
 
@@ -262,7 +262,7 @@ def allclose_block(
     provided ``rtol``, and ``atol``.
 
     In practice this function calls :py:func:`allclose_block_raise`, returning
-    ``True`` if no exception is raised, ``False`` otherwise.
+    :py:obj:`True` if no exception is raised, :py:obj:`False` otherwise.
 
     :param block_1: first :py:class:`TensorBlock`
     :param block_2: second :py:class:`TensorBlock`

--- a/python/src/equistore/operations/allclose.py
+++ b/python/src/equistore/operations/allclose.py
@@ -3,7 +3,7 @@ import numpy as np
 from equistore import TensorBlock, TensorMap
 
 from . import _dispatch
-from .equal_metadata import _check_blocks, _check_maps, _check_same_gradients
+from .equal_metadata import _check_blocks, _check_same_gradients, _check_same_keys
 
 
 def allclose(
@@ -221,7 +221,7 @@ def allclose_raise(
     :param atol: absolute tolerance for ``allclose``. Defaults: 1e-12.
     :param equal_nan: should two ``NaN`` be considered equal? Defaults: False.
     """
-    _check_maps(tensor1, tensor2, "allclose")
+    _check_same_keys(tensor1, tensor2, "allclose")
 
     for key, block1 in tensor1:
         try:

--- a/python/src/equistore/operations/allclose.py
+++ b/python/src/equistore/operations/allclose.py
@@ -3,22 +3,24 @@ import numpy as np
 from equistore import TensorBlock, TensorMap
 
 from . import _dispatch
+from .equal import NotEqualError
 from .equal_metadata import _check_blocks, _check_same_gradients, _check_same_keys
 
 
 def allclose(
-    tensor1: TensorMap,
-    tensor2: TensorMap,
+    tensor_1: TensorMap,
+    tensor_2: TensorMap,
     rtol=1e-13,
     atol=1e-12,
     equal_nan=False,
 ) -> bool:
-    """Compare two :py:class:`TensorMap`.
+    """
+    Compare two :py:class:`TensorMap`.
 
     This function returns ``True`` if the two tensors have the same keys
     (potentially in different order) and all the :py:class:`TensorBlock` have
-    the same (and in the same order) samples, components, properties,
-    and their values matrices pass the numpy-like ``allclose`` test with the provided
+    the same (and in the same order) samples, components, properties, and their
+    values matrices pass the numpy-like ``allclose`` test with the provided
     ``rtol``, and ``atol``.
 
     The :py:class:`TensorMap` contains gradient data, then this function only
@@ -27,13 +29,13 @@ def allclose(
     ``allclose`` test with the provided ``rtol``, and ``atol``.
 
     In practice this function calls :py:func:`allclose_raise`, returning
-    ``True`` if no exception is rased, `False` otherwise.
+    ``True`` if no exception is raised, ``False`` otherwise.
 
     Here are examples using this function:
 
     >>> from equistore import Labels
     >>> # Create simple block
-    >>> block1 = TensorBlock(
+    >>> block_1 = TensorBlock(
     ...     values=np.array(
     ...         [
     ...             [1, 2, 4],
@@ -52,8 +54,8 @@ def allclose(
     ...     components=[],
     ...     properties=Labels(["properties"], np.array([[0], [1], [2]])),
     ... )
-    >>> # Create a second block that is equivalent to block1
-    >>> block2 = TensorBlock(
+    >>> # Create a second block that is equivalent to block_1
+    >>> block_2 = TensorBlock(
     ...     values=np.array(
     ...         [
     ...             [1, 2, 4],
@@ -75,13 +77,13 @@ def allclose(
     >>> # Create tensors from blocks, using keys with different names
     >>> keys1 = Labels(names=["key1"], values=np.array([[0]]))
     >>> keys2 = Labels(names=["key2"], values=np.array([[0]]))
-    >>> tensor1 = TensorMap(keys1, [block1])
-    >>> tensor2 = TensorMap(keys2, [block2])
+    >>> tensor_1 = TensorMap(keys1, [block_1])
+    >>> tensor_2 = TensorMap(keys2, [block_2])
     >>> # Call allclose, which should fail as the blocks have different keys
     >>> # associated with them
-    >>> allclose(tensor1, tensor2)
+    >>> allclose(tensor_1, tensor_2)
     False
-    >>> # Create a third tensor, which differs from tensor1 only by 1e-5 in a
+    >>> # Create a third tensor, which differs from tensor_1 only by 1e-5 in a
     >>> # single block value
     >>> block3 = TensorBlock(
     ...     values=np.array(
@@ -102,59 +104,60 @@ def allclose(
     ...     components=[],
     ...     properties=Labels(["properties"], np.array([[0], [1], [2]])),
     ... )
-    >>> # Create tensors from blocks, using key with same name as block1
+    >>> # Create tensors from blocks, using key with same name as block_1
     >>> keys3 = Labels(names=["key1"], values=np.array([[0]]))
     >>> tensor3 = TensorMap(keys3, [block3])
     >>> # Call allclose, which should return False because the default rtol
     >>> # is 1e-13, and the difference in the first value between the blocks
     >>> # of the two tensors is 1e-5
-    >>> allclose(tensor1, tensor3)
+    >>> allclose(tensor_1, tensor3)
     False
     >>> # Calling allclose again with the optional argument rtol=1e-5 should
     >>> # return True, as the difference in the first value between the blocks
     >>> # of the two tensors is within the tolerance limit
-    >>> allclose(tensor1, tensor3, rtol=1e-5)
+    >>> allclose(tensor_1, tensor3, rtol=1e-5)
     True
 
-    :param tensor1: first :py:class:`TensorMap`.
-    :param tensor2: second :py:class:`TensorMap`.
+    :param tensor_1: first :py:class:`TensorMap`.
+    :param tensor_2: second :py:class:`TensorMap`.
     :param rtol: relative tolerance for ``allclose``. Default: 1e-13.
     :param atol: absolute tolerance for ``allclose``. Defaults: 1e-12.
     :param equal_nan: should two ``NaN`` be considered equal? Defaults: False.
     """
     try:
         allclose_raise(
-            tensor1=tensor1,
-            tensor2=tensor2,
+            tensor_1=tensor_1,
+            tensor_2=tensor_2,
             rtol=rtol,
             atol=atol,
             equal_nan=equal_nan,
         )
         return True
-    except ValueError:
+    except NotEqualError:
         return False
 
 
 def allclose_raise(
-    tensor1: TensorMap,
-    tensor2: TensorMap,
+    tensor_1: TensorMap,
+    tensor_2: TensorMap,
     rtol=1e-13,
     atol=1e-12,
     equal_nan=False,
 ):
     """
-    Compare two :py:class:`TensorMap`, raising a ``ValueError`` if they are not
-    the same.
+    Compare two :py:class:`TensorMap`, raising :py:class:`NotEqualError` if they
+    are not the same.
 
-    The message associated with the ``ValueError`` will contain more information
-    on where the two :py:class:`TensorMap` differ. See :py:func:`allclose` for
-    more information on which :py:class:`TensorMap` are considered equal.
+    The message associated with the exception will contain more information on
+    where the two :py:class:`TensorMap` differ. See :py:func:`allclose` for more
+    information on which :py:class:`TensorMap` are considered equal.
 
     Here are examples using this function:
 
+    >>> import equistore
     >>> from equistore import Labels
     >>> # Create simple block, with one np.nan value
-    >>> block1 = TensorBlock(
+    >>> block_1 = TensorBlock(
     ...     values=np.array(
     ...         [
     ...             [1, 2, 4],
@@ -173,9 +176,9 @@ def allclose_raise(
     ...     components=[],
     ...     properties=Labels(["properties"], np.array([[0], [1], [2]])),
     ... )
-    >>> # Create a second block that differs from block1 by 1e-5 in its
+    >>> # Create a second block that differs from block_1 by 1e-5 in its
     >>> # first value
-    >>> block2 = TensorBlock(
+    >>> block_2 = TensorBlock(
     ...     values=np.array(
     ...         [
     ...             [1 + 1e-5, 2, 4],
@@ -196,49 +199,55 @@ def allclose_raise(
     ... )
     >>> # Create tensors from blocks, using same keys
     >>> keys = Labels(names=["key"], values=np.array([[0]]))
-    >>> tensor1 = TensorMap(keys, [block1])
-    >>> tensor2 = TensorMap(keys, [block2])
-    >>> # Call allclose_raise, which should return a ValueError because:
+    >>> tensor_1 = TensorMap(keys, [block_1])
+    >>> tensor_2 = TensorMap(keys, [block_2])
+    >>> # Call allclose_raise, which should raise NotEqualError because:
     >>> # 1. The two NaNs are not considered equal,
     >>> # 2. The difference between the first value in the blocks
     >>> # is greater than the default rtol of 1e-13
     >>> # If this is executed yourself, you will see a nested exception
-    >>> # ValueError which explains that the values of the two blocks
-    >>> # are not allclose
-    >>> allclose_raise(tensor1, tensor2)
-    Traceback (most recent call last):
-        ...
-    ValueError: The TensorBlocks with key = (0,) are different
-    >>> # Call allclose_raise again, but use equal_nan=True and rtol=1e-5
+    >>> # explaining that the values of the two blocks are not allclose
+    >>> try:
+    ...     allclose_raise(tensor_1, tensor_2)
+    ... except equistore.NotEqualError as e:
+    ...     print(f"got an exception: {e}")
+    ...
+    got an exception: blocks for key '(0,)' are different
+    >>> # call allclose_raise again, but use equal_nan=True and rtol=1e-5
     >>> # This passes, as the two NaNs are now considered equal, and the
     >>> # difference between the first values of the blocks of the two tensors
     >>> # is within the rtol limit of 1e-5
-    >>> allclose_raise(tensor1, tensor2, equal_nan=True, rtol=1e-5)
+    >>> allclose_raise(tensor_1, tensor_2, equal_nan=True, rtol=1e-5)
 
-    :param tensor1: first :py:class:`TensorMap`.
-    :param tensor2: second :py:class:`TensorMap`.
+    :raises: :py:class:`NotEqualError` if the blocks are different
+
+    :param tensor_1: first :py:class:`TensorMap`.
+    :param tensor_2: second :py:class:`TensorMap`.
     :param rtol: relative tolerance for ``allclose``. Default: 1e-13.
     :param atol: absolute tolerance for ``allclose``. Defaults: 1e-12.
     :param equal_nan: should two ``NaN`` be considered equal? Defaults: False.
     """
-    _check_same_keys(tensor1, tensor2, "allclose")
+    try:
+        _check_same_keys(tensor_1, tensor_2, "allclose")
+    except ValueError as e:
+        raise NotEqualError("the tensor maps have different keys") from e
 
-    for key, block1 in tensor1:
+    for key, block_1 in tensor_1:
         try:
             allclose_block_raise(
-                block1,
-                tensor2.block(key),
+                block_1,
+                tensor_2.block(key),
                 rtol=rtol,
                 atol=atol,
                 equal_nan=equal_nan,
             )
-        except ValueError as e:
-            raise ValueError(f"The TensorBlocks with key = {key} are different") from e
+        except NotEqualError as e:
+            raise NotEqualError(f"blocks for key '{key}' are different") from e
 
 
 def allclose_block(
-    block1: TensorBlock,
-    block2: TensorBlock,
+    block_1: TensorBlock,
+    block_2: TensorBlock,
     rtol=1e-13,
     atol=1e-12,
     equal_nan=False,
@@ -256,13 +265,13 @@ def allclose_block(
     provided ``rtol``, and ``atol``.
 
     In practice this function calls :py:func:`allclose_block_raise`, returning
-    ``True`` if no exception is rased, `False` otherwise.
+    ``True`` if no exception is raised, ``False`` otherwise.
 
-    Here are some exmaples using this function:
+    Here are some examples using this function:
 
     >>> from equistore import Labels
     >>> # Create simple block
-    >>> block1 = TensorBlock(
+    >>> block_1 = TensorBlock(
     ...     values=np.array(
     ...         [
     ...             [1, 2, 4],
@@ -281,8 +290,8 @@ def allclose_block(
     ...     components=[],
     ...     properties=Labels(["property_1"], np.array([[0], [1], [2]])),
     ... )
-    >>> # Recreate block1, but change first value in the block from 1 to 1.00001
-    >>> block2 = TensorBlock(
+    >>> # Recreate block_1, but change first value in the block from 1 to 1.00001
+    >>> block_2 = TensorBlock(
     ...     values=np.array(
     ...         [
     ...             [1 + 1e-5, 2, 4],
@@ -304,54 +313,54 @@ def allclose_block(
     >>> # Call allclose_block, which should return False because the default
     >>> # rtol is 1e-13, and the difference in the first value between the
     >>> # two blocks is 1e-5
-    >>> allclose_block(block1, block2)
+    >>> allclose_block(block_1, block_2)
     False
     >>> # Calling allclose_block with the optional argument rtol=1e-5 should
     >>> # return True, as the difference in the first value between the two
     >>> # blocks is within the tolerance limit
-    >>> allclose_block(block1, block2, rtol=1e-5)
+    >>> allclose_block(block_1, block_2, rtol=1e-5)
     True
 
-    :param block1: first :py:class:`TensorBlock`.
-    :param block2: second :py:class:`TensorBlock`.
+    :param block_1: first :py:class:`TensorBlock`.
+    :param block_2: second :py:class:`TensorBlock`.
     :param rtol: relative tolerance for ``allclose``. Default: 1e-13.
     :param atol: absolute tolerance for ``allclose``. Defaults: 1e-12.
     :param equal_nan: should two ``NaN`` be considered equal? Defaults: False.
     """
     try:
         allclose_block_raise(
-            block1=block1,
-            block2=block2,
+            block_1=block_1,
+            block_2=block_2,
             rtol=rtol,
             atol=atol,
             equal_nan=equal_nan,
         )
         return True
-    except ValueError:
+    except NotEqualError:
         return False
 
 
 def allclose_block_raise(
-    block1: TensorBlock,
-    block2: TensorBlock,
+    block_1: TensorBlock,
+    block_2: TensorBlock,
     rtol=1e-13,
     atol=1e-12,
     equal_nan=False,
 ):
     """
-    Compare two :py:class:`TensorBlock`, raising a ``ValueError`` if they are
-    not the same.
+    Compare two :py:class:`TensorBlock`, raising :py:class:`NotEqualError` if
+    they are not the same.
 
-    The message associated with the ``ValueError`` will contain more information
-    on where the two :py:class:`TensorBlock` differ. See
-    :py:func:`allclose_block` for more information on which
-    :py:class:`TensorBlock` are considered equal.
+    The message associated with the exception will contain more information on
+    where the two :py:class:`TensorBlock` differ. See :py:func:`allclose_block`
+    for more information on which :py:class:`TensorBlock` are considered equal.
 
     Here is an example using this function:
 
+    >>> import equistore
     >>> from equistore import Labels
     >>> # Create simple block
-    >>> block1 = TensorBlock(
+    >>> block_1 = TensorBlock(
     ...     values=np.array(
     ...         [
     ...             [1, 2, 4],
@@ -370,8 +379,8 @@ def allclose_block_raise(
     ...     components=[],
     ...     properties=Labels(["property_1"], np.array([[0], [1], [2]])),
     ... )
-    >>> # Recreate block1, but rename properties label 'property_1' to 'property_2'
-    >>> block2 = TensorBlock(
+    >>> # Recreate block_1, but rename properties label 'property_1' to 'property_2'
+    >>> block_2 = TensorBlock(
     ...     values=np.array(
     ...         [
     ...             [1, 2, 4],
@@ -390,41 +399,59 @@ def allclose_block_raise(
     ...     components=[],
     ...     properties=Labels(["property_2"], np.array([[0], [1], [2]])),
     ... )
-    >>> # Call allclose_block_raise, which should raise a ValueError because the
+    >>> # Call allclose_block_raise, which should raise NotEqualError because the
     >>> # properties of the two blocks are not equal
-    >>> allclose_block_raise(block1, block2)
-    Traceback (most recent call last):
-        ...
-    ValueError: Inputs to 'allclose' should have the same properties:
-    properties names are not the same or not in the same order.
+    >>> try:
+    ...     allclose_block_raise(block_1, block_2)
+    ... except equistore.NotEqualError as e:
+    ...     print(f"got an exception: {e}")
+    ...
+    got an exception: inputs to 'allclose' should have the same properties:
+    properties names are not the same or not in the same order
 
-    :param block1: first :py:class:`TensorBlock`.
-    :param block2: second :py:class:`TensorBlock`.
+    :raises: :py:class:`NotEqualError` if the blocks are different
+
+    :param block_1: first :py:class:`TensorBlock`.
+    :param block_2: second :py:class:`TensorBlock`.
     :param rtol: relative tolerance for ``allclose``. Default: 1e-13.
     :param atol: absolute tolerance for ``allclose``. Defaults: 1e-12.
     :param equal_nan: should two ``NaN`` be considered equal? Defaults: False.
     """
 
-    if not np.all(block1.values.shape == block2.values.shape):
-        raise ValueError("values shapes are different")
+    if not np.all(block_1.values.shape == block_2.values.shape):
+        raise NotEqualError("values shapes are different")
 
     if not _dispatch.allclose(
-        block1.values,
-        block2.values,
+        block_1.values,
+        block_2.values,
         rtol=rtol,
         atol=atol,
         equal_nan=equal_nan,
     ):
-        raise ValueError("values are not allclose")
-    _check_blocks(
-        block1, block2, props=["samples", "properties", "components"], fname="allclose"
-    )
-    _check_same_gradients(
-        block1, block2, props=["samples", "properties", "components"], fname="allclose"
-    )
+        raise NotEqualError("values are not allclose")
 
-    for parameter, gradient1 in block1.gradients():
-        gradient2 = block2.gradient(parameter)
+    try:
+        _check_blocks(
+            block_1,
+            block_2,
+            props=["samples", "properties", "components"],
+            fname="allclose",
+        )
+    except ValueError as e:
+        raise NotEqualError(str(e))
+
+    try:
+        _check_same_gradients(
+            block_1,
+            block_2,
+            props=["samples", "properties", "components"],
+            fname="allclose",
+        )
+    except ValueError as e:
+        raise NotEqualError(str(e))
+
+    for parameter, gradient1 in block_1.gradients():
+        gradient2 = block_2.gradient(parameter)
 
         if not _dispatch.allclose(
             gradient1.data,
@@ -433,4 +460,4 @@ def allclose_block_raise(
             atol=atol,
             equal_nan=equal_nan,
         ):
-            raise ValueError(f'gradient ("{parameter}") data are not allclose')
+            raise NotEqualError(f"gradient '{parameter}' values are not allclose")

--- a/python/src/equistore/operations/allclose.py
+++ b/python/src/equistore/operations/allclose.py
@@ -31,7 +31,12 @@ def allclose(
     In practice this function calls :py:func:`allclose_raise`, returning
     ``True`` if no exception is raised, ``False`` otherwise.
 
-    Here are examples using this function:
+    :param tensor_1: first :py:class:`TensorMap`
+    :param tensor_2: second :py:class:`TensorMap`
+    :param rtol: relative tolerance for ``allclose``
+    :param atol: absolute tolerance for ``allclose``
+    :param equal_nan: should two ``NaN`` be considered equal?
+
 
     >>> from equistore import Labels
     >>> # Create simple block
@@ -117,12 +122,6 @@ def allclose(
     >>> # of the two tensors is within the tolerance limit
     >>> allclose(tensor_1, tensor3, rtol=1e-5)
     True
-
-    :param tensor_1: first :py:class:`TensorMap`.
-    :param tensor_2: second :py:class:`TensorMap`.
-    :param rtol: relative tolerance for ``allclose``. Default: 1e-13.
-    :param atol: absolute tolerance for ``allclose``. Defaults: 1e-12.
-    :param equal_nan: should two ``NaN`` be considered equal? Defaults: False.
     """
     try:
         allclose_raise(
@@ -152,7 +151,13 @@ def allclose_raise(
     where the two :py:class:`TensorMap` differ. See :py:func:`allclose` for more
     information on which :py:class:`TensorMap` are considered equal.
 
-    Here are examples using this function:
+    :raises: :py:class:`NotEqualError` if the blocks are different
+
+    :param tensor_1: first :py:class:`TensorMap`
+    :param tensor_2: second :py:class:`TensorMap`
+    :param rtol: relative tolerance for ``allclose``
+    :param atol: absolute tolerance for ``allclose``
+    :param equal_nan: should two ``NaN`` be considered equal?
 
     >>> import equistore
     >>> from equistore import Labels
@@ -218,14 +223,6 @@ def allclose_raise(
     >>> # difference between the first values of the blocks of the two tensors
     >>> # is within the rtol limit of 1e-5
     >>> allclose_raise(tensor_1, tensor_2, equal_nan=True, rtol=1e-5)
-
-    :raises: :py:class:`NotEqualError` if the blocks are different
-
-    :param tensor_1: first :py:class:`TensorMap`.
-    :param tensor_2: second :py:class:`TensorMap`.
-    :param rtol: relative tolerance for ``allclose``. Default: 1e-13.
-    :param atol: absolute tolerance for ``allclose``. Defaults: 1e-12.
-    :param equal_nan: should two ``NaN`` be considered equal? Defaults: False.
     """
     try:
         _check_same_keys(tensor_1, tensor_2, "allclose")
@@ -267,7 +264,12 @@ def allclose_block(
     In practice this function calls :py:func:`allclose_block_raise`, returning
     ``True`` if no exception is raised, ``False`` otherwise.
 
-    Here are some examples using this function:
+    :param block_1: first :py:class:`TensorBlock`
+    :param block_2: second :py:class:`TensorBlock`
+    :param rtol: relative tolerance for ``allclose``
+    :param atol: absolute tolerance for ``allclose``
+    :param equal_nan: should two ``NaN`` be considered equal?
+
 
     >>> from equistore import Labels
     >>> # Create simple block
@@ -320,12 +322,6 @@ def allclose_block(
     >>> # blocks is within the tolerance limit
     >>> allclose_block(block_1, block_2, rtol=1e-5)
     True
-
-    :param block_1: first :py:class:`TensorBlock`.
-    :param block_2: second :py:class:`TensorBlock`.
-    :param rtol: relative tolerance for ``allclose``. Default: 1e-13.
-    :param atol: absolute tolerance for ``allclose``. Defaults: 1e-12.
-    :param equal_nan: should two ``NaN`` be considered equal? Defaults: False.
     """
     try:
         allclose_block_raise(
@@ -355,7 +351,13 @@ def allclose_block_raise(
     where the two :py:class:`TensorBlock` differ. See :py:func:`allclose_block`
     for more information on which :py:class:`TensorBlock` are considered equal.
 
-    Here is an example using this function:
+    :raises: :py:class:`NotEqualError` if the blocks are different
+
+    :param block_1: first :py:class:`TensorBlock`
+    :param block_2: second :py:class:`TensorBlock`
+    :param rtol: relative tolerance for ``allclose``
+    :param atol: absolute tolerance for ``allclose``
+    :param equal_nan: should two ``NaN`` be considered equal?
 
     >>> import equistore
     >>> from equistore import Labels
@@ -408,14 +410,6 @@ def allclose_block_raise(
     ...
     got an exception: inputs to 'allclose' should have the same properties:
     properties names are not the same or not in the same order
-
-    :raises: :py:class:`NotEqualError` if the blocks are different
-
-    :param block_1: first :py:class:`TensorBlock`.
-    :param block_2: second :py:class:`TensorBlock`.
-    :param rtol: relative tolerance for ``allclose``. Default: 1e-13.
-    :param atol: absolute tolerance for ``allclose``. Defaults: 1e-12.
-    :param equal_nan: should two ``NaN`` be considered equal? Defaults: False.
     """
 
     if not np.all(block_1.values.shape == block_2.values.shape):

--- a/python/src/equistore/operations/block_from_array.py
+++ b/python/src/equistore/operations/block_from_array.py
@@ -23,7 +23,6 @@ def block_from_array(array: equistore.data.Array) -> TensorBlock:
         size of the corresponding axis. The returned :py:class:`TensorBlock` has
         no gradients.
 
-    Here is an example using this function:
 
     >>> import numpy as np
     >>> import equistore

--- a/python/src/equistore/operations/divide.py
+++ b/python/src/equistore/operations/divide.py
@@ -5,7 +5,7 @@ import numpy as np
 from ..block import TensorBlock
 from ..tensor import TensorMap
 from . import _dispatch
-from .equal_metadata import _check_blocks, _check_maps, _check_same_gradients
+from .equal_metadata import _check_blocks, _check_same_gradients, _check_same_keys
 
 
 def divide(A: TensorMap, B: Union[float, TensorMap]) -> TensorMap:
@@ -37,7 +37,7 @@ def divide(A: TensorMap, B: Union[float, TensorMap]) -> TensorMap:
 
     blocks = []
     if isinstance(B, TensorMap):
-        _check_maps(A, B, "divide")
+        _check_same_keys(A, B, "divide")
         for key, blockA in A:
             blockB = B.block(key)
             _check_blocks(

--- a/python/src/equistore/operations/dot.py
+++ b/python/src/equistore/operations/dot.py
@@ -3,7 +3,7 @@ import numpy as np
 from ..block import TensorBlock
 from ..tensor import TensorMap
 from . import _dispatch
-from .equal_metadata import _check_maps
+from .equal_metadata import _check_same_keys
 
 
 def dot(A: TensorMap, B: TensorMap) -> TensorMap:
@@ -67,7 +67,7 @@ def dot(A: TensorMap, B: TensorMap) -> TensorMap:
             ``B``; and the ``components`` equal to the ``components`` of ``A``
 
     """
-    _check_maps(A, B, "dot")
+    _check_same_keys(A, B, "dot")
 
     blocks = []
     for key, block1 in A:

--- a/python/src/equistore/operations/drop_blocks.py
+++ b/python/src/equistore/operations/drop_blocks.py
@@ -7,17 +7,22 @@ def drop_blocks(tensor: TensorMap, keys: Labels, copy: bool = False) -> TensorMa
     """
     Drop specified key/block pairs from a TensorMap.
 
-    :param tensor: the TensorMap to drop the key-block pair from.
-    :param keys: a :py:class:`Labels` object containing the keys of the blocks
-        to drop
-    :param copy: if ``True``, the returned :py:class:`TensorMap` is constructed
-        by copying the blocks from the input `tensor`. If ``False`` (default),
-        the values of the blocks in the output :py:class:`TensorMap` reference
-        the same data as the input `tensor`. The latter can be useful for
-        limiting memory usage, but should be used with caution when manipulating
-        the underlying data.
+    :param tensor:
+        the TensorMap to drop the key-block pair from.
 
-    :return: the input :py:class:`TensorMap` with the specified key/block pairs
+    :param keys:
+        a :py:class:`Labels` object containing the keys of the blocks to drop
+
+    :param copy:
+        if :py:obj:`True`, the returned :py:class:`TensorMap` is constructed by
+        copying the blocks from the input `tensor`. If :py:obj:`False`
+        (default), the values of the blocks in the output :py:class:`TensorMap`
+        reference the same data as the input `tensor`. The latter can be useful
+        for limiting memory usage, but should be used with caution when
+        manipulating the underlying data.
+
+    :return:
+        the input :py:class:`TensorMap` with the specified key/block pairs
         dropped.
     """
     # Check arg types

--- a/python/src/equistore/operations/empty_like.py
+++ b/python/src/equistore/operations/empty_like.py
@@ -3,7 +3,7 @@ from typing import List, Union
 from equistore import TensorBlock, TensorMap
 
 from . import _dispatch
-from .equal_metadata import _check_parameters_in_gradient_block
+from .equal_metadata import _check_gradient_presence
 
 
 def empty_like(
@@ -115,9 +115,7 @@ def empty_like_block(
     if parameters is None:
         parameters = block.gradients_list()
     else:
-        _check_parameters_in_gradient_block(
-            block=block, parameters=parameters, fname="empty_like_block"
-        )
+        _check_gradient_presence(block=block, parameters=parameters, fname="empty_like")
 
     for parameter in parameters:
         gradient = block.gradient(parameter)

--- a/python/src/equistore/operations/empty_like.py
+++ b/python/src/equistore/operations/empty_like.py
@@ -21,14 +21,12 @@ def empty_like(
     :param requires_grad: If autograd should record operations for the returned
                           tensor. This option is only relevant for torch.
 
-    Here is an example using this function. First we create a ``TensorMap`` with
-    just one block with two gradients, named ``alpha`` and ``beta``, containing
-    random data for values and gradients.
-
     >>> import numpy as np
     >>> import equistore
     >>> from equistore import TensorBlock, TensorMap, Labels
     >>> np.random.seed(1)
+    >>> # First we create a TensorMap with just one block with two gradients,
+    >>> # named 'alpha' and 'beta', containing random data
     >>> block = TensorBlock(
     ...     values=np.random.rand(4, 3),
     ...     samples=Labels.arange("sample", 4),
@@ -55,10 +53,8 @@ def empty_like(
         components (): []
         properties (3): ['property']
         gradients: ['alpha', 'beta']
-
-    Then we use the function ``empty_like`` to create a :py:class:`TensorMap`
-    with the same metadata as ``tensor``, but with all values uninitialized.
-
+    >>> # Then we use `empty_like` to create a TensorMap with the same metadata
+    >>> # as `tensor`, but with all values uninitialized.
     >>> tensor_empty = equistore.empty_like(tensor)
     >>> print(tensor_empty.block(0))
     TensorBlock
@@ -66,10 +62,8 @@ def empty_like(
         components (): []
         properties (3): ['property']
         gradients: ['alpha', 'beta']
-
-    Note that if we copy just the gradient ``alpha``, ``beta`` is no longer
-    available.
-
+    >>> # Note that if we copy just the gradient 'alpha', 'beta' is no longer
+    >>> # available.
     >>> tensor_empty = equistore.empty_like(tensor, parameters="alpha")
     >>> print(tensor_empty.block(0).gradients_list())
     ['alpha']

--- a/python/src/equistore/operations/empty_like.py
+++ b/python/src/equistore/operations/empty_like.py
@@ -18,9 +18,9 @@ def empty_like(
         Input tensor from which the metadata is taken.
 
     :param gradients:
-        Which gradients should be present in the output. If this is ``None``
-        (default) all gradient of ``tensor`` are present in the new
-        :py:class:`TensorMap`. If this is an empty list ``[]``, no gradients
+        Which gradients should be present in the output. If this is
+        :py:obj:`None` (default) all gradient of ``tensor`` are present in the
+        new :py:class:`TensorMap`. If this is an empty list ``[]``, no gradients
         information is copied.
 
     :param requires_grad:
@@ -97,10 +97,10 @@ def empty_like_block(
         Input block from which the metadata is taken.
 
     :param gradients:
-        Which gradients should be present in the output. If this is ``None``
-        (default) all gradient of ``block`` are present in the new
-        :py:class:`TensorBlock`. If this is an empty list ``[]``, no gradients
-        information is copied.
+        Which gradients should be present in the output. If this is
+        :py:obj:`None` (default) all gradient of ``block`` are present in the
+        new :py:class:`TensorBlock`. If this is an empty list ``[]``, no
+        gradients information is copied.
 
     :param requires_grad:
         If autograd should record operations for the returned tensor. This

--- a/python/src/equistore/operations/empty_like.py
+++ b/python/src/equistore/operations/empty_like.py
@@ -31,8 +31,10 @@ def empty_like(
     >>> import equistore
     >>> from equistore import TensorBlock, TensorMap, Labels
     >>> np.random.seed(1)
-    >>> # First we create a TensorMap with just one block with two gradients,
-    >>> # named 'alpha' and 'beta', containing random data
+
+    First we create a :py:class:`TensorMap` with just one block with two
+    gradients, named ``alpha`` and ``beta``, containing random data:
+
     >>> block = TensorBlock(
     ...     values=np.random.rand(4, 3),
     ...     samples=Labels.arange("sample", 4),
@@ -59,8 +61,10 @@ def empty_like(
         components (): []
         properties (3): ['property']
         gradients: ['alpha', 'beta']
-    >>> # Then we use `empty_like` to create a TensorMap with the same metadata
-    >>> # as `tensor`, but with all values uninitialized.
+
+    Then we use ``empty_like`` to create a :py:class:`TensorMap` with the same
+    metadata as ``tensor``, but with all values uninitialized.
+
     >>> tensor_empty = equistore.empty_like(tensor)
     >>> print(tensor_empty.block(0))
     TensorBlock
@@ -68,8 +72,10 @@ def empty_like(
         components (): []
         properties (3): ['property']
         gradients: ['alpha', 'beta']
-    >>> # Note that if we copy just the gradient 'alpha', 'beta' is no longer
-    >>> # available.
+
+    Note that if we copy just the gradient ``alpha``, ``beta`` is no longer
+    available.
+
     >>> tensor_empty = equistore.empty_like(tensor, gradients="alpha")
     >>> print(tensor_empty.block(0).gradients_list())
     ['alpha']

--- a/python/src/equistore/operations/empty_like.py
+++ b/python/src/equistore/operations/empty_like.py
@@ -8,18 +8,24 @@ from .equal_metadata import _check_gradient_presence
 
 def empty_like(
     tensor: TensorMap,
-    parameters: Union[List[str], str] = None,
+    gradients: Union[List[str], str] = None,
     requires_grad: bool = False,
 ) -> TensorMap:
     """Return a new :py:class:`TensorMap` with the same metadata as tensor,
-    and all values unitilized.
+    and all values uninitialized.
 
-    :param tensor: Input tensor from which the metadata is taken.
-    :param parameters: Which gradient parameter to copy. If ``None`` (default)
-                       all gradient of ``tensor`` are present in the new tensor.
-                       If empty list ``[]`` no gradients information are copied.
-    :param requires_grad: If autograd should record operations for the returned
-                          tensor. This option is only relevant for torch.
+    :param tensor:
+        Input tensor from which the metadata is taken.
+
+    :param gradients:
+        Which gradients should be present in the output. If this is ``None``
+        (default) all gradient of ``tensor`` are present in the new
+        :py:class:`TensorMap`. If this is an empty list ``[]``, no gradients
+        information is copied.
+
+    :param requires_grad:
+        If autograd should record operations for the returned tensor. This
+        option is only relevant for torch.
 
     >>> import numpy as np
     >>> import equistore
@@ -64,7 +70,7 @@ def empty_like(
         gradients: ['alpha', 'beta']
     >>> # Note that if we copy just the gradient 'alpha', 'beta' is no longer
     >>> # available.
-    >>> tensor_empty = equistore.empty_like(tensor, parameters="alpha")
+    >>> tensor_empty = equistore.empty_like(tensor, gradients="alpha")
     >>> print(tensor_empty.block(0).gradients_list())
     ['alpha']
     """
@@ -73,7 +79,7 @@ def empty_like(
     for _k, block in tensor:
         blocks.append(
             empty_like_block(
-                block=block, parameters=parameters, requires_grad=requires_grad
+                block=block, gradients=gradients, requires_grad=requires_grad
             )
         )
     return TensorMap(tensor.keys, blocks)
@@ -81,18 +87,24 @@ def empty_like(
 
 def empty_like_block(
     block: TensorBlock,
-    parameters: Union[List[str], str] = None,
+    gradients: Union[List[str], str] = None,
     requires_grad: bool = False,
 ) -> TensorBlock:
     """Return a new :py:class:`TensorBlock` with the same metadata as block,
-    and all values unitilized.
+    and all values uninitialized.
 
-    :param block: Input block from which the metadata is taken.
-    :param parameters: Which gradient parameter to copy. If ``None`` (default)
-                       all gradient of ``tensor`` are present in the new tensor.
-                       If empty list ``[]`` no gradients information are copied.
-    :param requires_grad: If autograd should record operations for the returned tensor.
-                          This option is only relevant for torch.
+    :param block:
+        Input block from which the metadata is taken.
+
+    :param gradients:
+        Which gradients should be present in the output. If this is ``None``
+        (default) all gradient of ``block`` are present in the new
+        :py:class:`TensorBlock`. If this is an empty list ``[]``, no gradients
+        information is copied.
+
+    :param requires_grad:
+        If autograd should record operations for the returned tensor. This
+        option is only relevant for torch.
     """
 
     values = _dispatch.empty_like(block.values, requires_grad=requires_grad)
@@ -103,15 +115,15 @@ def empty_like_block(
         properties=block.properties,
     )
 
-    if isinstance(parameters, str):
-        parameters = [parameters]
+    if isinstance(gradients, str):
+        gradients = [gradients]
 
-    if parameters is None:
-        parameters = block.gradients_list()
+    if gradients is None:
+        gradients = block.gradients_list()
     else:
-        _check_gradient_presence(block=block, parameters=parameters, fname="empty_like")
+        _check_gradient_presence(block=block, parameters=gradients, fname="empty_like")
 
-    for parameter in parameters:
+    for parameter in gradients:
         gradient = block.gradient(parameter)
         gradient_data = _dispatch.empty_like(gradient.data)
 

--- a/python/src/equistore/operations/equal.py
+++ b/python/src/equistore/operations/equal.py
@@ -3,7 +3,7 @@ import numpy as np
 from equistore import TensorBlock, TensorMap
 
 from . import _dispatch
-from .equal_metadata import _check_blocks, _check_maps, _check_same_gradients
+from .equal_metadata import _check_blocks, _check_same_gradients, _check_same_keys
 
 
 def equal(tensor1: TensorMap, tensor2: TensorMap) -> bool:
@@ -44,7 +44,7 @@ def equal_raise(tensor1: TensorMap, tensor2: TensorMap):
     :param tensor1: first :py:class:`TensorMap`.
     :param tensor2: second :py:class:`TensorMap`.
     """
-    _check_maps(tensor1, tensor2, "equal")
+    _check_same_keys(tensor1, tensor2, "equal")
 
     for key, block1 in tensor1:
         try:

--- a/python/src/equistore/operations/equal.py
+++ b/python/src/equistore/operations/equal.py
@@ -15,17 +15,17 @@ class NotEqualError(Exception):
 def equal(tensor_1: TensorMap, tensor_2: TensorMap) -> bool:
     """Compare two :py:class:`TensorMap`.
 
-    This function returns ``True`` if the two tensors have the same keys
+    This function returns :py:obj:`True` if the two tensors have the same keys
     (potentially in different order) and all the :py:class:`TensorBlock` have
     the same (and in the same order) samples, components, properties, and their
     their values are strictly equal.
 
     The :py:class:`TensorMap` contains gradient data, then this function only
-    returns ``True`` if all the gradients also have the same samples,
+    returns :py:obj:`True` if all the gradients also have the same samples,
     components, properties and their their values are strictly equal.
 
-    In practice this function calls :py:func:`equal_raise`, returning ``True``
-    if no exception is raised, ``False`` otherwise.
+    In practice this function calls :py:func:`equal_raise`, returning
+    :py:obj:`True` if no exception is raised, :py:obj:`False` otherwise.
 
     :param tensor_1: first :py:class:`TensorMap`.
     :param tensor_2: second :py:class:`TensorMap`.
@@ -68,15 +68,16 @@ def equal_block(block_1: TensorBlock, block_2: TensorBlock) -> bool:
     """
     Compare two :py:class:`TensorBlock`.
 
-    This function returns ``True`` if the two :py:class:`TensorBlock` have the
-    same samples, components, properties and their values are strictly equal.
+    This function returns :py:obj:`True` if the two :py:class:`TensorBlock` have
+    the same samples, components, properties and their values are strictly
+    equal.
 
     If the :py:class:`TensorBlock` contains gradients, then the gradient must
     also have same (and in the same order) samples, components, properties and
     their values are strictly equal.
 
     In practice this function calls :py:func:`equal_block_raise`, returning
-    ``True`` if no exception is raised, ``False`` otherwise.
+    :py:obj:`True` if no exception is raised, :py:obj:`False` otherwise.
 
     :param block_1: first :py:class:`TensorBlock`.
     :param block_2: second :py:class:`TensorBlock`.

--- a/python/src/equistore/operations/equal_metadata.py
+++ b/python/src/equistore/operations/equal_metadata.py
@@ -106,7 +106,7 @@ def equal_metadata(
             raise ValueError(f"Invalid metadata to check: {metadata}")
     # Check equivalence in keys
     try:
-        _check_maps(tensor_1, tensor_2, "equal_metadata")
+        _check_same_keys(tensor_1, tensor_2, "equal_metadata")
     except ValueError:
         return False
 
@@ -129,7 +129,7 @@ def equal_metadata(
     return True
 
 
-def _check_maps(a: TensorMap, b: TensorMap, fname: str):
+def _check_same_keys(a: TensorMap, b: TensorMap, fname: str):
     """Check if metadata between two TensorMaps is consistent for an operation.
 
     The functions verifies that
@@ -142,20 +142,23 @@ def _check_maps(a: TensorMap, b: TensorMap, fname: str):
     :param b: second :py:class:`TensorMap` for check
     """
 
-    if a.keys.names != b.keys.names:
+    keys_a = a.keys
+    keys_b = b.keys
+
+    if keys_a.names != keys_b.names:
         raise ValueError(
-            f"Inputs to {fname} should have the same keys. "
-            f"Got {a.keys.names} and {b.keys.names}."
+            f"inputs to {fname} should have the same keys names, "
+            f"got '{keys_a.names}' and '{keys_b.names}'"
         )
 
-    if len(a.blocks()) != len(b.blocks()):
+    if len(keys_a) != len(keys_b):
         raise ValueError(
-            f"Inputs to {fname} should have the same number of blocks. "
-            f"Got {len(a.blocks())} and {len(b.blocks())}."
+            f"inputs to {fname} should have the same number of blocks, "
+            f"got {len(keys_a)} and {len(keys_b)}"
         )
 
-    if not np.all([key in a.keys for key in b.keys]):
-        raise ValueError(f"Inputs to {fname} should have the same key indices.")
+    if not np.all([key in keys_a for key in keys_b]):
+        raise ValueError(f"inputs to {fname} should have the same keys")
 
 
 def _check_blocks(a: TensorBlock, b: TensorBlock, props: List[str], fname: str):

--- a/python/src/equistore/operations/equal_metadata.py
+++ b/python/src/equistore/operations/equal_metadata.py
@@ -174,10 +174,10 @@ def _check_blocks(a: TensorBlock, b: TensorBlock, props: List[str], fname: str):
                  ``'components'`` and ``'gradients'``.
     """
     for prop in props:
-        err_msg = f"Inputs to '{fname}' should have the same {prop}:\n"
-        err_msg_len = f"{prop} of the two `TensorBlock` have not the same lenght."
-        err_msg_1 = f"{prop} are not the same or not in the same order."
-        err_msg_names = f"{prop} names are not the same or not in the same order."
+        err_msg = f"inputs to '{fname}' should have the same {prop}:\n"
+        err_msg_len = f"{prop} of the two `TensorBlock` have different lengths"
+        err_msg_1 = f"{prop} are not the same or not in the same order"
+        err_msg_names = f"{prop} names are not the same or not in the same order"
         if prop == "samples":
             if not len(a.samples) == len(b.samples):
                 raise ValueError(err_msg + err_msg_len)
@@ -208,13 +208,14 @@ def _check_blocks(a: TensorBlock, b: TensorBlock, props: List[str], fname: str):
 
         else:
             raise ValueError(
-                f"{prop} is not a valid property to check. "
-                "Choose from 'samples', 'properties', 'components'."
+                f"{prop} is not a valid property to check, "
+                "choose from ['samples', 'properties', 'components']"
             )
 
 
 def _check_same_gradients(a: TensorBlock, b: TensorBlock, props: List[str], fname: str):
-    """Check if metadata between two gradients's TensorBlocks is consistent
+    """
+    Check if metadata between two gradients's TensorBlocks is consistent
      for an operation.
 
     The functions verifies that the metadata of the given props is the same
@@ -224,38 +225,38 @@ def _check_same_gradients(a: TensorBlock, b: TensorBlock, props: List[str], fnam
 
     :param a: first :py:class:`TensorBlock` for check
     :param b: second :py:class:`TensorBlock` for check
-    :param props: A list of strings containing the property to check.
-                 Allowed values are ``'samples'`` or ``'properties'``,
-                 ``'components'``. To check only if the ``'parameters'`` are consistent
-                 use ``props=None``, using ``'parameters'`` is allowed
+    :param props: A list of strings containing the property to check. Allowed
+                 values are ``'samples'`` or ``'properties'``, ``'components'``.
+                 To check only if the ``'parameters'`` are consistent use
+                 ``props=None``, using ``'parameters'`` is allowed
                   even though deprecated.
     """
-    err_msg = f"Inputs to {fname} should have the same gradient:\n"
+    err_msg = f"inputs to {fname} should have the same gradient:\n"
     grads_a = a.gradients_list()
     grads_b = b.gradients_list()
 
     if len(grads_a) != len(grads_b) or (
         not np.all([parameter in grads_b for parameter in grads_a])
     ):
-        raise ValueError(f"Inputs to {fname} should have the same gradient parameters.")
+        raise ValueError(f"inputs to {fname} should have the same gradient parameters")
 
     if props is not None:
         for parameter, grad_a in a.gradients():
             grad_b = b.gradient(parameter)
             for prop in props:
                 err_msg_len = (
-                    f'gradient ("{parameter}") {prop} of the two `TensorBlock` '
-                    "have not the same lenght."
+                    f"gradient '{parameter}' {prop} of the two `TensorBlock` "
+                    "have different lengths"
                 )
 
                 err_msg_1 = (
-                    f'gradient ("{parameter}") {prop} are not the same or not in the '
-                    "same order."
+                    f"gradient '{parameter}' {prop} are not the same or not in the "
+                    "same order"
                 )
 
                 err_msg_names = (
-                    f'gradient ("{parameter}") {prop} names are not the same '
-                    "or not in the same order."
+                    f"gradient '{parameter}' {prop} names are not the same "
+                    "or not in the same order"
                 )
 
                 if prop == "samples":
@@ -283,12 +284,12 @@ def _check_same_gradients(a: TensorBlock, b: TensorBlock, props: List[str], fnam
                         if not np.all(c1 == c2):
                             raise ValueError(err_msg + err_msg_1)
                 elif prop != "parameters":
-                    # parameters are already checked at the begining but i want to give
-                    # the opportunity to the 'user' to use it, without problems
+                    # parameters are already checked at the beginning but i want
+                    # to give the opportunity to the 'user' to use it, without
+                    # problems
                     raise ValueError(
-                        f"{prop} is not a valid property of the gradients to check. "
-                        "Choose from 'parameters', 'samples', "
-                        "'properties', 'components'."
+                        f"{prop} is not a valid property to check, "
+                        "choose from ['samples', 'properties', 'components']"
                     )
 
 

--- a/python/src/equistore/operations/equal_metadata.py
+++ b/python/src/equistore/operations/equal_metadata.py
@@ -293,11 +293,12 @@ def _check_same_gradients(a: TensorBlock, b: TensorBlock, props: List[str], fnam
                     )
 
 
-def _check_gradient_presence(block: TensorBlock, parameters: List, fname: str):
-    for p in parameters:
-        if p not in block.gradients_list():
+def _check_gradient_presence(block: TensorBlock, parameters: List[str], fname: str):
+    for parameter in parameters:
+        if parameter not in block.gradients_list():
             raise ValueError(
-                f"requested gradient '{p}' in {fname} is not defined in this tensor"
+                f"requested gradient '{parameter}' in {fname} is not defined "
+                "in this tensor"
             )
 
 

--- a/python/src/equistore/operations/equal_metadata.py
+++ b/python/src/equistore/operations/equal_metadata.py
@@ -289,14 +289,11 @@ def _check_same_gradients(a: TensorBlock, b: TensorBlock, props: List[str], fnam
                     )
 
 
-def _check_parameters_in_gradient_block(
-    block: TensorBlock, parameters: List, fname: str
-):
+def _check_gradient_presence(block: TensorBlock, parameters: List, fname: str):
     for p in parameters:
         if p not in block.gradients_list():
             raise ValueError(
-                f"The requested parameter '{p}' in {fname} is not a valid parameter"
-                "for the TensorBlock"
+                f"requested gradient '{p}' in {fname} is not defined in this tensor"
             )
 
 

--- a/python/src/equistore/operations/join.py
+++ b/python/src/equistore/operations/join.py
@@ -6,7 +6,7 @@ import numpy as np
 
 from ..labels import Labels
 from ..tensor import TensorBlock, TensorMap
-from .equal_metadata import _check_maps
+from .equal_metadata import _check_same_keys
 
 
 def join(tensor_maps: List[TensorMap], axis: str):
@@ -50,7 +50,7 @@ def join(tensor_maps: List[TensorMap], axis: str):
         return tensor_maps[0]
 
     for ts_to_join in tensor_maps[1:]:
-        _check_maps(tensor_maps[0], ts_to_join, "join")
+        _check_same_keys(tensor_maps[0], ts_to_join, "join")
 
     # Deduce if sample/property names are the same in all tensor_maps.
     # If this is not the case we have to change unify the corresponding labels later.

--- a/python/src/equistore/operations/lstsq.py
+++ b/python/src/equistore/operations/lstsq.py
@@ -32,14 +32,21 @@ def lstsq(X: TensorMap, Y: TensorMap, rcond, driver=None) -> TensorMap:
       are already transposed. Be aware of that if you want to manually access
       the values of blocks of ``w`` (see also the example below).
 
-    :param X: a :py:class:`TensorMap` containing the "coefficient" matrices
-    :param Y: a :py:class:`TensorMap` containing the "dependent variable" values
-    :param rcond: Cut-off ratio for small singular values of a. The singular
-        value :math:`{\sigma}_i` is treated as zero if smaller than
+    :param X:
+        a :py:class:`TensorMap` containing the "coefficient" matrices
+
+    :param Y:
+        a :py:class:`TensorMap` containing the "dependent variable" values
+
+    :param rcond:
+        Cut-off ratio for small singular values of a. The singular value
+        :math:`{\sigma}_i` is treated as zero if smaller than
         :math:`r_{cond}{\sigma}_1`, where :math:`{\sigma}_1` is the biggest
-        singular value of :math:`X_b`. ``None`` choses the default value for
-        numpy or PyTorch.
-    :param driver: Used only in torch (ignored if numpy is used), see
+        singular value of :math:`X_b`. :py:obj:`None` choses the default value
+        for numpy or PyTorch.
+
+    :param driver:
+        Used only in torch (ignored if numpy is used), see
         https://pytorch.org/docs/stable/generated/torch.linalg.lstsq.html for a
         full description
 

--- a/python/src/equistore/operations/lstsq.py
+++ b/python/src/equistore/operations/lstsq.py
@@ -5,7 +5,7 @@ import numpy as np
 from ..block import TensorBlock
 from ..tensor import TensorMap
 from . import _dispatch
-from .equal_metadata import _check_maps, _check_same_gradients
+from .equal_metadata import _check_same_gradients, _check_same_keys
 
 
 def lstsq(X: TensorMap, Y: TensorMap, rcond, driver=None) -> TensorMap:
@@ -110,7 +110,7 @@ def lstsq(X: TensorMap, Y: TensorMap, rcond, driver=None) -> TensorMap:
             stacklevel=1,
         )
 
-    _check_maps(X, Y, "lstsq")
+    _check_same_keys(X, Y, "lstsq")
 
     blocks = []
     for key, X_block in X:

--- a/python/src/equistore/operations/lstsq.py
+++ b/python/src/equistore/operations/lstsq.py
@@ -32,7 +32,21 @@ def lstsq(X: TensorMap, Y: TensorMap, rcond, driver=None) -> TensorMap:
       are already transposed. Be aware of that if you want to manually access
       the values of blocks of ``w`` (see also the example below).
 
-    Here is an example using this function:
+    :param X: a :py:class:`TensorMap` containing the "coefficient" matrices
+    :param Y: a :py:class:`TensorMap` containing the "dependent variable" values
+    :param rcond: Cut-off ratio for small singular values of a. The singular
+        value :math:`{\sigma}_i` is treated as zero if smaller than
+        :math:`r_{cond}{\sigma}_1`, where :math:`{\sigma}_1` is the biggest
+        singular value of :math:`X_b`. ``None`` choses the default value for
+        numpy or PyTorch.
+    :param driver: Used only in torch (ignored if numpy is used), see
+        https://pytorch.org/docs/stable/generated/torch.linalg.lstsq.html for a
+        full description
+
+    :return: a :py:class:`TensorMap` with the same keys of ``Y`` and ``X``, and
+        where each :py:class:`TensorBlock` has: the ``sample`` equal to the
+        ``properties`` of ``Y``; and the ``properties`` equal to the
+        ``properties`` of ``X``.
 
     >>> import numpy as np
     >>> from equistore import Labels, TensorBlock, TensorMap
@@ -79,28 +93,6 @@ def lstsq(X: TensorMap, Y: TensorMap, rcond, driver=None) -> TensorMap:
     >>> print(y)
     [[1. 0.]
      [0. 1.]]
-
-
-    :param X: a :py:class:`TensorMap` containing the "coefficient" matrices.
-    :param Y: a :py:class:`TensorMap` containing the "dependent variable"
-        values.
-    :param rcond: Cut-off ratio for small singular values of a. The singular
-        value :math:`{\sigma}_i` is treated as zero if smaller than
-        :math:`r_{cond}{\sigma}_1`, where :math:`{\sigma}_1` is the biggest
-        singular value of :math:`X_b`. ``None`` choses the default value for numpy
-        or PyTorch.
-    :param driver: Used only in torch (ignored if numpy is used), see
-        https://pytorch.org/docs/stable/generated/torch.linalg.lstsq.html for a
-        full description
-
-    :return: a :py:class:`TensorMap` with the same keys of ``Y`` and ``X``, and
-        where each :py:class:`TensorBlock` has: the ``sample`` equal to the
-        ``properties`` of ``Y``; and the ``properties`` equal to the
-        ``properties`` of ``X``.
-
-    :raises ValueError: if the order in the samples or components does not match
-        between ``X`` and ``Y``.
-
     """
     if rcond is None:
         warnings.warn(

--- a/python/src/equistore/operations/multiply.py
+++ b/python/src/equistore/operations/multiply.py
@@ -5,7 +5,7 @@ import numpy as np
 from ..block import TensorBlock
 from ..tensor import TensorMap
 from . import _dispatch
-from .equal_metadata import _check_blocks, _check_maps, _check_same_gradients
+from .equal_metadata import _check_blocks, _check_same_gradients, _check_same_keys
 
 
 def multiply(A: TensorMap, B: Union[float, TensorMap]) -> TensorMap:
@@ -36,7 +36,7 @@ def multiply(A: TensorMap, B: Union[float, TensorMap]) -> TensorMap:
     """
     blocks = []
     if isinstance(B, TensorMap):
-        _check_maps(A, B, "multiply")
+        _check_same_keys(A, B, "multiply")
         for key in A.keys:
             blockA = A[key]
             blockB = B[key]

--- a/python/src/equistore/operations/one_hot.py
+++ b/python/src/equistore/operations/one_hot.py
@@ -25,9 +25,7 @@ def one_hot(labels: Labels, dimension: Labels) -> np.ndarray:
         encoding along the selected dimension: its first dimension
         matches the one in ``labels``, while the second contains 1
         at the position corresponding to the original label and 0
-        everywhere else.
-
-    Here is an example using this function:
+        everywhere else
 
     >>> import numpy as np
     >>> import equistore

--- a/python/src/equistore/operations/ones_like.py
+++ b/python/src/equistore/operations/ones_like.py
@@ -3,7 +3,7 @@ from typing import List, Union
 from equistore import TensorBlock, TensorMap
 
 from . import _dispatch
-from .equal_metadata import _check_parameters_in_gradient_block
+from .equal_metadata import _check_gradient_presence
 
 
 def ones_like(
@@ -128,9 +128,7 @@ def ones_like_block(
     if parameters is None:
         parameters = block.gradients_list()
     else:
-        _check_parameters_in_gradient_block(
-            block=block, parameters=parameters, fname="ones_like_block"
-        )
+        _check_gradient_presence(block=block, parameters=parameters, fname="ones_like")
 
     for parameter in parameters:
         gradient = block.gradient(parameter)

--- a/python/src/equistore/operations/ones_like.py
+++ b/python/src/equistore/operations/ones_like.py
@@ -18,9 +18,9 @@ def ones_like(
         Input tensor from which the metadata is taken.
 
     :param gradients:
-        Which gradients should be present in the output. If this is ``None``
-        (default) all gradient of ``tensor`` are present in the new
-        :py:class:`TensorMap`. If this is an empty list ``[]``, no gradients
+        Which gradients should be present in the output. If this is
+        :py:obj:`None` (default) all gradient of ``tensor`` are present in the
+        new :py:class:`TensorMap`. If this is an empty list ``[]``, no gradients
         information is copied.
 
     :param requires_grad:
@@ -110,10 +110,10 @@ def ones_like_block(
         Input block from which the metadata is taken.
 
     :param gradients:
-        Which gradients should be present in the output. If this is ``None``
-        (default) all gradient of ``block`` are present in the new
-        :py:class:`TensorBlock`. If this is an empty list ``[]``, no gradients
-        information is copied.
+        Which gradients should be present in the output. If this is
+        :py:obj:`None` (default) all gradient of ``block`` are present in the
+        new :py:class:`TensorBlock`. If this is an empty list ``[]``, no
+        gradients information is copied.
 
     :param requires_grad:
         If autograd should record operations for the returned tensor. This

--- a/python/src/equistore/operations/ones_like.py
+++ b/python/src/equistore/operations/ones_like.py
@@ -21,14 +21,12 @@ def ones_like(
     :param requires_grad: If autograd should record operations for the returned
                           tensor. This option is only relevant for torch.
 
-    Here is an example using this function. First we create a ``TensorMap`` with
-    just one block with two gradients, named ``alpha`` and ``beta``, containing
-    random data for values and gradients.
-
     >>> import numpy as np
     >>> import equistore
     >>> from equistore import TensorBlock, TensorMap, Labels
     >>> np.random.seed(1)
+    >>> # First we create a TensorMap with just one block with two gradients,
+    >>> # named 'alpha' and 'beta', containing random data
     >>> block = TensorBlock(
     ...     values=np.random.rand(4, 3),
     ...     samples=Labels.arange("sample", 4),
@@ -55,10 +53,8 @@ def ones_like(
         components (): []
         properties (3): ['property']
         gradients: ['alpha', 'beta']
-
-    Then we use the function ``ones_like`` to create a :py:class:`TensorMap`
-    with the same metadata as ``tensor``, but with all values set equal to 1.
-
+    >>> # Then we use `ones_like` to create a TensorMap with the same metadata
+    >>> # as `tensor`, but with all values set to 1.
     >>> tensor_ones = equistore.ones_like(tensor)
     >>> print(tensor_ones.block(0))
     TensorBlock
@@ -79,10 +75,8 @@ def ones_like(
      [[1. 1. 1.]
       [1. 1. 1.]
       [1. 1. 1.]]]
-
-    Note that if we copy just the gradient ``alpha``, ``beta`` is no longer
-    available.
-
+    >>> # Note that if we copy just the gradient 'alpha', 'beta' is no longer
+    >>> # available.
     >>> tensor_ones = equistore.ones_like(tensor, parameters="alpha")
     >>> print(tensor_ones.block(0).gradients_list())
     ['alpha']

--- a/python/src/equistore/operations/ones_like.py
+++ b/python/src/equistore/operations/ones_like.py
@@ -31,8 +31,10 @@ def ones_like(
     >>> import equistore
     >>> from equistore import TensorBlock, TensorMap, Labels
     >>> np.random.seed(1)
-    >>> # First we create a TensorMap with just one block with two gradients,
-    >>> # named 'alpha' and 'beta', containing random data
+
+    First we create a :py:class:`TensorMap` with just one block with two
+    gradients, named ``alpha`` and ``beta``, containing random data:
+
     >>> block = TensorBlock(
     ...     values=np.random.rand(4, 3),
     ...     samples=Labels.arange("sample", 4),
@@ -59,8 +61,10 @@ def ones_like(
         components (): []
         properties (3): ['property']
         gradients: ['alpha', 'beta']
-    >>> # Then we use `ones_like` to create a TensorMap with the same metadata
-    >>> # as `tensor`, but with all values set to 1.
+
+    Then we use ``ones_like`` to create a :py:class:`TensorMap` with the same
+    metadata as ``tensor``, but with all values set to 1.
+
     >>> tensor_ones = equistore.ones_like(tensor)
     >>> print(tensor_ones.block(0))
     TensorBlock
@@ -81,8 +85,10 @@ def ones_like(
      [[1. 1. 1.]
       [1. 1. 1.]
       [1. 1. 1.]]]
-    >>> # Note that if we copy just the gradient 'alpha', 'beta' is no longer
-    >>> # available.
+
+    Note that if we copy just the gradient ``alpha``, ``beta`` is no longer
+    available.
+
     >>> tensor_ones = equistore.ones_like(tensor, gradients="alpha")
     >>> print(tensor_ones.block(0).gradients_list())
     ['alpha']

--- a/python/src/equistore/operations/ones_like.py
+++ b/python/src/equistore/operations/ones_like.py
@@ -8,18 +8,24 @@ from .equal_metadata import _check_gradient_presence
 
 def ones_like(
     tensor: TensorMap,
-    parameters: Union[List[str], str] = None,
+    gradients: Union[List[str], str] = None,
     requires_grad: bool = False,
 ) -> TensorMap:
     """Return a new :py:class:`TensorMap` with the same metadata as tensor,
     and all values equal to one.
 
-    :param tensor: Input tensor from which the metadata is taken.
-    :param parameters: Which gradient parameter to copy. If ``None`` (default)
-                       all gradient of ``tensor`` are present in the new tensor.
-                       If empty list ``[]`` no gradients information are copied.
-    :param requires_grad: If autograd should record operations for the returned
-                          tensor. This option is only relevant for torch.
+    :param tensor:
+        Input tensor from which the metadata is taken.
+
+    :param gradients:
+        Which gradients should be present in the output. If this is ``None``
+        (default) all gradient of ``tensor`` are present in the new
+        :py:class:`TensorMap`. If this is an empty list ``[]``, no gradients
+        information is copied.
+
+    :param requires_grad:
+        If autograd should record operations for the returned tensor. This
+        option is only relevant for torch.
 
     >>> import numpy as np
     >>> import equistore
@@ -77,7 +83,7 @@ def ones_like(
       [1. 1. 1.]]]
     >>> # Note that if we copy just the gradient 'alpha', 'beta' is no longer
     >>> # available.
-    >>> tensor_ones = equistore.ones_like(tensor, parameters="alpha")
+    >>> tensor_ones = equistore.ones_like(tensor, gradients="alpha")
     >>> print(tensor_ones.block(0).gradients_list())
     ['alpha']
     """
@@ -86,7 +92,7 @@ def ones_like(
     for block in tensor.blocks():
         blocks.append(
             ones_like_block(
-                block=block, parameters=parameters, requires_grad=requires_grad
+                block=block, gradients=gradients, requires_grad=requires_grad
             )
         )
     return TensorMap(tensor.keys, blocks)
@@ -94,18 +100,24 @@ def ones_like(
 
 def ones_like_block(
     block: TensorBlock,
-    parameters: Union[List[str], str] = None,
+    gradients: Union[List[str], str] = None,
     requires_grad: bool = False,
 ) -> TensorBlock:
     """Return a new :py:class:`TensorBlock` with the same metadata as block,
     and all values equal to one.
 
-    :param block: Input block from which the metadata is taken.
-    :param parameters: Which gradient parameter to copy. If ``None`` (default)
-                       all gradient of ``tensor`` are present in the new tensor.
-                       If empty list ``[]`` no gradients information are copied.
-    :param requires_grad: If autograd should record operations for the returned tensor.
-                          This option is only relevant for torch.
+    :param block:
+        Input block from which the metadata is taken.
+
+    :param gradients:
+        Which gradients should be present in the output. If this is ``None``
+        (default) all gradient of ``block`` are present in the new
+        :py:class:`TensorBlock`. If this is an empty list ``[]``, no gradients
+        information is copied.
+
+    :param requires_grad:
+        If autograd should record operations for the returned tensor. This
+        option is only relevant for torch.
     """
 
     values = _dispatch.ones_like(block.values, requires_grad=requires_grad)
@@ -116,15 +128,15 @@ def ones_like_block(
         properties=block.properties,
     )
 
-    if isinstance(parameters, str):
-        parameters = [parameters]
+    if isinstance(gradients, str):
+        gradients = [gradients]
 
-    if parameters is None:
-        parameters = block.gradients_list()
+    if gradients is None:
+        gradients = block.gradients_list()
     else:
-        _check_gradient_presence(block=block, parameters=parameters, fname="ones_like")
+        _check_gradient_presence(block=block, parameters=gradients, fname="ones_like")
 
-    for parameter in parameters:
+    for parameter in gradients:
         gradient = block.gradient(parameter)
         gradient_data = _dispatch.ones_like(gradient.data)
 

--- a/python/src/equistore/operations/random_like.py
+++ b/python/src/equistore/operations/random_like.py
@@ -3,7 +3,7 @@ from typing import List, Union
 from equistore import TensorBlock, TensorMap
 
 from . import _dispatch
-from .equal_metadata import _check_parameters_in_gradient_block
+from .equal_metadata import _check_gradient_presence
 
 
 def random_uniform_like(
@@ -134,8 +134,8 @@ def random_uniform_like_block(
     if parameters is None:
         parameters = block.gradients_list()
     else:
-        _check_parameters_in_gradient_block(
-            block=block, parameters=parameters, fname="random_uniform_like_block"
+        _check_gradient_presence(
+            block=block, parameters=parameters, fname="random_uniform_like"
         )
 
     for parameter in parameters:

--- a/python/src/equistore/operations/random_like.py
+++ b/python/src/equistore/operations/random_like.py
@@ -8,19 +8,25 @@ from .equal_metadata import _check_gradient_presence
 
 def random_uniform_like(
     tensor: TensorMap,
-    parameters: Union[List[str], str] = None,
+    gradients: Union[List[str], str] = None,
     requires_grad: bool = False,
 ) -> TensorMap:
     """
     Return a new :py:class:`TensorMap` with the same metadata as tensor, and all
     values randomly sampled from the uniform distribution between 0 and 1.
 
-    :param tensor: Input tensor from which the metadata is taken.
-    :param parameters: Which gradient parameter to copy. If ``None`` (default)
-                       all gradient of ``tensor`` are present in the new tensor.
-                       If empty list ``[]`` no gradients information are copied.
-    :param requires_grad: If autograd should record operations for the returned
-                          tensor. This option is only relevant for torch.
+    :param tensor:
+        Input tensor from which the metadata is taken.
+
+    :param gradients:
+        Which gradients should be present in the output. If this is ``None``
+        (default) all gradient of ``tensor`` are present in the new
+        :py:class:`TensorMap`. If this is an empty list ``[]``, no gradients
+        information is copied.
+
+    :param requires_grad:
+        If autograd should record operations for the returned tensor. This
+        option is only relevant for torch.
 
     >>> import numpy as np
     >>> import equistore
@@ -79,7 +85,7 @@ def random_uniform_like(
       [0.10233443 0.41405599 0.69440016]]]
     >>> # Note that if we copy just the gradient 'alpha', 'beta' is no longer
     >>> # available.
-    >>> tensor_random = equistore.random_uniform_like(tensor, parameters="alpha")
+    >>> tensor_random = equistore.random_uniform_like(tensor, gradients="alpha")
     >>> print(tensor_random.block(0).gradients_list())
     ['alpha']
     """
@@ -88,7 +94,7 @@ def random_uniform_like(
         blocks.append(
             random_uniform_like_block(
                 block=block,
-                parameters=parameters,
+                gradients=gradients,
                 requires_grad=requires_grad,
             )
         )
@@ -97,19 +103,25 @@ def random_uniform_like(
 
 def random_uniform_like_block(
     block: TensorBlock,
-    parameters: Union[List[str], str] = None,
+    gradients: Union[List[str], str] = None,
     requires_grad: bool = False,
 ) -> TensorBlock:
     """
     Return a new :py:class:`TensorBlock` with the same metadata as block, and
     all values randomly sampled from the uniform distribution between 0 and 1.
 
-    :param block: Input block from which the metadata is taken.
-    :param parameters: Which gradient parameter to copy. If ``None`` (default)
-                       all gradients of ``block`` are present in the new block.
-                       If empty list ``[]`` no gradients information are copied.
-    :param requires_grad: If autograd should record operations for the returned
-                          tensor. This option is only relevant for torch.
+    :param block:
+        Input block from which the metadata is taken.
+
+    :param gradients:
+        Which gradients should be present in the output. If this is ``None``
+        (default) all gradient of ``block`` are present in the new
+        :py:class:`TensorBlock`. If this is an empty list ``[]``, no gradients
+        information is copied.
+
+    :param requires_grad:
+        If autograd should record operations for the returned tensor. This
+        option is only relevant for torch.
     """
     values = _dispatch.rand_like(
         block.values,
@@ -122,17 +134,17 @@ def random_uniform_like_block(
         properties=block.properties,
     )
 
-    if isinstance(parameters, str):
-        parameters = [parameters]
+    if isinstance(gradients, str):
+        gradients = [gradients]
 
-    if parameters is None:
-        parameters = block.gradients_list()
+    if gradients is None:
+        gradients = block.gradients_list()
     else:
         _check_gradient_presence(
-            block=block, parameters=parameters, fname="random_uniform_like"
+            block=block, parameters=gradients, fname="random_uniform_like"
         )
 
-    for parameter in parameters:
+    for parameter in gradients:
         gradient = block.gradient(parameter)
         gradient_data = _dispatch.rand_like(
             gradient.data,

--- a/python/src/equistore/operations/random_like.py
+++ b/python/src/equistore/operations/random_like.py
@@ -19,9 +19,9 @@ def random_uniform_like(
         Input tensor from which the metadata is taken.
 
     :param gradients:
-        Which gradients should be present in the output. If this is ``None``
-        (default) all gradient of ``tensor`` are present in the new
-        :py:class:`TensorMap`. If this is an empty list ``[]``, no gradients
+        Which gradients should be present in the output. If this is
+        :py:obj:`None` (default) all gradient of ``tensor`` are present in the
+        new :py:class:`TensorMap`. If this is an empty list ``[]``, no gradients
         information is copied.
 
     :param requires_grad:
@@ -114,10 +114,10 @@ def random_uniform_like_block(
         Input block from which the metadata is taken.
 
     :param gradients:
-        Which gradients should be present in the output. If this is ``None``
-        (default) all gradient of ``block`` are present in the new
-        :py:class:`TensorBlock`. If this is an empty list ``[]``, no gradients
-        information is copied.
+        Which gradients should be present in the output. If this is
+        :py:obj:`None` (default) all gradient of ``block`` are present in the
+        new :py:class:`TensorBlock`. If this is an empty list ``[]``, no
+        gradients information is copied.
 
     :param requires_grad:
         If autograd should record operations for the returned tensor. This

--- a/python/src/equistore/operations/random_like.py
+++ b/python/src/equistore/operations/random_like.py
@@ -32,8 +32,10 @@ def random_uniform_like(
     >>> import equistore
     >>> from equistore import TensorBlock, TensorMap, Labels
     >>> np.random.seed(1)
-    >>> # First we create a TensorMap with just one block with two gradients,
-    >>> # named 'alpha' and 'beta', containing random data
+
+    First we create a :py:class:`TensorMap` with just one block with two
+    gradients, named ``alpha`` and ``beta``, containing random data:
+
     >>> block = TensorBlock(
     ...     values=np.random.rand(4, 3),
     ...     samples=Labels.arange("sample", 4),
@@ -60,9 +62,11 @@ def random_uniform_like(
         components (): []
         properties (3): ['property']
         gradients: ['alpha', 'beta']
-    >>> # Then we use `random_uniform_like` to create a TensorMap with the same
-    >>> # metadata as `tensor`, but with all values randomly sampled from a
-    >>> # uniform distribution
+
+    Then we use ``random_uniform_like`` to create a :py:class:`TensorMap` with
+    the same metadata as ``tensor``, but with all values randomly sampled from a
+    uniform distribution.
+
     >>> tensor_random = equistore.random_uniform_like(tensor)
     >>> print(tensor_random.block(0))
     TensorBlock
@@ -83,8 +87,10 @@ def random_uniform_like(
      [[0.49157316 0.05336255 0.57411761]
       [0.14672857 0.58930554 0.69975836]
       [0.10233443 0.41405599 0.69440016]]]
-    >>> # Note that if we copy just the gradient 'alpha', 'beta' is no longer
-    >>> # available.
+
+    Note that if we copy just the gradient ``alpha``, ``beta`` is no longer
+    available.
+
     >>> tensor_random = equistore.random_uniform_like(tensor, gradients="alpha")
     >>> print(tensor_random.block(0).gradients_list())
     ['alpha']

--- a/python/src/equistore/operations/random_like.py
+++ b/python/src/equistore/operations/random_like.py
@@ -22,14 +22,12 @@ def random_uniform_like(
     :param requires_grad: If autograd should record operations for the returned
                           tensor. This option is only relevant for torch.
 
-    Here is an example using this function. First we create a ``TensorMap`` with
-    just one block with two gradients, named ``alpha`` and ``beta``, containing
-    random data for values and gradients.
-
     >>> import numpy as np
     >>> import equistore
     >>> from equistore import TensorBlock, TensorMap, Labels
     >>> np.random.seed(1)
+    >>> # First we create a TensorMap with just one block with two gradients,
+    >>> # named 'alpha' and 'beta', containing random data
     >>> block = TensorBlock(
     ...     values=np.random.rand(4, 3),
     ...     samples=Labels.arange("sample", 4),
@@ -56,11 +54,9 @@ def random_uniform_like(
         components (): []
         properties (3): ['property']
         gradients: ['alpha', 'beta']
-
-    Then we use the function ``random_uniform_like`` to create a
-    :py:class:`TensorMap` with the same metadata as ``tensor``, but with all
-    values set equal to random values.
-
+    >>> # Then we use `random_uniform_like` to create a TensorMap with the same
+    >>> # metadata as `tensor`, but with all values randomly sampled from a
+    >>> # uniform distribution
     >>> tensor_random = equistore.random_uniform_like(tensor)
     >>> print(tensor_random.block(0))
     TensorBlock
@@ -81,10 +77,8 @@ def random_uniform_like(
      [[0.49157316 0.05336255 0.57411761]
       [0.14672857 0.58930554 0.69975836]
       [0.10233443 0.41405599 0.69440016]]]
-
-    Note that if we copy just the gradient ``alpha``, ``beta`` is no longer
-    available.
-
+    >>> # Note that if we copy just the gradient 'alpha', 'beta' is no longer
+    >>> # available.
     >>> tensor_random = equistore.random_uniform_like(tensor, parameters="alpha")
     >>> print(tensor_random.block(0).gradients_list())
     ['alpha']

--- a/python/src/equistore/operations/reduce_over_samples.py
+++ b/python/src/equistore/operations/reduce_over_samples.py
@@ -338,8 +338,15 @@ def sum_over_samples_block(
     performed. A single string is equivalent to a list with a single element:
     ``sample_names = "center"`` is the same as ``sample_names = ["center"]``.
 
-    This is best explained with an example:
+    :param block:
+        input :py:class:`TensorBlock`
+    :param sample_names:
+        names of samples to sum over
 
+    :returns:
+        a :py:class:`TensorBlock` containing the reduced values and sample labels
+
+    >>> from equistore import Labels, TensorBlock, TensorMap
     >>> block = TensorBlock(
     ...     values=np.array(
     ...         [
@@ -369,14 +376,6 @@ def sum_over_samples_block(
     >>> print(block_sum.values)
     [[ 4  7 10]
      [17 19 21]]
-
-    :param block:
-        input :py:class:`TensorBlock`
-    :param sample_names:
-        names of samples to sum over
-
-    :returns:
-        a :py:class:`TensorBlock` containing the reduced values and sample labels
     """
 
     return _reduce_over_samples_block(
@@ -401,8 +400,15 @@ def sum_over_samples(
     performed. A single string is equivalent to a list with a single element:
     ``sample_names = "center"`` is the same as ``sample_names = ["center"]``.
 
-    Here is an example using this function
+    :param tensor:
+        input :py:class:`TensorMap`
+    :param sample_names:
+        names of samples to sum over
 
+    :returns:
+        a :py:class:`TensorMap` containing the reduced values and sample labels
+
+    >>> from equistore import Labels, TensorBlock, TensorMap
     >>> block = TensorBlock(
     ...     values=np.array(
     ...         [
@@ -441,14 +447,6 @@ def sum_over_samples(
     >>> print(tensor_sum.block(0).values)
     [[ 4  7 10]
      [17 19 21]]
-
-    :param tensor:
-        input :py:class:`TensorMap`
-    :param sample_names:
-        names of samples to sum over
-
-    :returns:
-        a :py:class:`TensorMap` containing the reduced values and sample labels
     """
 
     return _reduce_over_samples(

--- a/python/src/equistore/operations/remove_gradients.py
+++ b/python/src/equistore/operations/remove_gradients.py
@@ -13,7 +13,7 @@ def remove_gradients(
     :param remove: which gradients should be excluded from the new tensor map.
         If this is set to ``None`` (this is the default), all the gradients will
         be removed.
-    :returns: A new tensormap withput the gradients.
+    :returns: A new tensormap without the gradients.
     """
 
     if remove is None:

--- a/python/src/equistore/operations/remove_gradients.py
+++ b/python/src/equistore/operations/remove_gradients.py
@@ -9,11 +9,16 @@ def remove_gradients(
 ) -> TensorMap:
     """Remove some or all of the gradients from a :py:class:`TensorMap`.
 
-    :param tensor: input :py:class:`TensorMap`, with gradients to remove
-    :param remove: which gradients should be excluded from the new tensor map.
-        If this is set to ``None`` (this is the default), all the gradients will
-        be removed.
-    :returns: A new tensormap without the gradients.
+    :param tensor:
+        input :py:class:`TensorMap`, with gradients to remove
+
+    :param remove:
+        which gradients should be excluded from the new tensor map. If this is
+        set to :py:obj:`None` (this is the default), all the gradients will be
+        removed.
+
+    :returns:
+        A new tensormap without the gradients.
     """
 
     if remove is None:

--- a/python/src/equistore/operations/solve.py
+++ b/python/src/equistore/operations/solve.py
@@ -3,7 +3,7 @@ import numpy as np
 from ..block import TensorBlock
 from ..tensor import TensorMap
 from . import _dispatch
-from .equal_metadata import _check_maps, _check_same_gradients
+from .equal_metadata import _check_same_gradients, _check_same_keys
 
 
 def solve(X: TensorMap, Y: TensorMap) -> TensorMap:
@@ -70,7 +70,7 @@ def solve(X: TensorMap, Y: TensorMap) -> TensorMap:
     >>> print(c.block().values)
     [[ 9.67680334 42.12534656]]
     """
-    _check_maps(X, Y, "solve")
+    _check_same_keys(X, Y, "solve")
 
     for _, X_block in X:
         shape = X_block.values.shape

--- a/python/src/equistore/operations/solve.py
+++ b/python/src/equistore/operations/solve.py
@@ -23,7 +23,6 @@ def solve(X: TensorMap, Y: TensorMap) -> TensorMap:
             equal to the ``properties`` of ``Y``;
             and the ``properties`` equal to the ``properties`` of ``X``.
 
-    Here is an example using this function:
 
     >>> import numpy as np
     >>> import equistore

--- a/python/src/equistore/operations/subtract.py
+++ b/python/src/equistore/operations/subtract.py
@@ -2,7 +2,7 @@ from typing import Union
 
 from ..tensor import TensorMap
 from .add import add
-from .equal_metadata import _check_maps
+from .equal_metadata import _check_same_keys
 from .multiply import multiply
 
 
@@ -32,7 +32,7 @@ def subtract(A: TensorMap, B: Union[float, TensorMap]) -> TensorMap:
     :return: New :py:class:`TensorMap` with the same metadata as ``A``.
     """
     if isinstance(B, TensorMap):
-        _check_maps(A, B, "subtract")
+        _check_same_keys(A, B, "subtract")
         B = multiply(B, -1)
     else:
         # check if can be converted in float (so if it is a constant value)

--- a/python/src/equistore/operations/unique_metadata.py
+++ b/python/src/equistore/operations/unique_metadata.py
@@ -91,7 +91,7 @@ def unique_metadata(
         corresponding to the name(s) of the indices along the specified ``axis``
         for which the unique values should be found.
     :param gradient: a ``str`` corresponding to the gradient parameter name for
-        the gradient blocks to find the unique indices for. If ``None``
+        the gradient blocks to find the unique indices for. If :py:obj:`None`
         (default), the unique indices of the regular :py:class:`TensorBlock`
         objects will be calculated.
 
@@ -172,7 +172,7 @@ def unique_metadata_block(
         corresponding to the name(s) of the metadata along the specified
         ``axis`` for which the unique indices should be found.
     :param gradient: a ``str`` corresponding to the gradient parameter name for
-        the gradient blocks to find the unique metadata for. If ``None``
+        the gradient blocks to find the unique metadata for. If :py:obj:`None`
         (default), the unique metadata of the regular :py:class:`TensorBlock`
         objects will be calculated.
 

--- a/python/src/equistore/operations/unique_metadata.py
+++ b/python/src/equistore/operations/unique_metadata.py
@@ -14,7 +14,7 @@ def unique_metadata(
     tensor: TensorMap,
     axis: str,
     names: Union[List[str], Tuple[str], str],
-    gradient_param: Optional[str] = None,
+    gradient: Optional[str] = None,
 ) -> Labels:
     """
     Returns a :py:class:`Labels` object containing the unique metadata across
@@ -22,11 +22,10 @@ def unique_metadata(
     returned for the specified ``axis`` (either ``"samples"`` or
     ``"properties"``) and metatdata ``names``.
 
-    Passing ``gradient_param`` as a ``str`` corresponding to a gradient
-    parameter (for instance ``"cell"`` or ``"positions"``) returns the unique
-    indices only for the gradient blocks. Note that gradient blocks by
-    definition have the same properties metadata as their parent
-    :py:class:`TensorBlock`.
+    Passing ``gradient`` as a ``str`` corresponding to a gradient parameter (for
+    instance ``"cell"`` or ``"positions"``) returns the unique indices only for
+    the gradient blocks. Note that gradient blocks by definition have the same
+    properties metadata as their parent :py:class:`TensorBlock`.
 
     An empty :py:class:`Labels` object is returned if there are no indices in
     the (gradient) blocks of ``tensor`` corresponding to the specified ``axis``
@@ -46,8 +45,9 @@ def unique_metadata(
             names=["structure"],
         )
 
-    Or, to find the unique ``"atom"`` indices in the ``"samples"`` metadata present
-    in the ``"positions"`` gradient blocks of a given :py:class:`TensorMap`:
+    Or, to find the unique ``"atom"`` indices in the ``"samples"`` metadata
+    present in the ``"positions"`` gradient blocks of a given
+    :py:class:`TensorMap`:
 
     .. code-block:: python
 
@@ -55,12 +55,12 @@ def unique_metadata(
             tensor,
             axis="samples",
             names=["atom"],
-            gradient_param="positions",
+            gradient="positions",
         )
 
-    The unique indices can then be used to split the :py:class:`TensorMap`
-    into several smaller :py:class:`TensorMap` objects. Say, for example, that
-    the ``unique_structures`` from the example above are:
+    The unique indices can then be used to split the :py:class:`TensorMap` into
+    several smaller :py:class:`TensorMap` objects. Say, for example, that the
+    ``unique_structures`` from the example above are:
 
     .. code-block:: python
 
@@ -90,8 +90,8 @@ def unique_metadata(
     :param names: a ``str``, ``list`` of ``str``, or ``tuple`` of ``str``
         corresponding to the name(s) of the indices along the specified ``axis``
         for which the unique values should be found.
-    :param gradient_param: a ``str`` corresponding to the gradient parameter
-        name for the gradient blocks to find the unique indices for. If none
+    :param gradient: a ``str`` corresponding to the gradient parameter name for
+        the gradient blocks to find the unique indices for. If ``None``
         (default), the unique indices of the regular :py:class:`TensorBlock`
         objects will be calculated.
 
@@ -102,38 +102,38 @@ def unique_metadata(
     """
     # Parse input args
     if not isinstance(tensor, TensorMap):
-        raise TypeError("`tensor` must be an equistore `TensorMap`")
+        raise TypeError("`tensor` argument must be an equistore TensorMap")
     names = (
         [names]
         if isinstance(names, str)
         else (list(names) if isinstance(names, tuple) else names)
     )
-    _check_args(tensor, axis, names, gradient_param)
+    _check_args(tensor, axis, names, gradient)
     # Make a list of the blocks to find unique indices for
-    if gradient_param is None:
+    if gradient is None:
         blocks = tensor.blocks()
     else:
-        blocks = [block.gradient(gradient_param) for block in tensor.blocks()]
+        blocks = [block.gradient(gradient) for block in tensor.blocks()]
 
-    return _unique_from_blocks(blocks, axis, names, gradient_param)
+    return _unique_from_blocks(blocks, axis, names, gradient)
 
 
 def unique_metadata_block(
     block: TensorBlock,
     axis: str,
     names: Union[List[str], Tuple[str], str],
-    gradient_param: Optional[str] = None,
+    gradient: Optional[str] = None,
 ) -> Labels:
     """
     Returns a :py:class:`Labels` object containing the unique metadata in the
     input :py:class:`TensorBlock`  ``block``, for the specified ``axis`` (either
     ``"samples"`` or ``"properties"``) and metatdata ``names``.
 
-    Passing ``gradient_param`` as a ``str`` corresponding to a gradient
-    parameter (for instance ``"cell"`` or ``"positions"``) returns the unique
-    indices only for the gradient block associated with ``block``. Note that
-    gradient blocks by definition have the same properties metadata as their
-    parent :py:class:`TensorBlock`.
+    Passing ``gradient`` as a ``str`` corresponding to a gradient parameter (for
+    instance ``"cell"`` or ``"positions"``) returns the unique indices only for
+    the gradient block associated with ``block``. Note that gradient blocks by
+    definition have the same properties metadata as their parent
+    :py:class:`TensorBlock`.
 
     An empty :py:class:`Labels` object is returned if there are no indices in
     the (gradient) blocks of ``tensor`` corresponding to the specified ``axis``
@@ -162,7 +162,7 @@ def unique_metadata_block(
             block,
             axis="samples",
             names=["atom"],
-            gradient_param="positions",
+            gradient="positions",
         )
 
     :param block: the :py:class:`TensorBlock` to find unique indices for.
@@ -171,8 +171,8 @@ def unique_metadata_block(
     :param names: a ``str``, ``list`` of ``str``, or ``tuple`` of ``str``
         corresponding to the name(s) of the metadata along the specified
         ``axis`` for which the unique indices should be found.
-    :param gradient_param: a ``str`` corresponding to the gradient parameter
-        name for the gradient blocks to find the unique metadata for. If none
+    :param gradient: a ``str`` corresponding to the gradient parameter name for
+        the gradient blocks to find the unique metadata for. If ``None``
         (default), the unique metadata of the regular :py:class:`TensorBlock`
         objects will be calculated.
 
@@ -183,34 +183,34 @@ def unique_metadata_block(
     """
     # Parse input args
     if not isinstance(block, TensorBlock):
-        raise TypeError("`block` must be an equistore `TensorBlock`")
+        raise TypeError("`block` argument must be an equistore TensorBlock")
     names = (
         [names]
         if isinstance(names, str)
         else (list(names) if isinstance(names, tuple) else names)
     )
-    _check_args(block, axis, names, gradient_param)
+    _check_args(block, axis, names, gradient)
     # Make a list of the blocks to find unique indices for
-    if gradient_param is None:
+    if gradient is None:
         blocks = [block]
     else:
-        blocks = [block.gradient(gradient_param)]
+        blocks = [block.gradient(gradient)]
 
-    return _unique_from_blocks(blocks, axis, names, gradient_param)
+    return _unique_from_blocks(blocks, axis, names, gradient)
 
 
 def _unique_from_blocks(
     blocks: List[TensorBlock],
     axis: str,
     names: List[str],
-    gradient_param: Optional[str],
+    gradient: Optional[str],
 ) -> Labels:
     """
     Finds the unique metadata of a list of blocks along the given ``axis`` and
-    for the specified ``names``. If ``gradient_param`` is specified, only finds
-    the unique indices for gradient blocks under the specified parameter name.
-    If the full list of names is not present in the metadata of any block, an
-    empty :py:class:`Labels` object is returned.
+    for the specified ``names``. If ``gradient`` is specified, only finds the
+    unique indices for gradient blocks under the specified parameter name. If
+    the full list of names is not present in the metadata of any block, an empty
+    :py:class:`Labels` object is returned.
     """
     # Extract indices from each block
     all_idxs = []
@@ -243,61 +243,49 @@ def _check_args(
     tensor: Union[TensorMap, TensorBlock],
     axis: str,
     names: List[str],
-    gradient_param: Optional[str] = None,
+    gradient: Optional[str] = None,
 ):
-    """
-    Checks input args for :py:func:`unique_metadata` and
-    :py:func:`unique_metadata_block`.
-    """
+    """Checks input args for `unique_metadata` and `unique_metadata_block`"""
     # Check tensors
     if isinstance(tensor, TensorMap):
         blocks = tensor.blocks()
-        # Check gradients
-        if gradient_param is not None:
-            if not isinstance(gradient_param, str):
+        if gradient is not None:
+            if not isinstance(gradient, str):
                 raise TypeError(
-                    f"`gradient_param` must be a `str`, not {type(gradient_param)}"
+                    f"`gradient` argument must be a `str`, not {type(gradient)}"
                 )
-            # Check all blocks have a gradient under the passed param
-            if not np.all([block.has_gradient(gradient_param) for block in blocks]):
+            if not np.all([block.has_gradient(gradient) for block in blocks]):
                 raise ValueError(
-                    "not all input blocks have a gradient under the"
-                    + f" passed `gradient_param` {gradient_param}"
+                    f"not all input blocks have a gradient with respect to '{gradient}'"
                 )
-            blocks = [
-                block.gradient(gradient_param) for block in blocks
-            ]  # redefine blocks
+            blocks = [block.gradient(gradient) for block in blocks]  # redefine blocks
+
     elif isinstance(tensor, TensorBlock):
         blocks = [tensor]
-        # Check gradients
-        if gradient_param is not None:
-            if not isinstance(gradient_param, str):
+        if gradient is not None:
+            if not isinstance(gradient, str):
                 raise TypeError(
-                    f"`gradient_param` must be a `str`, not {type(gradient_param)}"
+                    f"`gradient` argument must be a str, not {type(gradient)}"
                 )
-            # Check block has a gradient under the passed param
-            if not tensor.has_gradient(gradient_param):
+            if not tensor.has_gradient(gradient):
                 raise ValueError(
-                    "input block does not have a gradient under the"
-                    + f" passed `gradient_param` {gradient_param}"
+                    f"input block does not have a gradient with respect to '{gradient}'"
                 )
-            blocks = [tensor.gradient(gradient_param)]  # redefine blocks
-    # Check axis
+            blocks = [tensor.gradient(gradient)]
+
     if not isinstance(axis, str):
         raise TypeError(
-            "`axis` must be a `str`, either `'samples'` or `'properties'`,"
-            + f" receieved type {type(axis)}"
+            "`axis` argument must be a str, either `'samples'` or `'properties'`,"
+            + f" not {type(axis)}"
         )
     if axis not in ["samples", "properties"]:
-        raise ValueError(
-            "`axis` must be passed as either `'samples'` or `'properties'`,"
-            + f" {axis} was passed"
-        )
-    # Check names
+        raise ValueError("`axis` argument must be either `'samples'` or `'properties'`")
+
     if not isinstance(names, list):
-        raise TypeError(f"`names` must be a `list` of `str`, received {type(names)}")
+        raise TypeError(f"`names` argument must be a list of str, not {type(names)}")
+
     if not np.all([isinstance(name, str) for name in names]):
         raise TypeError(
-            "`names` must be a `list` of `str`, received"
-            + f" {[type(name) for name in names]}"
+            "`names` argument must be a list of str, "
+            + f"not {[type(name) for name in names]}"
         )

--- a/python/src/equistore/operations/zeros_like.py
+++ b/python/src/equistore/operations/zeros_like.py
@@ -3,7 +3,7 @@ from typing import List, Union
 from equistore import TensorBlock, TensorMap
 
 from . import _dispatch
-from .equal_metadata import _check_parameters_in_gradient_block
+from .equal_metadata import _check_gradient_presence
 
 
 def zeros_like(
@@ -128,9 +128,7 @@ def zeros_like_block(
     if parameters is None:
         parameters = block.gradients_list()
     else:
-        _check_parameters_in_gradient_block(
-            block=block, parameters=parameters, fname="zeros_like_block"
-        )
+        _check_gradient_presence(block=block, parameters=parameters, fname="zeros_like")
 
     for parameter in parameters:
         gradient = block.gradient(parameter)

--- a/python/src/equistore/operations/zeros_like.py
+++ b/python/src/equistore/operations/zeros_like.py
@@ -31,8 +31,10 @@ def zeros_like(
     >>> import equistore
     >>> from equistore import TensorBlock, TensorMap, Labels
     >>> np.random.seed(1)
-    >>> # First we create a TensorMap with just one block with two gradients,
-    >>> # named 'alpha' and 'beta', containing random data
+
+    First we create a :py:class:`TensorMap` with just one block with two
+    gradients, named ``alpha`` and ``beta``, containing random data:
+
     >>> block = TensorBlock(
     ...     values=np.random.rand(4, 3),
     ...     samples=Labels.arange("sample", 4),
@@ -59,8 +61,10 @@ def zeros_like(
         components (): []
         properties (3): ['property']
         gradients: ['alpha', 'beta']
-    >>> # Then we use `zeros_like` to create a TensorMap with the same metadata
-    >>> # as `tensor`, but with all values set to 0.
+
+    Then we use ``zeros_like`` to create a :py:class:`TensorMap` with
+    the same metadata as ``tensor``, but with all values set to 0.
+
     >>> tensor_zeros = equistore.zeros_like(tensor)
     >>> print(tensor_zeros.block(0))
     TensorBlock
@@ -81,8 +85,10 @@ def zeros_like(
      [[0. 0. 0.]
       [0. 0. 0.]
       [0. 0. 0.]]]
-    >>> # Note that if we copy just the gradient 'alpha', 'beta' is no longer
-    >>> # available.
+
+    Note that if we copy just the gradient ``alpha``, ``beta`` is no longer
+    available.
+
     >>> tensor_zeros = equistore.zeros_like(tensor, gradients="alpha")
     >>> print(tensor_zeros.block(0).gradients_list())
     ['alpha']

--- a/python/src/equistore/operations/zeros_like.py
+++ b/python/src/equistore/operations/zeros_like.py
@@ -8,18 +8,24 @@ from .equal_metadata import _check_gradient_presence
 
 def zeros_like(
     tensor: TensorMap,
-    parameters: Union[List[str], str] = None,
+    gradients: Union[List[str], str] = None,
     requires_grad: bool = False,
 ) -> TensorMap:
     """Return a new :py:class:`TensorMap` with the same metadata as tensor,
     and all values equal to zero.
 
-    :param tensor: Input tensor from which the metadata is taken.
-    :param parameters: Which gradient parameter to copy. If ``None`` (default)
-                       all gradient of ``tensor`` are present in the new tensor.
-                       If empty list ``[]`` no gradients information are copied.
-    :param requires_grad: If autograd should record operations for the returned
-                          tensor. This option is only relevant for torch.
+    :param tensor:
+        Input tensor from which the metadata is taken.
+
+    :param gradients:
+        Which gradients should be present in the output. If this is ``None``
+        (default) all gradient of ``tensor`` are present in the new
+        :py:class:`TensorMap`. If this is an empty list ``[]``, no gradients
+        information is copied.
+
+    :param requires_grad:
+        If autograd should record operations for the returned tensor. This
+        option is only relevant for torch.
 
     >>> import numpy as np
     >>> import equistore
@@ -77,7 +83,7 @@ def zeros_like(
       [0. 0. 0.]]]
     >>> # Note that if we copy just the gradient 'alpha', 'beta' is no longer
     >>> # available.
-    >>> tensor_zeros = equistore.zeros_like(tensor, parameters="alpha")
+    >>> tensor_zeros = equistore.zeros_like(tensor, gradients="alpha")
     >>> print(tensor_zeros.block(0).gradients_list())
     ['alpha']
     """
@@ -86,7 +92,7 @@ def zeros_like(
     for block in tensor.blocks():
         blocks.append(
             zeros_like_block(
-                block=block, parameters=parameters, requires_grad=requires_grad
+                block=block, gradients=gradients, requires_grad=requires_grad
             )
         )
     return TensorMap(tensor.keys, blocks)
@@ -94,18 +100,24 @@ def zeros_like(
 
 def zeros_like_block(
     block: TensorBlock,
-    parameters: Union[List[str], str] = None,
+    gradients: Union[List[str], str] = None,
     requires_grad: bool = False,
 ) -> TensorBlock:
     """Return a new :py:class:`TensorBlock` with the same metadata as block,
     and all values equal to zero.
 
-    :param block: Input block from which the metadata is taken.
-    :param parameters: Which gradient parameter to copy. If ``None`` (default)
-                       all gradient of ``tensor`` are present in the new tensor.
-                       If empty list ``[]`` no gradients information are copied.
-    :param requires_grad: If autograd should record operations for the returned tensor.
-                          This option is only relevant for torch.
+    :param block:
+        Input block from which the metadata is taken.
+
+    :param gradients:
+        Which gradients should be present in the output. If this is ``None``
+        (default) all gradient of ``block`` are present in the new
+        :py:class:`TensorBlock`. If this is an empty list ``[]``, no gradients
+        information is copied.
+
+    :param requires_grad:
+        If autograd should record operations for the returned tensor. This
+        option is only relevant for torch.
     """
 
     values = _dispatch.zeros_like(block.values, requires_grad=requires_grad)
@@ -116,15 +128,15 @@ def zeros_like_block(
         properties=block.properties,
     )
 
-    if isinstance(parameters, str):
-        parameters = [parameters]
+    if isinstance(gradients, str):
+        gradients = [gradients]
 
-    if parameters is None:
-        parameters = block.gradients_list()
+    if gradients is None:
+        gradients = block.gradients_list()
     else:
-        _check_gradient_presence(block=block, parameters=parameters, fname="zeros_like")
+        _check_gradient_presence(block=block, parameters=gradients, fname="zeros_like")
 
-    for parameter in parameters:
+    for parameter in gradients:
         gradient = block.gradient(parameter)
         gradient_data = _dispatch.zeros_like(gradient.data)
 

--- a/python/src/equistore/operations/zeros_like.py
+++ b/python/src/equistore/operations/zeros_like.py
@@ -18,9 +18,9 @@ def zeros_like(
         Input tensor from which the metadata is taken.
 
     :param gradients:
-        Which gradients should be present in the output. If this is ``None``
-        (default) all gradient of ``tensor`` are present in the new
-        :py:class:`TensorMap`. If this is an empty list ``[]``, no gradients
+        Which gradients should be present in the output. If this is
+        :py:obj:`None` (default) all gradient of ``tensor`` are present in the
+        new :py:class:`TensorMap`. If this is an empty list ``[]``, no gradients
         information is copied.
 
     :param requires_grad:
@@ -110,10 +110,10 @@ def zeros_like_block(
         Input block from which the metadata is taken.
 
     :param gradients:
-        Which gradients should be present in the output. If this is ``None``
-        (default) all gradient of ``block`` are present in the new
-        :py:class:`TensorBlock`. If this is an empty list ``[]``, no gradients
-        information is copied.
+        Which gradients should be present in the output. If this is
+        :py:obj:`None` (default) all gradient of ``block`` are present in the
+        new :py:class:`TensorBlock`. If this is an empty list ``[]``, no
+        gradients information is copied.
 
     :param requires_grad:
         If autograd should record operations for the returned tensor. This

--- a/python/src/equistore/operations/zeros_like.py
+++ b/python/src/equistore/operations/zeros_like.py
@@ -21,14 +21,12 @@ def zeros_like(
     :param requires_grad: If autograd should record operations for the returned
                           tensor. This option is only relevant for torch.
 
-    Here is an example using this function. First we create a ``TensorMap`` with
-    just one block with two gradients, named ``alpha`` and ``beta``, containing
-    random data for values and gradients.
-
     >>> import numpy as np
     >>> import equistore
     >>> from equistore import TensorBlock, TensorMap, Labels
     >>> np.random.seed(1)
+    >>> # First we create a TensorMap with just one block with two gradients,
+    >>> # named 'alpha' and 'beta', containing random data
     >>> block = TensorBlock(
     ...     values=np.random.rand(4, 3),
     ...     samples=Labels.arange("sample", 4),
@@ -55,10 +53,8 @@ def zeros_like(
         components (): []
         properties (3): ['property']
         gradients: ['alpha', 'beta']
-
-    Here we use the function ``zeros_like`` to create a :py:class:`TensorMap`
-    with the same metadata as ``tensor``, but with all values set equal to 0.
-
+    >>> # Then we use `zeros_like` to create a TensorMap with the same metadata
+    >>> # as `tensor`, but with all values set to 0.
     >>> tensor_zeros = equistore.zeros_like(tensor)
     >>> print(tensor_zeros.block(0))
     TensorBlock
@@ -79,10 +75,8 @@ def zeros_like(
      [[0. 0. 0.]
       [0. 0. 0.]
       [0. 0. 0.]]]
-
-    Note that if we copy just the gradient ``alpha``, ``beta`` is no longer
-    available.
-
+    >>> # Note that if we copy just the gradient 'alpha', 'beta' is no longer
+    >>> # available.
     >>> tensor_zeros = equistore.zeros_like(tensor, parameters="alpha")
     >>> print(tensor_zeros.block(0).gradients_list())
     ['alpha']

--- a/python/tests/blocks.py
+++ b/python/tests/blocks.py
@@ -13,9 +13,9 @@ from equistore import Labels, TensorBlock
 def block():
     return TensorBlock(
         values=np.full((3, 2), -1.0),
-        samples=Labels(["samples"], np.array([[0], [2], [4]])),
+        samples=Labels(["s"], np.array([[0], [2], [4]])),
         components=[],
-        properties=Labels(["properties"], np.array([[5], [3]])),
+        properties=Labels(["p"], np.array([[5], [3]])),
     )
 
 
@@ -26,7 +26,7 @@ def test_gradient_no_sample_error(block):
     )
     with pytest.raises(equistore.status.EquistoreError, match=msg):
         block.add_gradient(
-            "parameter",
+            "g",
             data=np.zeros((0, 2)),
             samples=Labels([], np.empty((0, 2))),
             components=[],
@@ -35,9 +35,9 @@ def test_gradient_no_sample_error(block):
 
 def test_repr(block):
     expected = """TensorBlock
-    samples (3): ['samples']
+    samples (3): ['s']
     components (): []
-    properties (2): ['properties']
+    properties (2): ['p']
     gradients: no"""
     assert block.__repr__() == expected
 
@@ -47,46 +47,46 @@ def test_repr_zero_samples():
         values=np.zeros((0, 2)),
         samples=Labels([], np.empty((0, 2))),
         components=[],
-        properties=Labels(["properties"], np.array([[5], [3]])),
+        properties=Labels(["p"], np.array([[5], [3]])),
     )
     expected = """TensorBlock
     samples (0): []
     components (): []
-    properties (2): ['properties']
+    properties (2): ['p']
     gradients: no"""
     assert block.__repr__() == expected
 
 
 def test_repr_zero_samples_gradient(block):
     block.add_gradient(
-        "parameter",
+        "g",
         data=np.zeros((0, 2)),
         samples=Labels(["sample"], np.empty((0, 2))),
         components=[],
     )
 
     expected_block = """TensorBlock
-    samples (3): ['samples']
+    samples (3): ['s']
     components (): []
-    properties (2): ['properties']
-    gradients: ['parameter']"""
+    properties (2): ['p']
+    gradients: ['g']"""
 
     assert block.__repr__() == expected_block
 
     expected_grad = """Gradient TensorBlock
-parameter: 'parameter'
+parameter: 'g'
 samples (0): ['sample']
 components (): []
-properties (2): ['properties']"""
+properties (2): ['p']"""
 
-    gradient = block.gradient("parameter")
+    gradient = block.gradient("g")
     assert gradient.__repr__() == expected_grad
 
 
 def test_block_no_components(block):
     assert_equal(block.values, np.full((3, 2), -1.0))
 
-    assert block.samples.names == ("samples",)
+    assert block.samples.names == ("s",)
     assert len(block.samples) == 3
     assert tuple(block.samples[0]) == (0,)
     assert tuple(block.samples[1]) == (2,)
@@ -94,7 +94,7 @@ def test_block_no_components(block):
 
     assert len(block.components) == 0
 
-    assert block.properties.names == ("properties",)
+    assert block.properties.names == ("p",)
     assert len(block.properties) == 2
     assert tuple(block.properties[0]) == (5,)
     assert tuple(block.properties[1]) == (3,)
@@ -104,26 +104,26 @@ def test_block_no_components(block):
 def block_components():
     return TensorBlock(
         values=np.full((3, 3, 2, 2), -1.0),
-        samples=Labels(["samples"], np.array([[0], [2], [4]])),
+        samples=Labels(["s"], np.array([[0], [2], [4]])),
         components=[
-            Labels(["component_1"], np.array([[-1], [0], [1]])),
-            Labels(["component_2"], np.array([[-4], [1]])),
+            Labels(["c_1"], np.array([[-1], [0], [1]])),
+            Labels(["c_2"], np.array([[-4], [1]])),
         ],
-        properties=Labels(["properties"], np.array([[5], [3]])),
+        properties=Labels(["p"], np.array([[5], [3]])),
     )
 
 
 def test_block_with_components(block_components):
     expected = """TensorBlock
-    samples (3): ['samples']
-    components (3, 2): ['component_1', 'component_2']
-    properties (2): ['properties']
+    samples (3): ['s']
+    components (3, 2): ['c_1', 'c_2']
+    properties (2): ['p']
     gradients: no"""
     assert block_components.__repr__() == expected
 
     assert_equal(block_components.values, np.full((3, 3, 2, 2), -1.0))
 
-    assert block_components.samples.names == ("samples",)
+    assert block_components.samples.names == ("s",)
     assert len(block_components.samples) == 3
     assert tuple(block_components.samples[0]) == (0,)
     assert tuple(block_components.samples[1]) == (2,)
@@ -131,19 +131,19 @@ def test_block_with_components(block_components):
 
     assert len(block_components.components) == 2
     component_1 = block_components.components[0]
-    assert component_1.names == ("component_1",)
+    assert component_1.names == ("c_1",)
     assert len(component_1) == 3
     assert tuple(component_1[0]) == (-1,)
     assert tuple(component_1[1]) == (0,)
     assert tuple(component_1[2]) == (1,)
 
     component_2 = block_components.components[1]
-    assert component_2.names == ("component_2",)
+    assert component_2.names == ("c_2",)
     assert len(component_2) == 2
     assert tuple(component_2[0]) == (-4,)
     assert tuple(component_2[1]) == (1,)
 
-    assert block_components.properties.names, ("properties",)
+    assert block_components.properties.names, ("p",)
     assert len(block_components.properties) == 2
     assert tuple(block_components.properties[0]) == (5,)
     assert tuple(block_components.properties[1]) == (3,)
@@ -151,37 +151,38 @@ def test_block_with_components(block_components):
 
 def test_gradients(block_components):
     block_components.add_gradient(
-        "parameter",
+        "g",
         data=np.full((2, 3, 2, 2), 11.0),
-        samples=Labels(["sample", "parameter"], np.array([[0, -2], [2, 3]])),
+        samples=Labels(["sample", "g"], np.array([[0, -2], [2, 3]])),
         components=[
-            Labels(["component_1"], np.array([[-1], [0], [1]])),
-            Labels(["component_2"], np.array([[-4], [1]])),
+            Labels(["c_1"], np.array([[-1], [0], [1]])),
+            Labels(["c_2"], np.array([[-4], [1]])),
         ],
     )
 
     expected = """TensorBlock
-    samples (3): ['samples']
-    components (3, 2): ['component_1', 'component_2']
-    properties (2): ['properties']
-    gradients: ['parameter']"""
+    samples (3): ['s']
+    components (3, 2): ['c_1', 'c_2']
+    properties (2): ['p']
+    gradients: ['g']"""
     assert block_components.__repr__() == expected
 
-    assert block_components.has_gradient("parameter")
+    assert block_components.has_gradient("g")
+    assert not block_components.has_gradient("something_else")
     assert not block_components.has_gradient("something else")
 
-    assert block_components.gradients_list() == ["parameter"]
+    assert block_components.gradients_list() == ["g"]
 
-    gradient = block_components.gradient("parameter")
+    gradient = block_components.gradient("g")
 
     expected_grad = """Gradient TensorBlock
-parameter: 'parameter'
-samples (2): ['sample', 'parameter']
-components (3, 2): ['component_1', 'component_2']
-properties (2): ['properties']"""
+parameter: 'g'
+samples (2): ['sample', 'g']
+components (3, 2): ['c_1', 'c_2']
+properties (2): ['p']"""
     assert gradient.__repr__() == expected_grad
 
-    assert gradient.samples.names == ("sample", "parameter")
+    assert gradient.samples.names == ("sample", "g")
     assert len(gradient.samples) == 2
     assert tuple(gradient.samples[0]) == (0, -2)
     assert tuple(gradient.samples[1]) == (2, 3)
@@ -192,11 +193,11 @@ properties (2): ['properties']"""
 def test_copy():
     block = TensorBlock(
         values=np.full((3, 3, 2), 2.0),
-        samples=Labels(["samples"], np.array([[0], [2], [4]])),
+        samples=Labels(["s"], np.array([[0], [2], [4]])),
         components=[
-            Labels(["component_1"], np.array([[-1], [0], [1]])),
+            Labels(["c_1"], np.array([[-1], [0], [1]])),
         ],
-        properties=Labels(["properties"], np.array([[5], [3]])),
+        properties=Labels(["p"], np.array([[5], [3]])),
     )
 
     # using TensorBlock.copy
@@ -208,7 +209,7 @@ def test_copy():
     assert id(clone.values) != block_values_id
 
     assert_equal(clone.values, np.full((3, 3, 2), 2.0))
-    assert clone.samples.names == ("samples",)
+    assert clone.samples.names == ("s",)
     assert len(clone.samples) == 3
     assert tuple(clone.samples[0]) == (0,)
     assert tuple(clone.samples[1]) == (2,)

--- a/python/tests/labels.py
+++ b/python/tests/labels.py
@@ -186,8 +186,8 @@ def test_arange_two_arguments():
 
 
 def test_arange_three_arguments():
-    labels_arange = Labels.arange("samples", 0, 10, 2)
-    assert labels_arange.names == ("samples",)
+    labels_arange = Labels.arange("s", 0, 10, 2)
+    assert labels_arange.names == ("s",)
     np.testing.assert_equal(labels_arange.asarray().reshape((-1,)), np.arange(0, 10, 2))
 
 

--- a/python/tests/operations/add.py
+++ b/python/tests/operations/add.py
@@ -15,29 +15,29 @@ def keys():
 def tensor_A(keys):
     block_1 = TensorBlock(
         values=np.array([[1, 2], [3, 5]]),
-        samples=Labels(["samples"], np.array([[0], [2]])),
+        samples=Labels(["s"], np.array([[0], [2]])),
         components=[],
-        properties=Labels(["properties"], np.array([[0], [1]])),
+        properties=Labels(["p"], np.array([[0], [1]])),
     )
 
     block_1.add_gradient(
-        "parameter",
+        "g",
         data=np.array([[[6, 1], [7, 2]], [[8, 3], [9, 4]]]),
         samples=Labels(["sample", "positions"], np.array([[0, 1], [1, 1]])),
         components=[
-            Labels(["components"], np.array([[0], [1]])),
+            Labels(["c"], np.array([[0], [1]])),
         ],
     )
 
     block_2 = TensorBlock(
         values=np.array([[1, 2], [3, 4], [5, 6]]),
-        samples=Labels(["samples"], np.array([[0], [2], [7]])),
+        samples=Labels(["s"], np.array([[0], [2], [7]])),
         components=[],
-        properties=Labels(["properties"], np.array([[0], [1]])),
+        properties=Labels(["p"], np.array([[0], [1]])),
     )
 
     block_2.add_gradient(
-        "parameter",
+        "g",
         data=np.array(
             [[[10, 11], [12, 13]], [[14, 15], [10, 11]], [[12, 13], [14, 15]]]
         ),
@@ -46,7 +46,7 @@ def tensor_A(keys):
             np.array([[0, 1], [1, 1], [2, 1]]),
         ),
         components=[
-            Labels(["components"], np.array([[0], [1]])),
+            Labels(["c"], np.array([[0], [1]])),
         ],
     )
 
@@ -57,29 +57,29 @@ def tensor_A(keys):
 def tensor_B(keys):
     block_1 = TensorBlock(
         values=np.array([[1.5, 2.1], [6.7, 10.2]]),
-        samples=Labels(["samples"], np.array([[0], [2]])),
+        samples=Labels(["s"], np.array([[0], [2]])),
         components=[],
-        properties=Labels(["properties"], np.array([[0], [1]])),
+        properties=Labels(["p"], np.array([[0], [1]])),
     )
 
     block_1.add_gradient(
-        "parameter",
+        "g",
         data=np.array([[[1, 0.1], [2, 0.2]], [[3, 0.3], [4.5, 0.4]]]),
         samples=Labels(["sample", "positions"], np.array([[0, 1], [1, 1]])),
         components=[
-            Labels(["components"], np.array([[0], [1]])),
+            Labels(["c"], np.array([[0], [1]])),
         ],
     )
 
     block_2 = TensorBlock(
         values=np.array([[10, 200.8], [3.76, 4.432], [545, 26]]),
-        samples=Labels(["samples"], np.array([[0], [2], [7]])),
+        samples=Labels(["s"], np.array([[0], [2], [7]])),
         components=[],
-        properties=Labels(["properties"], np.array([[0], [1]])),
+        properties=Labels(["p"], np.array([[0], [1]])),
     )
 
     block_2.add_gradient(
-        "parameter",
+        "g",
         data=np.array(
             [
                 [[1.0, 1.1], [1.2, 1.3]],
@@ -92,7 +92,7 @@ def tensor_B(keys):
             np.array([[0, 1], [1, 1], [2, 1]]),
         ),
         components=[
-            Labels(["components"], np.array([[0], [1]])),
+            Labels(["c"], np.array([[0], [1]])),
         ],
     )
 
@@ -103,29 +103,29 @@ def tensor_B(keys):
 def tensor_res_1(keys):
     block_1 = TensorBlock(
         values=np.array([[2.5, 4.1], [9.7, 15.2]]),
-        samples=Labels(["samples"], np.array([[0], [2]])),
+        samples=Labels(["s"], np.array([[0], [2]])),
         components=[],
-        properties=Labels(["properties"], np.array([[0], [1]])),
+        properties=Labels(["p"], np.array([[0], [1]])),
     )
 
     block_1.add_gradient(
-        "parameter",
+        "g",
         data=np.array(np.array([[[7, 1.1], [9, 2.2]], [[11, 3.3], [13.5, 4.4]]])),
         samples=Labels(["sample", "positions"], np.array([[0, 1], [1, 1]])),
         components=[
-            Labels(["components"], np.array([[0], [1]])),
+            Labels(["c"], np.array([[0], [1]])),
         ],
     )
 
     block_2 = TensorBlock(
         values=np.array([[11, 202.8], [6.76, 8.432], [550, 32]]),
-        samples=Labels(["samples"], np.array([[0], [2], [7]])),
+        samples=Labels(["s"], np.array([[0], [2], [7]])),
         components=[],
-        properties=Labels(["properties"], np.array([[0], [1]])),
+        properties=Labels(["p"], np.array([[0], [1]])),
     )
 
     block_2.add_gradient(
-        "parameter",
+        "g",
         data=np.array(
             [
                 [[11.0, 12.1], [13.2, 14.3]],
@@ -138,7 +138,7 @@ def tensor_res_1(keys):
             np.array([[0, 1], [1, 1], [2, 1]]),
         ),
         components=[
-            Labels(["components"], np.array([[0], [1]])),
+            Labels(["c"], np.array([[0], [1]])),
         ],
     )
     keys = Labels(names=["key_1", "key_2"], values=np.array([[0, 0], [1, 0]]))
@@ -150,26 +150,26 @@ def tensor_res_1(keys):
 def tensor_res_2(keys):
     block_1 = TensorBlock(
         values=np.array([[6.1, 7.1], [8.1, 10.1]]),
-        samples=Labels(["samples"], np.array([[0], [2]])),
+        samples=Labels(["s"], np.array([[0], [2]])),
         components=[],
-        properties=Labels(["properties"], np.array([[0], [1]])),
+        properties=Labels(["p"], np.array([[0], [1]])),
     )
     block_1.add_gradient(
-        "parameter",
+        "g",
         data=np.array([[[6, 1], [7, 2]], [[8, 3], [9, 4]]]),
         samples=Labels(["sample", "positions"], np.array([[0, 1], [1, 1]])),
         components=[
-            Labels(["components"], np.array([[0], [1]])),
+            Labels(["c"], np.array([[0], [1]])),
         ],
     )
     block_2 = TensorBlock(
         values=np.array([[6.1, 7.1], [8.1, 9.1], [10.1, 11.1]]),
-        samples=Labels(["samples"], np.array([[0], [2], [7]])),
+        samples=Labels(["s"], np.array([[0], [2], [7]])),
         components=[],
-        properties=Labels(["properties"], np.array([[0], [1]])),
+        properties=Labels(["p"], np.array([[0], [1]])),
     )
     block_2.add_gradient(
-        "parameter",
+        "g",
         data=np.array(
             [[[10, 11], [12, 13]], [[14, 15], [10, 11]], [[12, 13], [14, 15]]]
         ),
@@ -178,7 +178,7 @@ def tensor_res_2(keys):
             np.array([[0, 1], [1, 1], [2, 1]]),
         ),
         components=[
-            Labels(["components"], np.array([[0], [1]])),
+            Labels(["c"], np.array([[0], [1]])),
         ],
     )
 

--- a/python/tests/operations/allclose.py
+++ b/python/tests/operations/allclose.py
@@ -1,342 +1,319 @@
 import os
-import unittest
 
 import numpy as np
+import pytest
 
 import equistore
-from equistore import Labels, TensorBlock, TensorMap
+from equistore import Labels, NotEqualError, TensorBlock, TensorMap
 
 
 DATA_ROOT = os.path.join(os.path.dirname(__file__), "..", "data")
 
 
-class Testallclose(unittest.TestCase):
-    def test_allclose_nograd(self):
-        block_1 = TensorBlock(
-            values=np.array([[1, 2], [3, 5]], dtype=np.float64),
-            samples=Labels(["samples"], np.array([[0], [2]])),
-            components=[],
-            properties=Labels.arange("properties", 2),
-        )
-        block_2 = TensorBlock(
-            values=np.array([[1, 2], [3, 4], [5, 6], [1, 2], [3, 4], [5, 6]]),
-            samples=Labels.arange("samples", 6),
-            components=[],
-            properties=Labels.arange("properties", 2),
-        )
+def test_allclose_nograd():
+    block_1 = TensorBlock(
+        values=np.array([[1, 2], [3, 5]], dtype=np.float64),
+        samples=Labels(["samples"], np.array([[0], [2]])),
+        components=[],
+        properties=Labels.arange("properties", 2),
+    )
+    block_2 = TensorBlock(
+        values=np.array([[1, 2], [3, 4], [5, 6], [1, 2], [3, 4], [5, 6]]),
+        samples=Labels.arange("samples", 6),
+        components=[],
+        properties=Labels.arange("properties", 2),
+    )
 
-        block_3 = TensorBlock(
-            values=np.array([[1], [2]]),
-            samples=Labels(["samples"], np.array([[0], [2]])),
-            components=[],
-            properties=Labels(["properties"], np.array([[0]])),
-        )
-        block_4 = TensorBlock(
-            values=np.array([[23], [53], [83]]),
-            samples=Labels(["samples"], np.array([[0], [2], [7]])),
-            components=[],
-            properties=Labels(["properties"], np.array([[6]])),
-        )
-        keys = Labels(names=["key_1", "key_2"], values=np.array([[0, 0], [1, 0]]))
-        X = TensorMap(keys, [block_1, block_2])
-        self.assertTrue(equistore.allclose(X, X))
-        Y = TensorMap(keys, [block_3, block_4])
-        self.assertFalse(equistore.allclose(X, Y))
-        with self.assertRaises(ValueError) as cm:
-            equistore.allclose_raise(X, Y)
+    block_3 = TensorBlock(
+        values=np.array([[1], [2]]),
+        samples=Labels(["samples"], np.array([[0], [2]])),
+        components=[],
+        properties=Labels(["properties"], np.array([[0]])),
+    )
+    block_4 = TensorBlock(
+        values=np.array([[23], [53], [83]]),
+        samples=Labels(["samples"], np.array([[0], [2], [7]])),
+        components=[],
+        properties=Labels(["properties"], np.array([[6]])),
+    )
+    keys = Labels(names=["key_1", "key_2"], values=np.array([[0, 0], [1, 0]]))
+    X = TensorMap(keys, [block_1, block_2])
+    assert equistore.allclose(X, X)
+    Y = TensorMap(keys, [block_3, block_4])
+    assert not equistore.allclose(X, Y)
 
-        self.assertEqual(
-            str(cm.exception), "The TensorBlocks with key = (0, 0) are different"
-        )
+    message = r"blocks for key '\(0, 0\)' are different"
+    with pytest.raises(NotEqualError, match=message):
+        equistore.allclose_raise(X, Y)
 
-        block_1_c = TensorBlock(
-            values=np.array(
+    block_1_c = TensorBlock(
+        values=np.array(
+            [
                 [
-                    [
-                        [[1, 0.5], [4, 2], [1.5, 6.5]],
-                        [[2, 1], [6, 3], [6.1, 3.5]],
-                        [[9, 9], [9, 9.8], [10, 10.5]],
-                    ],
-                    [
-                        [[3, 1.5], [7, 3.5], [3.7, 1.5]],
-                        [[5, 2.5], [8, 4], [6.3, 1.5]],
-                        [[5, 7.1], [8, 4.8], [6.3, 14.466]],
-                    ],
+                    [[1, 0.5], [4, 2], [1.5, 6.5]],
+                    [[2, 1], [6, 3], [6.1, 3.5]],
+                    [[9, 9], [9, 9.8], [10, 10.5]],
                 ],
-                dtype=np.float64,
-            ),
-            samples=Labels(["samples"], np.array([[0], [2]])),
-            components=[
-                Labels.arange("c1", 3),
-                Labels.arange("c2", 3),
-            ],
-            properties=Labels.arange("properties", 2),
-        )
-        block_1_c_copy = TensorBlock(
-            values=block_1_c.values + 0.1e-6,
-            samples=Labels(["samples"], np.array([[0], [2]])),
-            components=[
-                Labels.arange("c1", 3),
-                Labels.arange("c2", 3),
-            ],
-            properties=Labels.arange("properties", 2),
-        )
-
-        block_2_c = TensorBlock(
-            values=np.array(
                 [
-                    [[[1, 2], [6.8, 2.8]], [[4.1, 6.2], [66.8, 62.8]]],
-                    [[[3, 4], [36, 6.4]], [[83, 84], [73.76, 76.74]]],
-                    [[[5, 6], [58, 68]], [[23.4, 5643.3], [234.5, 3247.6]]],
-                    [[[5.6, 6.6], [5.68, 668]], [[55.6, 676.76], [775.68, 0.668]]],
-                    [[[1, 2], [17.7, 27.7]], [[77.1, 22.2], [1.11, 3.42]]],
-                ]
-            ),
-            samples=Labels.arange("samples", 5),
-            components=[
-                Labels(["c1"], np.array([[3], [5]])),
-                Labels(["c2"], np.array([[6], [8]])),
+                    [[3, 1.5], [7, 3.5], [3.7, 1.5]],
+                    [[5, 2.5], [8, 4], [6.3, 1.5]],
+                    [[5, 7.1], [8, 4.8], [6.3, 14.466]],
+                ],
             ],
-            properties=Labels.arange("properties", 2),
-        )
-        block_2_c_copy = TensorBlock(
-            values=block_2_c.values + 0.1e-6,
-            samples=Labels.arange("samples", 5),
-            components=[
-                Labels(["c1"], np.array([[3], [5]])),
-                Labels(["c2"], np.array([[6], [8]])),
-            ],
-            properties=Labels.arange("properties", 2),
-        )
-        X_c = TensorMap(keys, [block_1_c, block_2_c])
-        X_c_copy = TensorMap(keys, [block_1_c_copy, block_2_c_copy])
-        self.assertFalse(equistore.allclose(X, X_c))
+            dtype=np.float64,
+        ),
+        samples=Labels(["samples"], np.array([[0], [2]])),
+        components=[
+            Labels.arange("c1", 3),
+            Labels.arange("c2", 3),
+        ],
+        properties=Labels.arange("properties", 2),
+    )
+    block_1_c_copy = TensorBlock(
+        values=block_1_c.values + 0.1e-6,
+        samples=Labels(["samples"], np.array([[0], [2]])),
+        components=[
+            Labels.arange("c1", 3),
+            Labels.arange("c2", 3),
+        ],
+        properties=Labels.arange("properties", 2),
+    )
 
-        self.assertTrue(equistore.allclose(X_c, X_c))
-        self.assertFalse(equistore.allclose(X_c, X_c_copy))
-        self.assertTrue(equistore.allclose(X_c, X_c_copy, rtol=1e-5))
-        self.assertTrue(equistore.allclose(X_c, X_c_copy, atol=1e-1))
+    block_2_c = TensorBlock(
+        values=np.array(
+            [
+                [[[1, 2], [6.8, 2.8]], [[4.1, 6.2], [66.8, 62.8]]],
+                [[[3, 4], [36, 6.4]], [[83, 84], [73.76, 76.74]]],
+                [[[5, 6], [58, 68]], [[23.4, 5643.3], [234.5, 3247.6]]],
+                [[[5.6, 6.6], [5.68, 668]], [[55.6, 676.76], [775.68, 0.668]]],
+                [[[1, 2], [17.7, 27.7]], [[77.1, 22.2], [1.11, 3.42]]],
+            ]
+        ),
+        samples=Labels.arange("samples", 5),
+        components=[
+            Labels(["c1"], np.array([[3], [5]])),
+            Labels(["c2"], np.array([[6], [8]])),
+        ],
+        properties=Labels.arange("properties", 2),
+    )
+    block_2_c_copy = TensorBlock(
+        values=block_2_c.values + 0.1e-6,
+        samples=Labels.arange("samples", 5),
+        components=[
+            Labels(["c1"], np.array([[3], [5]])),
+            Labels(["c2"], np.array([[6], [8]])),
+        ],
+        properties=Labels.arange("properties", 2),
+    )
+    X_c = TensorMap(keys, [block_1_c, block_2_c])
+    X_c_copy = TensorMap(keys, [block_1_c_copy, block_2_c_copy])
+    assert not equistore.allclose(X, X_c)
 
-    def test_self_allclose_grad(self):
-        tensor1 = equistore.load(
-            os.path.join(DATA_ROOT, "qm7-spherical-expansion.npz"),
-            use_numpy=True,
-        )
-        blocks = []
-        blocks_e6 = []
-        for _, block in tensor1:
-            blocks.append(block.copy())
-            be6 = block.copy()
-            be6.values[:] += 1e-6
-            blocks_e6.append(be6)
+    assert equistore.allclose(X_c, X_c)
+    assert not equistore.allclose(X_c, X_c_copy)
+    assert equistore.allclose(X_c, X_c_copy, rtol=1e-5)
+    assert equistore.allclose(X_c, X_c_copy, atol=1e-1)
 
-        tensor1_copy = TensorMap(tensor1.keys, blocks)
-        tensor1_e6 = TensorMap(tensor1.keys, blocks_e6)
-        self.assertTrue(equistore.allclose(tensor1, tensor1_copy))
-        self.assertFalse(equistore.allclose(tensor1, tensor1_e6))
-        self.assertTrue(equistore.allclose(tensor1, tensor1_e6, rtol=1e-5, atol=1e-5))
 
-        with self.assertRaises(ValueError) as cm:
-            equistore.allclose_raise(tensor1, tensor1_e6)
+def test_self_allclose_grad():
+    tensor1 = equistore.load(
+        os.path.join(DATA_ROOT, "qm7-spherical-expansion.npz"),
+        use_numpy=True,
+    )
+    blocks = []
+    blocks_e6 = []
+    for _, block in tensor1:
+        blocks.append(block.copy())
+        be6 = block.copy()
+        be6.values[:] += 1e-6
+        blocks_e6.append(be6)
 
-        self.assertEqual(
-            str(cm.exception), "The TensorBlocks with key = (0, 1, 1) are different"
-        )
+    tensor1_copy = TensorMap(tensor1.keys, blocks)
+    tensor1_e6 = TensorMap(tensor1.keys, blocks_e6)
+    assert equistore.allclose(tensor1, tensor1_copy)
+    assert not equistore.allclose(tensor1, tensor1_e6)
+    assert equistore.allclose(tensor1, tensor1_e6, rtol=1e-5, atol=1e-5)
 
-        with self.assertRaises(ValueError) as cm:
-            equistore.allclose_block_raise(tensor1.block(0), tensor1_e6.block(0))
-        self.assertEqual(str(cm.exception), "values are not allclose")
+    message = r"blocks for key '\(0, 1, 1\)' are different"
+    with pytest.raises(NotEqualError, match=message):
+        equistore.allclose_raise(tensor1, tensor1_e6)
 
-    def test_self_allclose_exceptions(self):
-        block_1 = TensorBlock(
-            values=np.array([[1], [2]]),
-            samples=Labels(["samples"], np.array([[0], [2]])),
-            components=[],
-            properties=Labels(["properties"], np.array([[0]])),
-        )
-        block_2 = TensorBlock(
-            values=np.array([[1], [2]]),
-            samples=Labels(["samples_5"], np.array([[0], [2]])),
-            components=[],
-            properties=Labels(["properties"], np.array([[0]])),
-        )
-        block_3 = TensorBlock(
-            values=np.array([[1], [2]]),
-            samples=Labels(["samples"], np.array([[0], [6]])),
-            components=[],
-            properties=Labels(["properties"], np.array([[0]])),
-        )
+    message = "values are not allclose"
+    with pytest.raises(NotEqualError, match=message):
+        equistore.allclose_block_raise(tensor1.block(0), tensor1_e6.block(0))
 
-        block_4 = TensorBlock(
-            values=np.array([[[1], [4]], [[44], [2]]]),
-            samples=Labels(["samples"], np.array([[0], [2]])),
-            components=[
-                Labels(["component"], np.array([[0], [6]])),
-            ],
-            properties=Labels(["properties"], np.array([[0]])),
-        )
-        block_5 = TensorBlock(
-            values=np.array([[[1], [4]], [[44], [2]]]),
-            samples=Labels(["samples"], np.array([[0], [2]])),
-            components=[
-                Labels(["component1"], np.array([[0], [6]])),
-            ],
-            properties=Labels(["properties"], np.array([[0]])),
-        )
 
-        block_6 = TensorBlock(
-            values=np.array([[[1], [4]], [[44], [2]]]),
-            samples=Labels(["samples"], np.array([[2], [0]])),
-            components=[
-                Labels(["component"], np.array([[0], [6]])),
-            ],
-            properties=Labels(["properties"], np.array([[0]])),
-        )
+def test_self_allclose_exceptions():
+    block_1 = TensorBlock(
+        values=np.array([[1], [2]]),
+        samples=Labels(["samples"], np.array([[0], [2]])),
+        components=[],
+        properties=Labels(["properties"], np.array([[0]])),
+    )
+    block_2 = TensorBlock(
+        values=np.array([[1], [2]]),
+        samples=Labels(["samples_5"], np.array([[0], [2]])),
+        components=[],
+        properties=Labels(["properties"], np.array([[0]])),
+    )
+    block_3 = TensorBlock(
+        values=np.array([[1], [2]]),
+        samples=Labels(["samples"], np.array([[0], [6]])),
+        components=[],
+        properties=Labels(["properties"], np.array([[0]])),
+    )
 
-        self.assertFalse(equistore.allclose_block(block_1, block_2))
+    block_4 = TensorBlock(
+        values=np.array([[[1], [4]], [[44], [2]]]),
+        samples=Labels(["samples"], np.array([[0], [2]])),
+        components=[
+            Labels(["component"], np.array([[0], [6]])),
+        ],
+        properties=Labels(["properties"], np.array([[0]])),
+    )
+    block_5 = TensorBlock(
+        values=np.array([[[1], [4]], [[44], [2]]]),
+        samples=Labels(["samples"], np.array([[0], [2]])),
+        components=[
+            Labels(["component1"], np.array([[0], [6]])),
+        ],
+        properties=Labels(["properties"], np.array([[0]])),
+    )
 
-        with self.assertRaises(ValueError) as cm:
-            equistore.allclose_block_raise(block_1, block_2)
+    block_6 = TensorBlock(
+        values=np.array([[[1], [4]], [[44], [2]]]),
+        samples=Labels(["samples"], np.array([[2], [0]])),
+        components=[
+            Labels(["component"], np.array([[0], [6]])),
+        ],
+        properties=Labels(["properties"], np.array([[0]])),
+    )
 
-        self.assertEqual(
-            str(cm.exception),
-            "Inputs to 'allclose' should have the same samples:\n"
-            "samples names are not the same or not in the same order.",
-        )
+    assert not equistore.allclose_block(block_1, block_2)
 
-        with self.assertRaises(ValueError) as cm:
-            equistore.allclose_block_raise(block_1, block_3)
+    message = (
+        "inputs to 'allclose' should have the same samples:\n"
+        "samples names are not the same or not in the same order"
+    )
+    with pytest.raises(NotEqualError, match=message):
+        equistore.allclose_block_raise(block_1, block_2)
 
-        self.assertEqual(
-            str(cm.exception),
-            "Inputs to 'allclose' should have the same samples:\n"
-            "samples are not the same or not in the same order.",
-        )
+    message = (
+        "inputs to 'allclose' should have the same samples:\n"
+        "samples are not the same or not in the same order"
+    )
+    with pytest.raises(NotEqualError, match=message):
+        equistore.allclose_block_raise(block_1, block_3)
 
-        with self.assertRaises(ValueError) as cm:
-            equistore.allclose_block_raise(block_1, block_4)
+    message = "values shapes are different"
+    with pytest.raises(NotEqualError, match=message):
+        equistore.allclose_block_raise(block_1, block_4)
 
-        self.assertEqual(str(cm.exception), "values shapes are different")
+    message = (
+        "inputs to 'allclose' should have the same components:\n"
+        "components names are not the same or not in the same order"
+    )
+    with pytest.raises(NotEqualError, match=message):
+        equistore.allclose_block_raise(block_5, block_4)
 
-        with self.assertRaises(ValueError) as cm:
-            equistore.allclose_block_raise(block_5, block_4)
+    message = (
+        "inputs to 'allclose' should have the same samples:\n"
+        "samples are not the same or not in the same order"
+    )
+    with pytest.raises(NotEqualError, match=message):
+        equistore.allclose_block_raise(block_6, block_4)
 
-        self.assertEqual(
-            str(cm.exception),
-            "Inputs to 'allclose' should have the same components:\n"
-            "components names are not the same or not in the same order.",
-        )
 
-        with self.assertRaises(ValueError) as cm:
-            equistore.allclose_block_raise(block_6, block_4)
+def test_self_allclose_exceptions_gradient():
+    block_1 = TensorBlock(
+        values=np.array([[1], [2]]),
+        samples=Labels(["samples"], np.array([[0], [2]])),
+        components=[],
+        properties=Labels(["properties"], np.array([[0]])),
+    )
 
-        self.assertEqual(
-            str(cm.exception),
-            "Inputs to 'allclose' should have the same samples:\n"
-            "samples are not the same or not in the same order.",
-        )
+    block_1.add_gradient(
+        "parameter",
+        data=np.full((2, 1), 11.0),
+        samples=Labels(["sample", "parameter"], np.array([[0, -2], [2, 3]])),
+        components=[],
+    )
 
-    def test_self_allclose_exceptions_gradient(self):
-        block_1 = TensorBlock(
-            values=np.array([[1], [2]]),
-            samples=Labels(["samples"], np.array([[0], [2]])),
-            components=[],
-            properties=Labels(["properties"], np.array([[0]])),
-        )
+    block_2 = TensorBlock(
+        values=np.array([[1], [2]]),
+        samples=Labels(["samples"], np.array([[0], [2]])),
+        components=[],
+        properties=Labels(["properties"], np.array([[0]])),
+    )
 
-        block_1.add_gradient(
-            "parameter",
-            data=np.full((2, 1), 11.0),
-            samples=Labels(["sample", "parameter"], np.array([[0, -2], [2, 3]])),
-            components=[],
-        )
+    block_2.add_gradient(
+        "parameter",
+        data=np.full((2, 1), 11.0),
+        samples=Labels(["sample", "parameter1"], np.array([[0, -2], [2, 3]])),
+        components=[],
+    )
 
-        block_2 = TensorBlock(
-            values=np.array([[1], [2]]),
-            samples=Labels(["samples"], np.array([[0], [2]])),
-            components=[],
-            properties=Labels(["properties"], np.array([[0]])),
-        )
+    message = (
+        "inputs to allclose should have the same gradient:\n"
+        "gradient 'parameter' samples names are not the same"
+        " or not in the same order"
+    )
+    with pytest.raises(NotEqualError, match=message):
+        equistore.allclose_block_raise(block_1, block_2)
 
-        block_2.add_gradient(
-            "parameter",
-            data=np.full((2, 1), 11.0),
-            samples=Labels(["sample", "parameter1"], np.array([[0, -2], [2, 3]])),
-            components=[],
-        )
+    block_3 = TensorBlock(
+        values=np.array([[1], [2]]),
+        samples=Labels(["samples"], np.array([[0], [2]])),
+        components=[],
+        properties=Labels(["properties"], np.array([[0]])),
+    )
 
-        with self.assertRaises(ValueError) as cm:
-            equistore.allclose_block_raise(block_1, block_2)
+    block_3.add_gradient(
+        "parameter",
+        data=np.full((2, 1), 1.0),
+        samples=Labels(["sample", "parameter"], np.array([[0, -2], [2, 3]])),
+        components=[],
+    )
 
-        self.assertEqual(
-            str(cm.exception),
-            "Inputs to allclose should have the same gradient:\n"
-            'gradient ("parameter") samples names are not the same'
-            " or not in the same order.",
-        )
+    message = "gradient 'parameter' values are not allclose"
+    with pytest.raises(NotEqualError, match=message):
+        equistore.allclose_block_raise(block_1, block_3)
 
-        block_3 = TensorBlock(
-            values=np.array([[1], [2]]),
-            samples=Labels(["samples"], np.array([[0], [2]])),
-            components=[],
-            properties=Labels(["properties"], np.array([[0]])),
-        )
+    block_4 = TensorBlock(
+        values=np.array([[1], [2]]),
+        samples=Labels(["samples"], np.array([[0], [2]])),
+        components=[],
+        properties=Labels(["properties"], np.array([[0]])),
+    )
 
-        block_3.add_gradient(
-            "parameter",
-            data=np.full((2, 1), 1.0),
-            samples=Labels(["sample", "parameter"], np.array([[0, -2], [2, 3]])),
-            components=[],
-        )
+    block_4.add_gradient(
+        "parameter",
+        data=np.full((2, 3, 1), 1.0),
+        samples=Labels(["sample", "parameter"], np.array([[0, -2], [2, 3]])),
+        components=[Labels.arange("component_1", -1, 2)],
+    )
 
-        with self.assertRaises(ValueError) as cm:
-            equistore.allclose_block_raise(block_1, block_3)
+    block_5 = TensorBlock(
+        values=np.array([[1], [2]]),
+        samples=Labels(["samples"], np.array([[0], [2]])),
+        components=[],
+        properties=Labels(["properties"], np.array([[0]])),
+    )
 
-        self.assertEqual(
-            str(cm.exception),
-            'gradient ("parameter") data are not allclose',
-        )
+    block_5.add_gradient(
+        "parameter",
+        data=np.full((2, 3, 1), 1.0),
+        samples=Labels(["sample", "parameter"], np.array([[0, -2], [2, 3]])),
+        components=[Labels(["component_1"], np.array([[-1], [6], [1]]))],
+    )
 
-        block_4 = TensorBlock(
-            values=np.array([[1], [2]]),
-            samples=Labels(["samples"], np.array([[0], [2]])),
-            components=[],
-            properties=Labels(["properties"], np.array([[0]])),
-        )
-
-        block_4.add_gradient(
-            "parameter",
-            data=np.full((2, 3, 1), 1.0),
-            samples=Labels(["sample", "parameter"], np.array([[0, -2], [2, 3]])),
-            components=[Labels.arange("component_1", -1, 2)],
-        )
-
-        block_5 = TensorBlock(
-            values=np.array([[1], [2]]),
-            samples=Labels(["samples"], np.array([[0], [2]])),
-            components=[],
-            properties=Labels(["properties"], np.array([[0]])),
-        )
-
-        block_5.add_gradient(
-            "parameter",
-            data=np.full((2, 3, 1), 1.0),
-            samples=Labels(["sample", "parameter"], np.array([[0, -2], [2, 3]])),
-            components=[Labels(["component_1"], np.array([[-1], [6], [1]]))],
-        )
-
-        with self.assertRaises(ValueError) as cm:
-            equistore.allclose_block_raise(block_5, block_4)
-
-        self.assertEqual(
-            str(cm.exception),
-            "Inputs to allclose should have the same gradient:\n"
-            'gradient ("parameter") components are not the same'
-            " or not in the same order.",
-        )
+    message = (
+        "inputs to allclose should have the same gradient:\n"
+        "gradient 'parameter' components are not the same"
+        " or not in the same order"
+    )
+    with pytest.raises(NotEqualError, match=message):
+        equistore.allclose_block_raise(block_5, block_4)
 
 
 # TODO: add tests with torch & torch scripting/tracing
-
-if __name__ == "__main__":
-    unittest.main()

--- a/python/tests/operations/allclose.py
+++ b/python/tests/operations/allclose.py
@@ -13,28 +13,28 @@ DATA_ROOT = os.path.join(os.path.dirname(__file__), "..", "data")
 def test_allclose_nograd():
     block_1 = TensorBlock(
         values=np.array([[1, 2], [3, 5]], dtype=np.float64),
-        samples=Labels(["samples"], np.array([[0], [2]])),
+        samples=Labels(["s"], np.array([[0], [2]])),
         components=[],
-        properties=Labels.arange("properties", 2),
+        properties=Labels.arange("p", 2),
     )
     block_2 = TensorBlock(
         values=np.array([[1, 2], [3, 4], [5, 6], [1, 2], [3, 4], [5, 6]]),
-        samples=Labels.arange("samples", 6),
+        samples=Labels.arange("s", 6),
         components=[],
-        properties=Labels.arange("properties", 2),
+        properties=Labels.arange("p", 2),
     )
 
     block_3 = TensorBlock(
         values=np.array([[1], [2]]),
-        samples=Labels(["samples"], np.array([[0], [2]])),
+        samples=Labels(["s"], np.array([[0], [2]])),
         components=[],
-        properties=Labels(["properties"], np.array([[0]])),
+        properties=Labels(["p"], np.array([[0]])),
     )
     block_4 = TensorBlock(
         values=np.array([[23], [53], [83]]),
-        samples=Labels(["samples"], np.array([[0], [2], [7]])),
+        samples=Labels(["s"], np.array([[0], [2], [7]])),
         components=[],
-        properties=Labels(["properties"], np.array([[6]])),
+        properties=Labels(["p"], np.array([[6]])),
     )
     keys = Labels(names=["key_1", "key_2"], values=np.array([[0, 0], [1, 0]]))
     X = TensorMap(keys, [block_1, block_2])
@@ -62,21 +62,21 @@ def test_allclose_nograd():
             ],
             dtype=np.float64,
         ),
-        samples=Labels(["samples"], np.array([[0], [2]])),
+        samples=Labels(["s"], np.array([[0], [2]])),
         components=[
-            Labels.arange("c1", 3),
-            Labels.arange("c2", 3),
+            Labels.arange("c_1", 3),
+            Labels.arange("c_2", 3),
         ],
-        properties=Labels.arange("properties", 2),
+        properties=Labels.arange("p", 2),
     )
     block_1_c_copy = TensorBlock(
         values=block_1_c.values + 0.1e-6,
-        samples=Labels(["samples"], np.array([[0], [2]])),
+        samples=Labels(["s"], np.array([[0], [2]])),
         components=[
-            Labels.arange("c1", 3),
-            Labels.arange("c2", 3),
+            Labels.arange("c_1", 3),
+            Labels.arange("c_2", 3),
         ],
-        properties=Labels.arange("properties", 2),
+        properties=Labels.arange("p", 2),
     )
 
     block_2_c = TensorBlock(
@@ -89,21 +89,21 @@ def test_allclose_nograd():
                 [[[1, 2], [17.7, 27.7]], [[77.1, 22.2], [1.11, 3.42]]],
             ]
         ),
-        samples=Labels.arange("samples", 5),
+        samples=Labels.arange("s", 5),
         components=[
-            Labels(["c1"], np.array([[3], [5]])),
-            Labels(["c2"], np.array([[6], [8]])),
+            Labels(["c_1"], np.array([[3], [5]])),
+            Labels(["c_2"], np.array([[6], [8]])),
         ],
-        properties=Labels.arange("properties", 2),
+        properties=Labels.arange("p", 2),
     )
     block_2_c_copy = TensorBlock(
         values=block_2_c.values + 0.1e-6,
-        samples=Labels.arange("samples", 5),
+        samples=Labels.arange("s", 5),
         components=[
-            Labels(["c1"], np.array([[3], [5]])),
-            Labels(["c2"], np.array([[6], [8]])),
+            Labels(["c_1"], np.array([[3], [5]])),
+            Labels(["c_2"], np.array([[6], [8]])),
         ],
-        properties=Labels.arange("properties", 2),
+        properties=Labels.arange("p", 2),
     )
     X_c = TensorMap(keys, [block_1_c, block_2_c])
     X_c_copy = TensorMap(keys, [block_1_c_copy, block_2_c_copy])
@@ -146,47 +146,47 @@ def test_self_allclose_grad():
 def test_self_allclose_exceptions():
     block_1 = TensorBlock(
         values=np.array([[1], [2]]),
-        samples=Labels(["samples"], np.array([[0], [2]])),
+        samples=Labels(["s"], np.array([[0], [2]])),
         components=[],
-        properties=Labels(["properties"], np.array([[0]])),
+        properties=Labels(["p"], np.array([[0]])),
     )
     block_2 = TensorBlock(
         values=np.array([[1], [2]]),
-        samples=Labels(["samples_5"], np.array([[0], [2]])),
+        samples=Labels(["other_s"], np.array([[0], [2]])),
         components=[],
-        properties=Labels(["properties"], np.array([[0]])),
+        properties=Labels(["p"], np.array([[0]])),
     )
     block_3 = TensorBlock(
         values=np.array([[1], [2]]),
-        samples=Labels(["samples"], np.array([[0], [6]])),
+        samples=Labels(["s"], np.array([[0], [6]])),
         components=[],
-        properties=Labels(["properties"], np.array([[0]])),
+        properties=Labels(["p"], np.array([[0]])),
     )
 
     block_4 = TensorBlock(
         values=np.array([[[1], [4]], [[44], [2]]]),
-        samples=Labels(["samples"], np.array([[0], [2]])),
+        samples=Labels(["s"], np.array([[0], [2]])),
         components=[
-            Labels(["component"], np.array([[0], [6]])),
+            Labels(["c"], np.array([[0], [6]])),
         ],
-        properties=Labels(["properties"], np.array([[0]])),
+        properties=Labels(["p"], np.array([[0]])),
     )
     block_5 = TensorBlock(
         values=np.array([[[1], [4]], [[44], [2]]]),
-        samples=Labels(["samples"], np.array([[0], [2]])),
+        samples=Labels(["s"], np.array([[0], [2]])),
         components=[
-            Labels(["component1"], np.array([[0], [6]])),
+            Labels(["other_c"], np.array([[0], [6]])),
         ],
-        properties=Labels(["properties"], np.array([[0]])),
+        properties=Labels(["p"], np.array([[0]])),
     )
 
     block_6 = TensorBlock(
         values=np.array([[[1], [4]], [[44], [2]]]),
-        samples=Labels(["samples"], np.array([[2], [0]])),
+        samples=Labels(["s"], np.array([[2], [0]])),
         components=[
-            Labels(["component"], np.array([[0], [6]])),
+            Labels(["c"], np.array([[0], [6]])),
         ],
-        properties=Labels(["properties"], np.array([[0]])),
+        properties=Labels(["p"], np.array([[0]])),
     )
 
     assert not equistore.allclose_block(block_1, block_2)
@@ -227,90 +227,88 @@ def test_self_allclose_exceptions():
 def test_self_allclose_exceptions_gradient():
     block_1 = TensorBlock(
         values=np.array([[1], [2]]),
-        samples=Labels(["samples"], np.array([[0], [2]])),
+        samples=Labels(["s"], np.array([[0], [2]])),
         components=[],
-        properties=Labels(["properties"], np.array([[0]])),
+        properties=Labels(["p"], np.array([[0]])),
     )
 
     block_1.add_gradient(
-        "parameter",
+        "g",
         data=np.full((2, 1), 11.0),
-        samples=Labels(["sample", "parameter"], np.array([[0, -2], [2, 3]])),
+        samples=Labels(["sample", "g"], np.array([[0, -2], [2, 3]])),
         components=[],
     )
 
     block_2 = TensorBlock(
         values=np.array([[1], [2]]),
-        samples=Labels(["samples"], np.array([[0], [2]])),
+        samples=Labels(["s"], np.array([[0], [2]])),
         components=[],
-        properties=Labels(["properties"], np.array([[0]])),
+        properties=Labels(["p"], np.array([[0]])),
     )
 
     block_2.add_gradient(
-        "parameter",
+        "g",
         data=np.full((2, 1), 11.0),
-        samples=Labels(["sample", "parameter1"], np.array([[0, -2], [2, 3]])),
+        samples=Labels(["sample", "other_g"], np.array([[0, -2], [2, 3]])),
         components=[],
     )
 
     message = (
         "inputs to allclose should have the same gradient:\n"
-        "gradient 'parameter' samples names are not the same"
-        " or not in the same order"
+        "gradient 'g' samples names are not the same or not in the same order"
     )
     with pytest.raises(NotEqualError, match=message):
         equistore.allclose_block_raise(block_1, block_2)
 
     block_3 = TensorBlock(
         values=np.array([[1], [2]]),
-        samples=Labels(["samples"], np.array([[0], [2]])),
+        samples=Labels(["s"], np.array([[0], [2]])),
         components=[],
-        properties=Labels(["properties"], np.array([[0]])),
+        properties=Labels(["p"], np.array([[0]])),
     )
 
     block_3.add_gradient(
-        "parameter",
+        "g",
         data=np.full((2, 1), 1.0),
-        samples=Labels(["sample", "parameter"], np.array([[0, -2], [2, 3]])),
+        samples=Labels(["sample", "g"], np.array([[0, -2], [2, 3]])),
         components=[],
     )
 
-    message = "gradient 'parameter' values are not allclose"
+    message = "gradient 'g' values are not allclose"
     with pytest.raises(NotEqualError, match=message):
         equistore.allclose_block_raise(block_1, block_3)
 
     block_4 = TensorBlock(
         values=np.array([[1], [2]]),
-        samples=Labels(["samples"], np.array([[0], [2]])),
+        samples=Labels(["s"], np.array([[0], [2]])),
         components=[],
-        properties=Labels(["properties"], np.array([[0]])),
+        properties=Labels(["p"], np.array([[0]])),
     )
 
     block_4.add_gradient(
-        "parameter",
+        "g",
         data=np.full((2, 3, 1), 1.0),
-        samples=Labels(["sample", "parameter"], np.array([[0, -2], [2, 3]])),
-        components=[Labels.arange("component_1", -1, 2)],
+        samples=Labels(["sample", "g"], np.array([[0, -2], [2, 3]])),
+        components=[Labels.arange("c_1", -1, 2)],
     )
 
     block_5 = TensorBlock(
         values=np.array([[1], [2]]),
-        samples=Labels(["samples"], np.array([[0], [2]])),
+        samples=Labels(["s"], np.array([[0], [2]])),
         components=[],
-        properties=Labels(["properties"], np.array([[0]])),
+        properties=Labels(["p"], np.array([[0]])),
     )
 
     block_5.add_gradient(
-        "parameter",
+        "g",
         data=np.full((2, 3, 1), 1.0),
-        samples=Labels(["sample", "parameter"], np.array([[0, -2], [2, 3]])),
-        components=[Labels(["component_1"], np.array([[-1], [6], [1]]))],
+        samples=Labels(["sample", "g"], np.array([[0, -2], [2, 3]])),
+        components=[Labels(["c_1"], np.array([[-1], [6], [1]]))],
     )
 
     message = (
         "inputs to allclose should have the same gradient:\n"
-        "gradient 'parameter' components are not the same"
-        " or not in the same order"
+        "gradient 'g' components are not the same or not in the same order"
     )
     with pytest.raises(NotEqualError, match=message):
         equistore.allclose_block_raise(block_5, block_4)

--- a/python/tests/operations/block_from_array.py
+++ b/python/tests/operations/block_from_array.py
@@ -1,56 +1,52 @@
-from os import path
-
 import numpy as np
 import pytest
 
 import equistore
 
 
-DATA_ROOT = path.join(path.dirname(__file__), "..", "data")
+@pytest.mark.parametrize("n_axes", [0, 1])
+def test_too_few_axes(n_axes):
+    """Test block_from_array when too few axes are provided."""
+    with pytest.raises(ValueError, match="at least"):
+        equistore.block_from_array(np.zeros((4,) * n_axes))
 
 
-class TestBlockFromArray:
-    @pytest.mark.parametrize("n_axes", [0, 1])
-    def test_too_few_axes(self, n_axes):
-        """Test block_from_array when too few axes are provided."""
-        with pytest.raises(ValueError, match="at least"):
-            equistore.block_from_array(np.zeros((4,) * n_axes))
+def test_without_components():
+    """Test block_from_array for a 2D array."""
+    array = np.zeros((6, 7))
+    block = equistore.block_from_array(array)
+    assert block.values is array
 
-    def test_without_components(self):
-        """Test block_from_array for a 2D array."""
-        array = np.zeros((6, 7))
-        tblock = equistore.block_from_array(array)
-        assert tblock.values is array
+    assert block.samples.names == ("sample",)
+    np.testing.assert_equal(
+        block.samples.asarray(), np.arange(array.shape[0]).reshape((-1, 1))
+    )
 
-        assert tblock.samples.names == ("sample",)
-        np.testing.assert_equal(
-            tblock.samples.asarray(), np.arange(array.shape[0]).reshape((-1, 1))
-        )
+    assert block.properties.names == ("property",)
+    np.testing.assert_equal(
+        block.properties.asarray(), np.arange(array.shape[1]).reshape((-1, 1))
+    )
 
-        assert tblock.properties.names == ("property",)
-        np.testing.assert_equal(
-            tblock.properties.asarray(), np.arange(array.shape[1]).reshape((-1, 1))
-        )
 
-    def test_with_components(self):
-        """Test block_from_array with components."""
-        array = array = np.zeros((6, 5, 7))
-        tblock = equistore.block_from_array(array)
-        assert tblock.values is array
+def test_with_components():
+    """Test block_from_array with components."""
+    array = array = np.zeros((6, 5, 7))
+    block = equistore.block_from_array(array)
+    assert block.values is array
 
-        assert tblock.samples.names == ("sample",)
-        np.testing.assert_equal(
-            tblock.samples.asarray(), np.arange(array.shape[0]).reshape((-1, 1))
-        )
+    assert block.samples.names == ("sample",)
+    np.testing.assert_equal(
+        block.samples.asarray(), np.arange(array.shape[0]).reshape((-1, 1))
+    )
 
-        assert len(tblock.components) == 1
-        component = tblock.components[0]
-        assert component.names == ("component_1",)
-        np.testing.assert_equal(
-            component.asarray(), np.arange(array.shape[1]).reshape((-1, 1))
-        )
+    assert len(block.components) == 1
+    component = block.components[0]
+    assert component.names == ("component_1",)
+    np.testing.assert_equal(
+        component.asarray(), np.arange(array.shape[1]).reshape((-1, 1))
+    )
 
-        assert tblock.properties.names == ("property",)
-        np.testing.assert_equal(
-            tblock.properties.asarray(), np.arange(array.shape[2]).reshape((-1, 1))
-        )
+    assert block.properties.names == ("property",)
+    np.testing.assert_equal(
+        block.properties.asarray(), np.arange(array.shape[2]).reshape((-1, 1))
+    )

--- a/python/tests/operations/divide.py
+++ b/python/tests/operations/divide.py
@@ -14,40 +14,40 @@ class TestDivide(unittest.TestCase):
     def test_self_divide_tensors_nogradient(self):
         block_1 = TensorBlock(
             values=np.array([[1, 2], [3, 5]]),
-            samples=Labels(["samples"], np.array([[0], [2]])),
+            samples=Labels(["s"], np.array([[0], [2]])),
             components=[],
-            properties=Labels.arange("properties", 2),
+            properties=Labels.arange("p", 2),
         )
         block_2 = TensorBlock(
             values=np.array([[1, 2], [3, 4], [5, 6]]),
-            samples=Labels(["samples"], np.array([[0], [2], [7]])),
+            samples=Labels(["s"], np.array([[0], [2], [7]])),
             components=[],
-            properties=Labels.arange("properties", 2),
+            properties=Labels.arange("p", 2),
         )
         block_3 = TensorBlock(
             values=np.array([[1.5, 2.1], [6.7, 10.2]]),
-            samples=Labels(["samples"], np.array([[0], [2]])),
+            samples=Labels(["s"], np.array([[0], [2]])),
             components=[],
-            properties=Labels.arange("properties", 2),
+            properties=Labels.arange("p", 2),
         )
         block_4 = TensorBlock(
             values=np.array([[10, 200.8], [3.76, 4.432], [545, 26]]),
-            samples=Labels(["samples"], np.array([[0], [2], [7]])),
+            samples=Labels(["s"], np.array([[0], [2], [7]])),
             components=[],
-            properties=Labels.arange("properties", 2),
+            properties=Labels.arange("p", 2),
         )
 
         block_res1 = TensorBlock(
             values=block_1.values[:] / block_3.values[:],
-            samples=Labels(["samples"], np.array([[0], [2]])),
+            samples=Labels(["s"], np.array([[0], [2]])),
             components=[],
-            properties=Labels.arange("properties", 2),
+            properties=Labels.arange("p", 2),
         )
         block_res2 = TensorBlock(
             values=block_2.values[:] / block_4.values[:],
-            samples=Labels(["samples"], np.array([[0], [2], [7]])),
+            samples=Labels(["s"], np.array([[0], [2], [7]])),
             components=[],
-            properties=Labels.arange("properties", 2),
+            properties=Labels.arange("p", 2),
         )
         keys = Labels(names=["key_1", "key_2"], values=np.array([[0, 0], [1, 0]]))
         A = TensorMap(keys, [block_1, block_2])
@@ -64,27 +64,27 @@ class TestDivide(unittest.TestCase):
     def test_self_divide_tensors_gradient(self):
         block_1 = TensorBlock(
             values=np.array([[14, 24], [43, 45]]),
-            samples=Labels(["samples"], np.array([[0], [2]])),
+            samples=Labels(["s"], np.array([[0], [2]])),
             components=[],
-            properties=Labels.arange("properties", 2),
+            properties=Labels.arange("p", 2),
         )
         block_1.add_gradient(
-            "parameter",
+            "g",
             data=np.array([[[6, 1], [7, 2]], [[8, 3], [9, 4]]]),
             samples=Labels(["sample", "positions"], np.array([[0, 1], [1, 1]])),
             components=[
-                Labels.arange("components", 2),
+                Labels.arange("c", 2),
             ],
         )
 
         block_2 = TensorBlock(
             values=np.array([[15, 25], [53, 54], [55, 65]]),
-            samples=Labels(["samples"], np.array([[0], [2], [7]])),
+            samples=Labels(["s"], np.array([[0], [2], [7]])),
             components=[],
-            properties=Labels.arange("properties", 2),
+            properties=Labels.arange("p", 2),
         )
         block_2.add_gradient(
-            "parameter",
+            "g",
             data=np.array(
                 [[[10, 11], [12, 13]], [[14, 15], [10, 11]], [[12, 13], [14, 15]]]
             ),
@@ -93,32 +93,32 @@ class TestDivide(unittest.TestCase):
                 np.array([[0, 1], [1, 1], [2, 1]]),
             ),
             components=[
-                Labels.arange("components", 2),
+                Labels.arange("c", 2),
             ],
         )
 
         block_3 = TensorBlock(
             values=np.array([[1.45, 2.41], [6.47, 10.42]]),
-            samples=Labels(["samples"], np.array([[0], [2]])),
+            samples=Labels(["s"], np.array([[0], [2]])),
             components=[],
-            properties=Labels.arange("properties", 2),
+            properties=Labels.arange("p", 2),
         )
         block_3.add_gradient(
-            "parameter",
+            "g",
             data=np.array([[[1, 0.1], [2, 0.2]], [[3, 0.3], [4.5, 0.4]]]),
             samples=Labels(["sample", "positions"], np.array([[0, 1], [1, 1]])),
             components=[
-                Labels.arange("components", 2),
+                Labels.arange("c", 2),
             ],
         )
         block_4 = TensorBlock(
             values=np.array([[105, 200.58], [3.756, 4.4325], [545.5, 26.05]]),
-            samples=Labels(["samples"], np.array([[0], [2], [7]])),
+            samples=Labels(["s"], np.array([[0], [2], [7]])),
             components=[],
-            properties=Labels.arange("properties", 2),
+            properties=Labels.arange("p", 2),
         )
         block_4.add_gradient(
-            "parameter",
+            "g",
             data=np.array(
                 [
                     [[1.0, 1.1], [1.2, 1.3]],
@@ -131,18 +131,18 @@ class TestDivide(unittest.TestCase):
                 np.array([[0, 1], [1, 1], [2, 1]]),
             ),
             components=[
-                Labels.arange("components", 2),
+                Labels.arange("c", 2),
             ],
         )
 
         block_res1 = TensorBlock(
             values=np.array([[9.65517241, 9.95850622], [6.64605873, 4.31861804]]),
-            samples=Labels(["samples"], np.array([[0], [2]])),
+            samples=Labels(["s"], np.array([[0], [2]])),
             components=[],
-            properties=Labels.arange("properties", 2),
+            properties=Labels.arange("p", 2),
         )
         block_res1.add_gradient(
-            "parameter",
+            "g",
             data=np.array(
                 [
                     [
@@ -154,7 +154,7 @@ class TestDivide(unittest.TestCase):
             ),
             samples=Labels(["sample", "positions"], np.array([[0, 1], [1, 1]])),
             components=[
-                Labels.arange("components", 2),
+                Labels.arange("c", 2),
             ],
         )
         block_res2 = TensorBlock(
@@ -165,12 +165,12 @@ class TestDivide(unittest.TestCase):
                     [0.10082493, 2.49520154],
                 ]
             ),
-            samples=Labels(["samples"], np.array([[0], [2], [7]])),
+            samples=Labels(["s"], np.array([[0], [2], [7]])),
             components=[],
-            properties=Labels.arange("properties", 2),
+            properties=Labels.arange("p", 2),
         )
         block_res2.add_gradient(
-            "parameter",
+            "g",
             data=np.array(
                 [
                     [[0.09387755, 0.05415743], [0.11265306, 0.06400424]],
@@ -183,7 +183,7 @@ class TestDivide(unittest.TestCase):
                 np.array([[0, 1], [1, 1], [2, 1]]),
             ),
             components=[
-                Labels.arange("components", 2),
+                Labels.arange("c", 2),
             ],
         )
         keys = Labels(names=["key_1", "key_2"], values=np.array([[0, 0], [1, 0]]))
@@ -206,26 +206,26 @@ class TestDivide(unittest.TestCase):
     def test_self_divide_scalar_gradient(self):
         block_1 = TensorBlock(
             values=np.array([[1, 2], [3, 5]]),
-            samples=Labels(["samples"], np.array([[0], [2]])),
+            samples=Labels(["s"], np.array([[0], [2]])),
             components=[],
-            properties=Labels.arange("properties", 2),
+            properties=Labels.arange("p", 2),
         )
         block_1.add_gradient(
-            "parameter",
+            "g",
             data=np.array([[[6, 1], [7, 2]], [[8, 3], [9, 4]]]),
             samples=Labels(["sample", "positions"], np.array([[0, 1], [1, 1]])),
             components=[
-                Labels.arange("components", 2),
+                Labels.arange("c", 2),
             ],
         )
         block_2 = TensorBlock(
             values=np.array([[11, 12], [13, 14], [15, 16]]),
-            samples=Labels(["samples"], np.array([[0], [2], [7]])),
+            samples=Labels(["s"], np.array([[0], [2], [7]])),
             components=[],
-            properties=Labels.arange("properties", 2),
+            properties=Labels.arange("p", 2),
         )
         block_2.add_gradient(
-            "parameter",
+            "g",
             data=np.array(
                 [[[10, 11], [12, 13]], [[14, 15], [10, 11]], [[12, 13], [14, 15]]]
             ),
@@ -234,18 +234,18 @@ class TestDivide(unittest.TestCase):
                 np.array([[0, 1], [1, 1], [2, 1]]),
             ),
             components=[
-                Labels.arange("components", 2),
+                Labels.arange("c", 2),
             ],
         )
 
         block_res1 = TensorBlock(
             values=np.array([[0.19607843, 0.39215686], [0.58823529, 0.98039216]]),
-            samples=Labels(["samples"], np.array([[0], [2]])),
+            samples=Labels(["s"], np.array([[0], [2]])),
             components=[],
-            properties=Labels.arange("properties", 2),
+            properties=Labels.arange("p", 2),
         )
         block_res1.add_gradient(
-            "parameter",
+            "g",
             data=np.array(
                 [
                     [[1.17647059, 0.19607843], [1.37254902, 0.39215686]],
@@ -254,7 +254,7 @@ class TestDivide(unittest.TestCase):
             ),
             samples=Labels(["sample", "positions"], np.array([[0, 1], [1, 1]])),
             components=[
-                Labels.arange("components", 2),
+                Labels.arange("c", 2),
             ],
         )
         block_res2 = TensorBlock(
@@ -265,12 +265,12 @@ class TestDivide(unittest.TestCase):
                     [2.94117647, 3.1372549],
                 ]
             ),
-            samples=Labels(["samples"], np.array([[0], [2], [7]])),
+            samples=Labels(["s"], np.array([[0], [2], [7]])),
             components=[],
-            properties=Labels.arange("properties", 2),
+            properties=Labels.arange("p", 2),
         )
         block_res2.add_gradient(
-            "parameter",
+            "g",
             data=np.array(
                 [
                     [[1.96078431, 2.15686275], [2.35294118, 2.54901961]],
@@ -283,7 +283,7 @@ class TestDivide(unittest.TestCase):
                 np.array([[0, 1], [1, 1], [2, 1]]),
             ),
             components=[
-                Labels.arange("components", 2),
+                Labels.arange("c", 2),
             ],
         )
 
@@ -302,9 +302,9 @@ class TestDivide(unittest.TestCase):
     def test_self_divide_error(self):
         block_1 = TensorBlock(
             values=np.array([[1, 2], [3, 5]]),
-            samples=Labels(["samples"], np.array([[0], [2]])),
+            samples=Labels(["s"], np.array([[0], [2]])),
             components=[],
-            properties=Labels.arange("properties", 2),
+            properties=Labels.arange("p", 2),
         )
         keys = Labels(names=["key_1", "key_2"], values=np.array([[0, 0]]))
         A = TensorMap(keys, [block_1])

--- a/python/tests/operations/dot.py
+++ b/python/tests/operations/dot.py
@@ -69,7 +69,7 @@ class TestDot(unittest.TestCase):
             block2 = TensorBlock(
                 values=value2,
                 samples=Labels(
-                    ["samples"],
+                    ["s"],
                     np.array([[i] for i in range(n_samples)]),
                 ),
                 components=[],

--- a/python/tests/operations/drop_blocks.py
+++ b/python/tests/operations/drop_blocks.py
@@ -43,9 +43,7 @@ def test_drop_all(test_tensor_map):
     keys = test_tensor_map.keys
     tensor = equistore.drop_blocks(test_tensor_map, keys)
     empty_tensor = TensorMap(keys=Labels.empty(keys.names), blocks=[])
-    assert not (
-        equistore.equal(tensor, empty_tensor)
-    )  # TODO: reverse this once #175 is fixed
+    assert equistore.equal(tensor, empty_tensor)
 
 
 def test_drop_first(test_tensor_map):

--- a/python/tests/operations/empty_like.py
+++ b/python/tests/operations/empty_like.py
@@ -1,7 +1,6 @@
 import os
-import unittest
 
-import numpy as np
+import pytest
 
 import equistore
 
@@ -9,135 +8,31 @@ import equistore
 DATA_ROOT = os.path.join(os.path.dirname(__file__), "..", "data")
 
 
-class TestEmpty_like(unittest.TestCase):
-    def test_empty_like_nocomponent(self):
-        tensor = equistore.load(
-            os.path.join(DATA_ROOT, "qm7-power-spectrum.npz"),
-            # the npz is using DEFLATE compression, equistore only supports STORED
-            use_numpy=True,
-        )
-        empty_tensor = equistore.empty_like(tensor)
+def test_empty_like():
+    tensor = equistore.load(
+        os.path.join(DATA_ROOT, "qm7-spherical-expansion.npz"),
+        # the npz is using DEFLATE compression, equistore only supports STORED
+        use_numpy=True,
+    )
+    empty_tensor = equistore.empty_like(tensor)
+    empty_tensor_positions = equistore.empty_like(tensor, gradients="positions")
 
-        self.assertTrue(np.all(tensor.keys == empty_tensor.keys))
-        for key, empty_block in empty_tensor:
-            block = tensor.block(key)
-            self.assertTrue(np.all(empty_block.samples == block.samples))
-            self.assertTrue(np.all(empty_block.properties == block.properties))
-            self.assertEqual(len(empty_block.components), len(block.components))
-            self.assertTrue(
-                np.all(
-                    [
-                        np.all(empty_block.components[i] == block.components[i])
-                        for i in range(len(block.components))
-                    ]
-                )
-            )
-            self.assertEqual(
-                empty_block.values.shape, np.empty_like(block.values).shape
-            )
+    assert equistore.equal_metadata(empty_tensor, tensor)
 
-            for empty_parameter, empty_gradient in empty_block.gradients():
-                gradient = block.gradient(empty_parameter)
-                self.assertTrue(np.all(empty_gradient.samples == gradient.samples))
-                self.assertEqual(
-                    len(empty_gradient.components), len(gradient.components)
-                )
-                self.assertTrue(
-                    np.all(
-                        [
-                            np.all(
-                                empty_gradient.components[i] == gradient.components[i]
-                            )
-                            for i in range(len(gradient.components))
-                        ]
-                    )
-                )
-                self.assertEqual(
-                    empty_gradient.data.shape, np.empty_like(gradient.data).shape
-                )
+    tensor_no_cell = equistore.remove_gradients(tensor, "cell")
+    assert equistore.equal_metadata(empty_tensor_positions, tensor_no_cell)
 
-    def test_empty_component(self):
-        tensor = equistore.load(
-            os.path.join(DATA_ROOT, "qm7-spherical-expansion.npz"),
-            # the npz is using DEFLATE compression, equistore only supports STORED
-            use_numpy=True,
-        )
-        empty_tensor = equistore.empty_like(tensor)
-        empty_tensor_positions = equistore.empty_like(tensor, parameters="positions")
 
-        self.assertTrue(np.all(tensor.keys == empty_tensor.keys))
-        self.assertTrue(np.all(tensor.keys == empty_tensor_positions.keys))
-        for key, empty_block in empty_tensor:
-            block = tensor.block(key)
-            empty_block_pos = empty_tensor_positions.block(key)
-            self.assertTrue(np.all(empty_block.samples == block.samples))
-            self.assertTrue(np.all(empty_block.properties == block.properties))
+def test_empty_like_error():
+    tensor = equistore.load(
+        os.path.join(DATA_ROOT, "qm7-spherical-expansion.npz"),
+        # the npz is using DEFLATE compression, equistore only supports STORED
+        use_numpy=True,
+    )
 
-            self.assertTrue(np.all(empty_block_pos.samples == block.samples))
-            self.assertTrue(np.all(empty_block_pos.properties == block.properties))
-            self.assertEqual(
-                empty_block_pos.values.shape, np.empty_like(block.values).shape
-            )
-
-            self.assertTrue(empty_block.gradients_list() == block.gradients_list())
-            for empty_parameter, empty_gradient in empty_block.gradients():
-                gradient = block.gradient(empty_parameter)
-                self.assertTrue(np.all(empty_gradient.samples == gradient.samples))
-                self.assertEqual(
-                    len(empty_gradient.components), len(gradient.components)
-                )
-                self.assertTrue(
-                    np.all(
-                        [
-                            np.all(
-                                empty_gradient.components[i] == gradient.components[i]
-                            )
-                            for i in range(len(gradient.components))
-                        ]
-                    )
-                )
-                self.assertEqual(
-                    empty_gradient.data.shape, np.empty_like(gradient.data).shape
-                )
-
-            self.assertTrue(empty_block_pos.gradients_list() == ["positions"])
-            for empty_parameter_pos, empty_gradient_pos in empty_block_pos.gradients():
-                gradient = block.gradient(empty_parameter_pos)
-                self.assertTrue(np.all(empty_gradient_pos.samples == gradient.samples))
-                self.assertEqual(
-                    len(empty_gradient_pos.components), len(gradient.components)
-                )
-                self.assertTrue(
-                    np.all(
-                        [
-                            np.all(
-                                empty_gradient_pos.components[i]
-                                == gradient.components[i]
-                            )
-                            for i in range(len(gradient.components))
-                        ]
-                    )
-                )
-                self.assertEqual(
-                    empty_gradient_pos.data.shape, np.empty_like(gradient.data).shape
-                )
-
-    def test_empty_error(self):
-        tensor = equistore.load(
-            os.path.join(DATA_ROOT, "qm7-spherical-expansion.npz"),
-            # the npz is using DEFLATE compression, equistore only supports STORED
-            use_numpy=True,
-        )
-
-        with self.assertRaises(ValueError) as cm:
-            tensor = equistore.empty_like(tensor, parameters=["positions", "err"])
-        self.assertEqual(
-            str(cm.exception),
-            "requested gradient 'err' in empty_like is not defined in this tensor",
-        )
+    message = "requested gradient 'err' in empty_like is not defined in this tensor"
+    with pytest.raises(ValueError, match=message):
+        tensor = equistore.empty_like(tensor, gradients=["positions", "err"])
 
 
 # TODO: add tests with torch & torch scripting/tracing
-
-if __name__ == "__main__":
-    unittest.main()

--- a/python/tests/operations/empty_like.py
+++ b/python/tests/operations/empty_like.py
@@ -133,8 +133,7 @@ class TestEmpty_like(unittest.TestCase):
             tensor = equistore.empty_like(tensor, parameters=["positions", "err"])
         self.assertEqual(
             str(cm.exception),
-            "The requested parameter 'err' in empty_like_block "
-            "is not a valid parameterfor the TensorBlock",
+            "requested gradient 'err' in empty_like is not defined in this tensor",
         )
 
 

--- a/python/tests/operations/equal.py
+++ b/python/tests/operations/equal.py
@@ -10,31 +10,31 @@ from equistore import Labels, NotEqualError, TensorBlock, TensorMap
 DATA_ROOT = os.path.join(os.path.dirname(__file__), "..", "data")
 
 
-def test_equal_nograd():
+def test_equal_no_gradient():
     block_1 = TensorBlock(
         values=np.array([[1, 2], [3, 5]], dtype=np.float64),
-        samples=Labels(["samples"], np.array([[0], [2]])),
+        samples=Labels(["s"], np.array([[0], [2]])),
         components=[],
-        properties=Labels.arange("properties", 2),
+        properties=Labels.arange("p", 2),
     )
     block_2 = TensorBlock(
         values=np.array([[1, 2], [3, 4], [5, 6], [1, 2], [3, 4], [5, 6]]),
-        samples=Labels.arange("samples", 6),
+        samples=Labels.arange("s", 6),
         components=[],
-        properties=Labels.arange("properties", 2),
+        properties=Labels.arange("p", 2),
     )
 
     block_3 = TensorBlock(
         values=np.array([[1], [2]]),
-        samples=Labels(["samples"], np.array([[0], [2]])),
+        samples=Labels(["s"], np.array([[0], [2]])),
         components=[],
-        properties=Labels(["properties"], np.array([[0]])),
+        properties=Labels(["p"], np.array([[0]])),
     )
     block_4 = TensorBlock(
         values=np.array([[23], [53], [83]]),
-        samples=Labels(["samples"], np.array([[0], [2], [7]])),
+        samples=Labels(["s"], np.array([[0], [2], [7]])),
         components=[],
-        properties=Labels(["properties"], np.array([[6]])),
+        properties=Labels(["p"], np.array([[6]])),
     )
     keys = Labels(names=["key_1", "key_2"], values=np.array([[0, 0], [1, 0]]))
     X = TensorMap(keys, [block_1, block_2])
@@ -63,21 +63,21 @@ def test_equal_nograd():
             ],
             dtype=np.float64,
         ),
-        samples=Labels(["samples"], np.array([[0], [2]])),
+        samples=Labels(["s"], np.array([[0], [2]])),
         components=[
             Labels.arange("c1", 3),
             Labels.arange("c2", 3),
         ],
-        properties=Labels.arange("properties", 2),
+        properties=Labels.arange("p", 2),
     )
     block_1_c_copy = TensorBlock(
         values=block_1_c.values + 0.1e-6,
-        samples=Labels(["samples"], np.array([[0], [2]])),
+        samples=Labels(["s"], np.array([[0], [2]])),
         components=[
             Labels.arange("c1", 3),
             Labels.arange("c2", 3),
         ],
-        properties=Labels.arange("properties", 2),
+        properties=Labels.arange("p", 2),
     )
 
     block_2_c = TensorBlock(
@@ -90,21 +90,21 @@ def test_equal_nograd():
                 [[[1, 2], [17.7, 27.7]], [[77.1, 22.2], [1.11, 3.42]]],
             ]
         ),
-        samples=Labels.arange("samples", 5),
+        samples=Labels.arange("s", 5),
         components=[
             Labels(["c1"], np.array([[3], [5]])),
             Labels(["c2"], np.array([[6], [8]])),
         ],
-        properties=Labels.arange("properties", 2),
+        properties=Labels.arange("p", 2),
     )
     block_2_c_copy = TensorBlock(
         values=block_2_c.values + 0.1e-6,
-        samples=Labels.arange("samples", 5),
+        samples=Labels.arange("s", 5),
         components=[
             Labels(["c1"], np.array([[3], [5]])),
             Labels(["c2"], np.array([[6], [8]])),
         ],
-        properties=Labels.arange("properties", 2),
+        properties=Labels.arange("p", 2),
     )
     X_c = TensorMap(keys, [block_1_c, block_2_c])
     X_c_copy = TensorMap(keys, [block_1_c_copy, block_2_c_copy])
@@ -143,47 +143,47 @@ def test_self_equal_grad():
 def test_self_equal_exceptions():
     block_1 = TensorBlock(
         values=np.array([[1], [2]]),
-        samples=Labels(["samples"], np.array([[0], [2]])),
+        samples=Labels(["s"], np.array([[0], [2]])),
         components=[],
-        properties=Labels(["properties"], np.array([[0]])),
+        properties=Labels(["p"], np.array([[0]])),
     )
     block_2 = TensorBlock(
         values=np.array([[1], [2]]),
-        samples=Labels(["samples_5"], np.array([[0], [2]])),
+        samples=Labels(["other_s"], np.array([[0], [2]])),
         components=[],
-        properties=Labels(["properties"], np.array([[0]])),
+        properties=Labels(["p"], np.array([[0]])),
     )
     block_3 = TensorBlock(
         values=np.array([[1], [2]]),
-        samples=Labels(["samples"], np.array([[0], [6]])),
+        samples=Labels(["s"], np.array([[0], [6]])),
         components=[],
-        properties=Labels(["properties"], np.array([[0]])),
+        properties=Labels(["p"], np.array([[0]])),
     )
 
     block_4 = TensorBlock(
         values=np.array([[[1], [4]], [[44], [2]]]),
-        samples=Labels(["samples"], np.array([[0], [2]])),
+        samples=Labels(["s"], np.array([[0], [2]])),
         components=[
-            Labels(["component"], np.array([[0], [6]])),
+            Labels(["c"], np.array([[0], [6]])),
         ],
-        properties=Labels(["properties"], np.array([[0]])),
+        properties=Labels(["p"], np.array([[0]])),
     )
     block_5 = TensorBlock(
         values=np.array([[[1], [4]], [[44], [2]]]),
-        samples=Labels(["samples"], np.array([[0], [2]])),
+        samples=Labels(["s"], np.array([[0], [2]])),
         components=[
-            Labels(["component1"], np.array([[0], [6]])),
+            Labels(["other_c"], np.array([[0], [6]])),
         ],
-        properties=Labels(["properties"], np.array([[0]])),
+        properties=Labels(["p"], np.array([[0]])),
     )
 
     block_6 = TensorBlock(
         values=np.array([[[1], [4]], [[44], [2]]]),
-        samples=Labels(["samples"], np.array([[2], [0]])),
+        samples=Labels(["s"], np.array([[2], [0]])),
         components=[
-            Labels(["component"], np.array([[0], [6]])),
+            Labels(["c"], np.array([[0], [6]])),
         ],
-        properties=Labels(["properties"], np.array([[0]])),
+        properties=Labels(["p"], np.array([[0]])),
     )
 
     assert not equistore.equal_block(block_1, block_2)
@@ -221,30 +221,30 @@ def test_self_equal_exceptions():
 
     block_7 = TensorBlock(
         values=np.ones((2, 2, 4, 1)),
-        samples=Labels(["samples"], np.array([[2], [0]])),
+        samples=Labels(["s"], np.array([[2], [0]])),
         components=[
-            Labels(["component1"], np.array([[0], [6]])),
-            Labels(["component2"], np.array([[0], [1], [2], [7]])),
+            Labels(["c_1"], np.array([[0], [6]])),
+            Labels(["c_2"], np.array([[0], [1], [2], [7]])),
         ],
-        properties=Labels(["properties"], np.array([[0]])),
+        properties=Labels(["p"], np.array([[0]])),
     )
     block_8 = TensorBlock(
         values=np.ones((2, 2, 4, 1)),
-        samples=Labels(["samples"], np.array([[2], [0]])),
+        samples=Labels(["s"], np.array([[2], [0]])),
         components=[
-            Labels(["component1"], np.array([[0], [6]])),
-            Labels(["component2"], np.array([[0], [8], [6], [7]])),
+            Labels(["c_1"], np.array([[0], [6]])),
+            Labels(["c_2"], np.array([[0], [8], [6], [7]])),
         ],
-        properties=Labels(["properties"], np.array([[0]])),
+        properties=Labels(["p"], np.array([[0]])),
     )
     block_9 = TensorBlock(
         values=np.ones((2, 2, 4, 1)) * 3,
-        samples=Labels(["samples"], np.array([[2], [0]])),
+        samples=Labels(["s"], np.array([[2], [0]])),
         components=[
-            Labels(["component1"], np.array([[0], [6]])),
-            Labels(["component2"], np.array([[0], [8], [6], [7]])),
+            Labels(["c_1"], np.array([[0], [6]])),
+            Labels(["c_2"], np.array([[0], [8], [6], [7]])),
         ],
-        properties=Labels(["properties"], np.array([[0]])),
+        properties=Labels(["p"], np.array([[0]])),
     )
 
     assert not equistore.equal_block(block_7, block_8)
@@ -265,135 +265,128 @@ def test_self_equal_exceptions():
 def test_self_equal_exceptions_gradient():
     block_1 = TensorBlock(
         values=np.array([[1], [2]]),
-        samples=Labels(["samples"], np.array([[0], [2]])),
+        samples=Labels(["s"], np.array([[0], [2]])),
         components=[],
-        properties=Labels(["properties"], np.array([[0]])),
+        properties=Labels(["p"], np.array([[0]])),
     )
 
     block_1.add_gradient(
-        "parameter",
+        "g",
         data=np.full((2, 1), 11.0),
-        samples=Labels(["sample", "parameter"], np.array([[0, -2], [2, 3]])),
+        samples=Labels(["sample", "g"], np.array([[0, -2], [2, 3]])),
         components=[],
     )
 
     block_2 = TensorBlock(
         values=np.array([[1], [2]]),
-        samples=Labels(["samples"], np.array([[0], [2]])),
+        samples=Labels(["s"], np.array([[0], [2]])),
         components=[],
-        properties=Labels(["properties"], np.array([[0]])),
+        properties=Labels(["p"], np.array([[0]])),
     )
 
     block_2.add_gradient(
-        "parameter",
+        "g",
         data=np.full((2, 1), 11.0),
-        samples=Labels(["sample", "parameter1"], np.array([[0, -2], [2, 3]])),
+        samples=Labels(["sample", "other_g"], np.array([[0, -2], [2, 3]])),
         components=[],
     )
 
     message = (
         "inputs to equal should have the same gradient:\n"
-        "gradient 'parameter' samples names are not the same"
-        " or not in the same order"
+        "gradient 'g' samples names are not the same or not in the same order"
     )
     with pytest.raises(NotEqualError, match=message):
         equistore.equal_block_raise(block_1, block_2)
 
     block_3 = TensorBlock(
         values=np.array([[1], [2]]),
-        samples=Labels(["samples"], np.array([[0], [2]])),
+        samples=Labels(["s"], np.array([[0], [2]])),
         components=[],
-        properties=Labels(["properties"], np.array([[0]])),
+        properties=Labels(["p"], np.array([[0]])),
     )
 
     block_3.add_gradient(
-        "parameter",
+        "g",
         data=np.full((2, 1), 1.0),
-        samples=Labels(["sample", "parameter"], np.array([[0, -2], [2, 3]])),
+        samples=Labels(["sample", "g"], np.array([[0, -2], [2, 3]])),
         components=[],
     )
 
-    with pytest.raises(
-        NotEqualError, match="gradient 'parameter' values are not equal"
-    ):
+    with pytest.raises(NotEqualError, match="gradient 'g' values are not equal"):
         equistore.equal_block_raise(block_1, block_3)
 
     block_4 = TensorBlock(
         values=np.array([[1], [2]]),
-        samples=Labels(["samples"], np.array([[0], [2]])),
+        samples=Labels(["s"], np.array([[0], [2]])),
         components=[],
-        properties=Labels(["properties"], np.array([[0]])),
+        properties=Labels(["p"], np.array([[0]])),
     )
 
     block_4.add_gradient(
-        "parameter",
+        "g",
         data=np.full((2, 3, 1), 1.0),
-        samples=Labels(["sample", "parameter"], np.array([[0, -2], [2, 3]])),
-        components=[Labels.arange("component_1", -1, 2)],
+        samples=Labels(["sample", "g"], np.array([[0, -2], [2, 3]])),
+        components=[Labels.arange("c_1", -1, 2)],
     )
 
     block_5 = TensorBlock(
         values=np.array([[1], [2]]),
-        samples=Labels(["samples"], np.array([[0], [2]])),
+        samples=Labels(["s"], np.array([[0], [2]])),
         components=[],
-        properties=Labels(["properties"], np.array([[0]])),
+        properties=Labels(["p"], np.array([[0]])),
     )
 
     block_5.add_gradient(
-        "parameter",
+        "g",
         data=np.full((2, 3, 1), 1.0),
-        samples=Labels(["sample", "parameter"], np.array([[0, -2], [2, 3]])),
-        components=[Labels(["component_1"], np.array([[-1], [6], [1]]))],
+        samples=Labels(["sample", "g"], np.array([[0, -2], [2, 3]])),
+        components=[Labels(["c_1"], np.array([[-1], [6], [1]]))],
     )
 
     message = (
         "inputs to equal should have the same gradient:\n"
-        "gradient 'parameter' components are not the same"
-        " or not in the same order"
+        "gradient 'g' components are not the same or not in the same order"
     )
     with pytest.raises(NotEqualError, match=message):
         equistore.equal_block_raise(block_5, block_4)
 
     block_6 = TensorBlock(
         values=np.array([[1], [2]]),
-        samples=Labels(["samples"], np.array([[0], [2]])),
+        samples=Labels(["s"], np.array([[0], [2]])),
         components=[],
-        properties=Labels(["properties"], np.array([[0]])),
+        properties=Labels(["p"], np.array([[0]])),
     )
 
     block_6.add_gradient(
-        "parameter",
+        "g",
         data=np.full((2, 3, 1), 1.0),
-        samples=Labels(["sample", "parameter_1"], np.array([[0, -2], [2, 3]])),
-        components=[Labels(["component_1"], np.array([[-1], [6], [1]]))],
+        samples=Labels(["sample", "other_g"], np.array([[0, -2], [2, 3]])),
+        components=[Labels(["c_1"], np.array([[-1], [6], [1]]))],
     )
 
     message = (
         "inputs to equal should have the same gradient:\n"
-        "gradient 'parameter' samples names are not the same"
-        " or not in the same order"
+        "gradient 'g' samples names are not the same or not in the same order"
     )
     with pytest.raises(NotEqualError, match=message):
         equistore.equal_block_raise(block_5, block_6)
 
     block_7 = TensorBlock(
         values=np.array([[1], [2]]),
-        samples=Labels(["samples"], np.array([[0], [2]])),
+        samples=Labels(["s"], np.array([[0], [2]])),
         components=[],
-        properties=Labels(["properties"], np.array([[0]])),
+        properties=Labels(["p"], np.array([[0]])),
     )
 
     block_7.add_gradient(
-        "parameter",
+        "g",
         data=np.full((2, 3, 1), 5.0),
-        samples=Labels(["sample", "parameter_1"], np.array([[0, -2], [2, 3]])),
-        components=[Labels(["component_1"], np.array([[-1], [6], [1]]))],
+        samples=Labels(["sample", "other_g"], np.array([[0, -2], [2, 3]])),
+        components=[Labels(["c_1"], np.array([[-1], [6], [1]]))],
     )
     assert not equistore.equal_block(block_6, block_7)
 
-    with pytest.raises(
-        NotEqualError, match="gradient 'parameter' values are not equal"
-    ):
+    with pytest.raises(NotEqualError, match="gradient 'g' values are not equal"):
         equistore.equal_block_raise(block_6, block_7)
 
 

--- a/python/tests/operations/equal.py
+++ b/python/tests/operations/equal.py
@@ -1,434 +1,400 @@
 import os
-import unittest
 
 import numpy as np
+import pytest
 
 import equistore
-from equistore import Labels, TensorBlock, TensorMap
+from equistore import Labels, NotEqualError, TensorBlock, TensorMap
 
 
 DATA_ROOT = os.path.join(os.path.dirname(__file__), "..", "data")
 
 
-class TestEqual(unittest.TestCase):
-    def test_equal_nograd(self):
-        block_1 = TensorBlock(
-            values=np.array([[1, 2], [3, 5]], dtype=np.float64),
-            samples=Labels(["samples"], np.array([[0], [2]])),
-            components=[],
-            properties=Labels.arange("properties", 2),
-        )
-        block_2 = TensorBlock(
-            values=np.array([[1, 2], [3, 4], [5, 6], [1, 2], [3, 4], [5, 6]]),
-            samples=Labels.arange("samples", 6),
-            components=[],
-            properties=Labels.arange("properties", 2),
-        )
+def test_equal_nograd():
+    block_1 = TensorBlock(
+        values=np.array([[1, 2], [3, 5]], dtype=np.float64),
+        samples=Labels(["samples"], np.array([[0], [2]])),
+        components=[],
+        properties=Labels.arange("properties", 2),
+    )
+    block_2 = TensorBlock(
+        values=np.array([[1, 2], [3, 4], [5, 6], [1, 2], [3, 4], [5, 6]]),
+        samples=Labels.arange("samples", 6),
+        components=[],
+        properties=Labels.arange("properties", 2),
+    )
 
-        block_3 = TensorBlock(
-            values=np.array([[1], [2]]),
-            samples=Labels(["samples"], np.array([[0], [2]])),
-            components=[],
-            properties=Labels(["properties"], np.array([[0]])),
-        )
-        block_4 = TensorBlock(
-            values=np.array([[23], [53], [83]]),
-            samples=Labels(["samples"], np.array([[0], [2], [7]])),
-            components=[],
-            properties=Labels(["properties"], np.array([[6]])),
-        )
-        keys = Labels(names=["key_1", "key_2"], values=np.array([[0, 0], [1, 0]]))
-        X = TensorMap(keys, [block_1, block_2])
-        self.assertTrue(equistore.equal(X, X))
-        Y = TensorMap(keys, [block_3, block_4])
-        self.assertFalse(equistore.equal(X, Y))
-        with self.assertRaises(ValueError) as cm:
-            equistore.equal_raise(X, Y)
+    block_3 = TensorBlock(
+        values=np.array([[1], [2]]),
+        samples=Labels(["samples"], np.array([[0], [2]])),
+        components=[],
+        properties=Labels(["properties"], np.array([[0]])),
+    )
+    block_4 = TensorBlock(
+        values=np.array([[23], [53], [83]]),
+        samples=Labels(["samples"], np.array([[0], [2], [7]])),
+        components=[],
+        properties=Labels(["properties"], np.array([[6]])),
+    )
+    keys = Labels(names=["key_1", "key_2"], values=np.array([[0, 0], [1, 0]]))
+    X = TensorMap(keys, [block_1, block_2])
+    assert equistore.equal(X, X)
 
-        self.assertEqual(
-            str(cm.exception), "The TensorBlocks with key = (0, 0) are different"
-        )
+    Y = TensorMap(keys, [block_3, block_4])
+    assert not equistore.equal(X, Y)
 
-        block_1_c = TensorBlock(
-            values=np.array(
+    message = r"blocks for key '\(0, 0\)' are different"
+    with pytest.raises(NotEqualError, match=message):
+        equistore.equal_raise(X, Y)
+
+    block_1_c = TensorBlock(
+        values=np.array(
+            [
                 [
-                    [
-                        [[1, 0.5], [4, 2], [1.5, 6.5]],
-                        [[2, 1], [6, 3], [6.1, 3.5]],
-                        [[9, 9], [9, 9.8], [10, 10.5]],
-                    ],
-                    [
-                        [[3, 1.5], [7, 3.5], [3.7, 1.5]],
-                        [[5, 2.5], [8, 4], [6.3, 1.5]],
-                        [[5, 7.1], [8, 4.8], [6.3, 14.466]],
-                    ],
+                    [[1, 0.5], [4, 2], [1.5, 6.5]],
+                    [[2, 1], [6, 3], [6.1, 3.5]],
+                    [[9, 9], [9, 9.8], [10, 10.5]],
                 ],
-                dtype=np.float64,
-            ),
-            samples=Labels(["samples"], np.array([[0], [2]])),
-            components=[
-                Labels.arange("c1", 3),
-                Labels.arange("c2", 3),
-            ],
-            properties=Labels.arange("properties", 2),
-        )
-        block_1_c_copy = TensorBlock(
-            values=block_1_c.values + 0.1e-6,
-            samples=Labels(["samples"], np.array([[0], [2]])),
-            components=[
-                Labels.arange("c1", 3),
-                Labels.arange("c2", 3),
-            ],
-            properties=Labels.arange("properties", 2),
-        )
-
-        block_2_c = TensorBlock(
-            values=np.array(
                 [
-                    [[[1, 2], [6.8, 2.8]], [[4.1, 6.2], [66.8, 62.8]]],
-                    [[[3, 4], [36, 6.4]], [[83, 84], [73.76, 76.74]]],
-                    [[[5, 6], [58, 68]], [[23.4, 5643.3], [234.5, 3247.6]]],
-                    [[[5.6, 6.6], [5.68, 668]], [[55.6, 676.76], [775.68, 0.668]]],
-                    [[[1, 2], [17.7, 27.7]], [[77.1, 22.2], [1.11, 3.42]]],
-                ]
-            ),
-            samples=Labels.arange("samples", 5),
-            components=[
-                Labels(["c1"], np.array([[3], [5]])),
-                Labels(["c2"], np.array([[6], [8]])),
+                    [[3, 1.5], [7, 3.5], [3.7, 1.5]],
+                    [[5, 2.5], [8, 4], [6.3, 1.5]],
+                    [[5, 7.1], [8, 4.8], [6.3, 14.466]],
+                ],
             ],
-            properties=Labels.arange("properties", 2),
-        )
-        block_2_c_copy = TensorBlock(
-            values=block_2_c.values + 0.1e-6,
-            samples=Labels.arange("samples", 5),
-            components=[
-                Labels(["c1"], np.array([[3], [5]])),
-                Labels(["c2"], np.array([[6], [8]])),
-            ],
-            properties=Labels.arange("properties", 2),
-        )
-        X_c = TensorMap(keys, [block_1_c, block_2_c])
-        X_c_copy = TensorMap(keys, [block_1_c_copy, block_2_c_copy])
-        self.assertFalse(equistore.equal(X, X_c))
+            dtype=np.float64,
+        ),
+        samples=Labels(["samples"], np.array([[0], [2]])),
+        components=[
+            Labels.arange("c1", 3),
+            Labels.arange("c2", 3),
+        ],
+        properties=Labels.arange("properties", 2),
+    )
+    block_1_c_copy = TensorBlock(
+        values=block_1_c.values + 0.1e-6,
+        samples=Labels(["samples"], np.array([[0], [2]])),
+        components=[
+            Labels.arange("c1", 3),
+            Labels.arange("c2", 3),
+        ],
+        properties=Labels.arange("properties", 2),
+    )
 
-        self.assertTrue(equistore.equal(X_c, X_c))
-        self.assertFalse(equistore.equal(X_c, X_c_copy))
+    block_2_c = TensorBlock(
+        values=np.array(
+            [
+                [[[1, 2], [6.8, 2.8]], [[4.1, 6.2], [66.8, 62.8]]],
+                [[[3, 4], [36, 6.4]], [[83, 84], [73.76, 76.74]]],
+                [[[5, 6], [58, 68]], [[23.4, 5643.3], [234.5, 3247.6]]],
+                [[[5.6, 6.6], [5.68, 668]], [[55.6, 676.76], [775.68, 0.668]]],
+                [[[1, 2], [17.7, 27.7]], [[77.1, 22.2], [1.11, 3.42]]],
+            ]
+        ),
+        samples=Labels.arange("samples", 5),
+        components=[
+            Labels(["c1"], np.array([[3], [5]])),
+            Labels(["c2"], np.array([[6], [8]])),
+        ],
+        properties=Labels.arange("properties", 2),
+    )
+    block_2_c_copy = TensorBlock(
+        values=block_2_c.values + 0.1e-6,
+        samples=Labels.arange("samples", 5),
+        components=[
+            Labels(["c1"], np.array([[3], [5]])),
+            Labels(["c2"], np.array([[6], [8]])),
+        ],
+        properties=Labels.arange("properties", 2),
+    )
+    X_c = TensorMap(keys, [block_1_c, block_2_c])
+    X_c_copy = TensorMap(keys, [block_1_c_copy, block_2_c_copy])
+    assert not equistore.equal(X, X_c)
 
-    def test_self_equal_grad(self):
-        tensor1 = equistore.load(
-            os.path.join(DATA_ROOT, "qm7-spherical-expansion.npz"),
-            use_numpy=True,
-        )
-        blocks = []
-        blocks_e6 = []
-        for _, block in tensor1:
-            blocks.append(block.copy())
-            be6 = block.copy()
-            be6.values[:] += 1e-6
-            blocks_e6.append(be6)
+    assert equistore.equal(X_c, X_c)
+    assert not equistore.equal(X_c, X_c_copy)
 
-        tensor1_copy = TensorMap(tensor1.keys, blocks)
-        tensor1_e6 = TensorMap(tensor1.keys, blocks_e6)
-        self.assertTrue(equistore.equal(tensor1, tensor1_copy))
-        self.assertFalse(equistore.equal(tensor1, tensor1_e6))
 
-        with self.assertRaises(ValueError) as cm:
-            equistore.equal_raise(tensor1, tensor1_e6)
+def test_self_equal_grad():
+    tensor1 = equistore.load(
+        os.path.join(DATA_ROOT, "qm7-spherical-expansion.npz"),
+        use_numpy=True,
+    )
+    blocks = []
+    blocks_e6 = []
+    for _, block in tensor1:
+        blocks.append(block.copy())
+        be6 = block.copy()
+        be6.values[:] += 1e-6
+        blocks_e6.append(be6)
 
-        self.assertEqual(
-            str(cm.exception), "The TensorBlocks with key = (0, 1, 1) are different"
-        )
+    tensor1_copy = TensorMap(tensor1.keys, blocks)
+    tensor1_e6 = TensorMap(tensor1.keys, blocks_e6)
+    assert equistore.equal(tensor1, tensor1_copy)
+    assert not equistore.equal(tensor1, tensor1_e6)
 
-        with self.assertRaises(ValueError) as cm:
-            equistore.equal_block_raise(tensor1.block(0), tensor1_e6.block(0))
-        self.assertEqual(str(cm.exception), "values are not equal")
+    message = r"blocks for key '\(0, 1, 1\)' are different"
+    with pytest.raises(NotEqualError, match=message):
+        equistore.equal_raise(tensor1, tensor1_e6)
 
-    def test_self_equal_exceptions(self):
-        block_1 = TensorBlock(
-            values=np.array([[1], [2]]),
-            samples=Labels(["samples"], np.array([[0], [2]])),
-            components=[],
-            properties=Labels(["properties"], np.array([[0]])),
-        )
-        block_2 = TensorBlock(
-            values=np.array([[1], [2]]),
-            samples=Labels(["samples_5"], np.array([[0], [2]])),
-            components=[],
-            properties=Labels(["properties"], np.array([[0]])),
-        )
-        block_3 = TensorBlock(
-            values=np.array([[1], [2]]),
-            samples=Labels(["samples"], np.array([[0], [6]])),
-            components=[],
-            properties=Labels(["properties"], np.array([[0]])),
-        )
+    with pytest.raises(NotEqualError, match="values are not equal"):
+        equistore.equal_block_raise(tensor1.block(0), tensor1_e6.block(0))
 
-        block_4 = TensorBlock(
-            values=np.array([[[1], [4]], [[44], [2]]]),
-            samples=Labels(["samples"], np.array([[0], [2]])),
-            components=[
-                Labels(["component"], np.array([[0], [6]])),
-            ],
-            properties=Labels(["properties"], np.array([[0]])),
-        )
-        block_5 = TensorBlock(
-            values=np.array([[[1], [4]], [[44], [2]]]),
-            samples=Labels(["samples"], np.array([[0], [2]])),
-            components=[
-                Labels(["component1"], np.array([[0], [6]])),
-            ],
-            properties=Labels(["properties"], np.array([[0]])),
-        )
 
-        block_6 = TensorBlock(
-            values=np.array([[[1], [4]], [[44], [2]]]),
-            samples=Labels(["samples"], np.array([[2], [0]])),
-            components=[
-                Labels(["component"], np.array([[0], [6]])),
-            ],
-            properties=Labels(["properties"], np.array([[0]])),
-        )
+def test_self_equal_exceptions():
+    block_1 = TensorBlock(
+        values=np.array([[1], [2]]),
+        samples=Labels(["samples"], np.array([[0], [2]])),
+        components=[],
+        properties=Labels(["properties"], np.array([[0]])),
+    )
+    block_2 = TensorBlock(
+        values=np.array([[1], [2]]),
+        samples=Labels(["samples_5"], np.array([[0], [2]])),
+        components=[],
+        properties=Labels(["properties"], np.array([[0]])),
+    )
+    block_3 = TensorBlock(
+        values=np.array([[1], [2]]),
+        samples=Labels(["samples"], np.array([[0], [6]])),
+        components=[],
+        properties=Labels(["properties"], np.array([[0]])),
+    )
 
-        self.assertFalse(equistore.equal_block(block_1, block_2))
+    block_4 = TensorBlock(
+        values=np.array([[[1], [4]], [[44], [2]]]),
+        samples=Labels(["samples"], np.array([[0], [2]])),
+        components=[
+            Labels(["component"], np.array([[0], [6]])),
+        ],
+        properties=Labels(["properties"], np.array([[0]])),
+    )
+    block_5 = TensorBlock(
+        values=np.array([[[1], [4]], [[44], [2]]]),
+        samples=Labels(["samples"], np.array([[0], [2]])),
+        components=[
+            Labels(["component1"], np.array([[0], [6]])),
+        ],
+        properties=Labels(["properties"], np.array([[0]])),
+    )
 
-        with self.assertRaises(ValueError) as cm:
-            equistore.equal_block_raise(block_1, block_2)
+    block_6 = TensorBlock(
+        values=np.array([[[1], [4]], [[44], [2]]]),
+        samples=Labels(["samples"], np.array([[2], [0]])),
+        components=[
+            Labels(["component"], np.array([[0], [6]])),
+        ],
+        properties=Labels(["properties"], np.array([[0]])),
+    )
 
-        self.assertEqual(
-            str(cm.exception),
-            "Inputs to 'equal' should have the same samples:\n"
-            "samples names are not the same or not in the same order.",
-        )
+    assert not equistore.equal_block(block_1, block_2)
 
-        with self.assertRaises(ValueError) as cm:
-            equistore.equal_block_raise(block_1, block_3)
+    message = (
+        "inputs to 'equal' should have the same samples:\n"
+        "samples names are not the same or not in the same order"
+    )
+    with pytest.raises(NotEqualError, match=message):
+        equistore.equal_block_raise(block_1, block_2)
 
-        self.assertEqual(
-            str(cm.exception),
-            "Inputs to 'equal' should have the same samples:\n"
-            "samples are not the same or not in the same order.",
-        )
+    message = (
+        "inputs to 'equal' should have the same samples:\n"
+        "samples are not the same or not in the same order"
+    )
+    with pytest.raises(NotEqualError, match=message):
+        equistore.equal_block_raise(block_1, block_3)
 
-        with self.assertRaises(ValueError) as cm:
-            equistore.equal_block_raise(block_1, block_4)
+    with pytest.raises(NotEqualError, match="values shapes are different"):
+        equistore.equal_block_raise(block_1, block_4)
 
-        self.assertEqual(str(cm.exception), "values shapes are different")
+    message = (
+        "inputs to 'equal' should have the same components:\n"
+        "components names are not the same or not in the same order"
+    )
+    with pytest.raises(NotEqualError, match=message):
+        equistore.equal_block_raise(block_5, block_4)
 
-        with self.assertRaises(ValueError) as cm:
-            equistore.equal_block_raise(block_5, block_4)
+    message = (
+        "inputs to 'equal' should have the same samples:\n"
+        "samples are not the same or not in the same order"
+    )
+    with pytest.raises(NotEqualError, match=message):
+        equistore.equal_block_raise(block_6, block_4)
 
-        self.assertEqual(
-            str(cm.exception),
-            "Inputs to 'equal' should have the same components:\n"
-            "components names are not the same or not in the same order.",
-        )
+    block_7 = TensorBlock(
+        values=np.ones((2, 2, 4, 1)),
+        samples=Labels(["samples"], np.array([[2], [0]])),
+        components=[
+            Labels(["component1"], np.array([[0], [6]])),
+            Labels(["component2"], np.array([[0], [1], [2], [7]])),
+        ],
+        properties=Labels(["properties"], np.array([[0]])),
+    )
+    block_8 = TensorBlock(
+        values=np.ones((2, 2, 4, 1)),
+        samples=Labels(["samples"], np.array([[2], [0]])),
+        components=[
+            Labels(["component1"], np.array([[0], [6]])),
+            Labels(["component2"], np.array([[0], [8], [6], [7]])),
+        ],
+        properties=Labels(["properties"], np.array([[0]])),
+    )
+    block_9 = TensorBlock(
+        values=np.ones((2, 2, 4, 1)) * 3,
+        samples=Labels(["samples"], np.array([[2], [0]])),
+        components=[
+            Labels(["component1"], np.array([[0], [6]])),
+            Labels(["component2"], np.array([[0], [8], [6], [7]])),
+        ],
+        properties=Labels(["properties"], np.array([[0]])),
+    )
 
-        with self.assertRaises(ValueError) as cm:
-            equistore.equal_block_raise(block_6, block_4)
+    assert not equistore.equal_block(block_7, block_8)
 
-        self.assertEqual(
-            str(cm.exception),
-            "Inputs to 'equal' should have the same samples:\n"
-            "samples are not the same or not in the same order.",
-        )
+    assert not equistore.equal_block(block_8, block_9)
 
-        block_7 = TensorBlock(
-            values=np.ones((2, 2, 4, 1)),
-            samples=Labels(["samples"], np.array([[2], [0]])),
-            components=[
-                Labels(["component1"], np.array([[0], [6]])),
-                Labels(["component2"], np.array([[0], [1], [2], [7]])),
-            ],
-            properties=Labels(["properties"], np.array([[0]])),
-        )
-        block_8 = TensorBlock(
-            values=np.ones((2, 2, 4, 1)),
-            samples=Labels(["samples"], np.array([[2], [0]])),
-            components=[
-                Labels(["component1"], np.array([[0], [6]])),
-                Labels(["component2"], np.array([[0], [8], [6], [7]])),
-            ],
-            properties=Labels(["properties"], np.array([[0]])),
-        )
-        block_9 = TensorBlock(
-            values=np.ones((2, 2, 4, 1)) * 3,
-            samples=Labels(["samples"], np.array([[2], [0]])),
-            components=[
-                Labels(["component1"], np.array([[0], [6]])),
-                Labels(["component2"], np.array([[0], [8], [6], [7]])),
-            ],
-            properties=Labels(["properties"], np.array([[0]])),
-        )
+    message = (
+        "inputs to 'equal' should have the same components:\n"
+        "components are not the same or not in the same order"
+    )
+    with pytest.raises(NotEqualError, match=message):
+        equistore.equal_block_raise(block_7, block_8)
 
-        self.assertFalse(equistore.equal_block(block_7, block_8))
+    with pytest.raises(NotEqualError, match="values are not equal"):
+        equistore.equal_block_raise(block_8, block_9)
 
-        self.assertFalse(equistore.equal_block(block_8, block_9))
 
-        with self.assertRaises(ValueError) as cm:
-            equistore.equal_block_raise(block_7, block_8)
+def test_self_equal_exceptions_gradient():
+    block_1 = TensorBlock(
+        values=np.array([[1], [2]]),
+        samples=Labels(["samples"], np.array([[0], [2]])),
+        components=[],
+        properties=Labels(["properties"], np.array([[0]])),
+    )
 
-        self.assertEqual(
-            str(cm.exception),
-            "Inputs to 'equal' should have the same components:\n"
-            "components are not the same or not in the same order.",
-        )
+    block_1.add_gradient(
+        "parameter",
+        data=np.full((2, 1), 11.0),
+        samples=Labels(["sample", "parameter"], np.array([[0, -2], [2, 3]])),
+        components=[],
+    )
 
-        with self.assertRaises(ValueError) as cm:
-            equistore.equal_block_raise(block_8, block_9)
+    block_2 = TensorBlock(
+        values=np.array([[1], [2]]),
+        samples=Labels(["samples"], np.array([[0], [2]])),
+        components=[],
+        properties=Labels(["properties"], np.array([[0]])),
+    )
 
-        self.assertEqual(
-            str(cm.exception),
-            "values are not equal",
-        )
+    block_2.add_gradient(
+        "parameter",
+        data=np.full((2, 1), 11.0),
+        samples=Labels(["sample", "parameter1"], np.array([[0, -2], [2, 3]])),
+        components=[],
+    )
 
-    def test_self_equal_exceptions_gradient(self):
-        block_1 = TensorBlock(
-            values=np.array([[1], [2]]),
-            samples=Labels(["samples"], np.array([[0], [2]])),
-            components=[],
-            properties=Labels(["properties"], np.array([[0]])),
-        )
+    message = (
+        "inputs to equal should have the same gradient:\n"
+        "gradient 'parameter' samples names are not the same"
+        " or not in the same order"
+    )
+    with pytest.raises(NotEqualError, match=message):
+        equistore.equal_block_raise(block_1, block_2)
 
-        block_1.add_gradient(
-            "parameter",
-            data=np.full((2, 1), 11.0),
-            samples=Labels(["sample", "parameter"], np.array([[0, -2], [2, 3]])),
-            components=[],
-        )
+    block_3 = TensorBlock(
+        values=np.array([[1], [2]]),
+        samples=Labels(["samples"], np.array([[0], [2]])),
+        components=[],
+        properties=Labels(["properties"], np.array([[0]])),
+    )
 
-        block_2 = TensorBlock(
-            values=np.array([[1], [2]]),
-            samples=Labels(["samples"], np.array([[0], [2]])),
-            components=[],
-            properties=Labels(["properties"], np.array([[0]])),
-        )
+    block_3.add_gradient(
+        "parameter",
+        data=np.full((2, 1), 1.0),
+        samples=Labels(["sample", "parameter"], np.array([[0, -2], [2, 3]])),
+        components=[],
+    )
 
-        block_2.add_gradient(
-            "parameter",
-            data=np.full((2, 1), 11.0),
-            samples=Labels(["sample", "parameter1"], np.array([[0, -2], [2, 3]])),
-            components=[],
-        )
+    with pytest.raises(
+        NotEqualError, match="gradient 'parameter' values are not equal"
+    ):
+        equistore.equal_block_raise(block_1, block_3)
 
-        with self.assertRaises(ValueError) as cm:
-            equistore.equal_block_raise(block_1, block_2)
+    block_4 = TensorBlock(
+        values=np.array([[1], [2]]),
+        samples=Labels(["samples"], np.array([[0], [2]])),
+        components=[],
+        properties=Labels(["properties"], np.array([[0]])),
+    )
 
-        self.assertEqual(
-            str(cm.exception),
-            "Inputs to equal should have the same gradient:\n"
-            'gradient ("parameter") samples names are not the same'
-            " or not in the same order.",
-        )
+    block_4.add_gradient(
+        "parameter",
+        data=np.full((2, 3, 1), 1.0),
+        samples=Labels(["sample", "parameter"], np.array([[0, -2], [2, 3]])),
+        components=[Labels.arange("component_1", -1, 2)],
+    )
 
-        block_3 = TensorBlock(
-            values=np.array([[1], [2]]),
-            samples=Labels(["samples"], np.array([[0], [2]])),
-            components=[],
-            properties=Labels(["properties"], np.array([[0]])),
-        )
+    block_5 = TensorBlock(
+        values=np.array([[1], [2]]),
+        samples=Labels(["samples"], np.array([[0], [2]])),
+        components=[],
+        properties=Labels(["properties"], np.array([[0]])),
+    )
 
-        block_3.add_gradient(
-            "parameter",
-            data=np.full((2, 1), 1.0),
-            samples=Labels(["sample", "parameter"], np.array([[0, -2], [2, 3]])),
-            components=[],
-        )
+    block_5.add_gradient(
+        "parameter",
+        data=np.full((2, 3, 1), 1.0),
+        samples=Labels(["sample", "parameter"], np.array([[0, -2], [2, 3]])),
+        components=[Labels(["component_1"], np.array([[-1], [6], [1]]))],
+    )
 
-        with self.assertRaises(ValueError) as cm:
-            equistore.equal_block_raise(block_1, block_3)
+    message = (
+        "inputs to equal should have the same gradient:\n"
+        "gradient 'parameter' components are not the same"
+        " or not in the same order"
+    )
+    with pytest.raises(NotEqualError, match=message):
+        equistore.equal_block_raise(block_5, block_4)
 
-        self.assertEqual(
-            str(cm.exception),
-            'gradient ("parameter") data are not equal',
-        )
+    block_6 = TensorBlock(
+        values=np.array([[1], [2]]),
+        samples=Labels(["samples"], np.array([[0], [2]])),
+        components=[],
+        properties=Labels(["properties"], np.array([[0]])),
+    )
 
-        block_4 = TensorBlock(
-            values=np.array([[1], [2]]),
-            samples=Labels(["samples"], np.array([[0], [2]])),
-            components=[],
-            properties=Labels(["properties"], np.array([[0]])),
-        )
+    block_6.add_gradient(
+        "parameter",
+        data=np.full((2, 3, 1), 1.0),
+        samples=Labels(["sample", "parameter_1"], np.array([[0, -2], [2, 3]])),
+        components=[Labels(["component_1"], np.array([[-1], [6], [1]]))],
+    )
 
-        block_4.add_gradient(
-            "parameter",
-            data=np.full((2, 3, 1), 1.0),
-            samples=Labels(["sample", "parameter"], np.array([[0, -2], [2, 3]])),
-            components=[Labels.arange("component_1", -1, 2)],
-        )
+    message = (
+        "inputs to equal should have the same gradient:\n"
+        "gradient 'parameter' samples names are not the same"
+        " or not in the same order"
+    )
+    with pytest.raises(NotEqualError, match=message):
+        equistore.equal_block_raise(block_5, block_6)
 
-        block_5 = TensorBlock(
-            values=np.array([[1], [2]]),
-            samples=Labels(["samples"], np.array([[0], [2]])),
-            components=[],
-            properties=Labels(["properties"], np.array([[0]])),
-        )
+    block_7 = TensorBlock(
+        values=np.array([[1], [2]]),
+        samples=Labels(["samples"], np.array([[0], [2]])),
+        components=[],
+        properties=Labels(["properties"], np.array([[0]])),
+    )
 
-        block_5.add_gradient(
-            "parameter",
-            data=np.full((2, 3, 1), 1.0),
-            samples=Labels(["sample", "parameter"], np.array([[0, -2], [2, 3]])),
-            components=[Labels(["component_1"], np.array([[-1], [6], [1]]))],
-        )
+    block_7.add_gradient(
+        "parameter",
+        data=np.full((2, 3, 1), 5.0),
+        samples=Labels(["sample", "parameter_1"], np.array([[0, -2], [2, 3]])),
+        components=[Labels(["component_1"], np.array([[-1], [6], [1]]))],
+    )
+    assert not equistore.equal_block(block_6, block_7)
 
-        with self.assertRaises(ValueError) as cm:
-            equistore.equal_block_raise(block_5, block_4)
-
-        self.assertEqual(
-            str(cm.exception),
-            "Inputs to equal should have the same gradient:\n"
-            'gradient ("parameter") components are not the same'
-            " or not in the same order.",
-        )
-
-        block_6 = TensorBlock(
-            values=np.array([[1], [2]]),
-            samples=Labels(["samples"], np.array([[0], [2]])),
-            components=[],
-            properties=Labels(["properties"], np.array([[0]])),
-        )
-
-        block_6.add_gradient(
-            "parameter",
-            data=np.full((2, 3, 1), 1.0),
-            samples=Labels(["sample", "parameter_1"], np.array([[0, -2], [2, 3]])),
-            components=[Labels(["component_1"], np.array([[-1], [6], [1]]))],
-        )
-        with self.assertRaises(ValueError) as cm:
-            equistore.equal_block_raise(block_5, block_6)
-
-        self.assertEqual(
-            str(cm.exception),
-            "Inputs to equal should have the same gradient:\n"
-            'gradient ("parameter") samples names are not the same'
-            " or not in the same order.",
-        )
-
-        block_7 = TensorBlock(
-            values=np.array([[1], [2]]),
-            samples=Labels(["samples"], np.array([[0], [2]])),
-            components=[],
-            properties=Labels(["properties"], np.array([[0]])),
-        )
-
-        block_7.add_gradient(
-            "parameter",
-            data=np.full((2, 3, 1), 5.0),
-            samples=Labels(["sample", "parameter_1"], np.array([[0, -2], [2, 3]])),
-            components=[Labels(["component_1"], np.array([[-1], [6], [1]]))],
-        )
-        self.assertFalse(equistore.equal_block(block_6, block_7))
-
-        with self.assertRaises(ValueError) as cm:
-            equistore.equal_block_raise(block_6, block_7)
-
-        self.assertEqual(
-            str(cm.exception),
-            'gradient ("parameter") data are not equal',
-        )
+    with pytest.raises(
+        NotEqualError, match="gradient 'parameter' values are not equal"
+    ):
+        equistore.equal_block_raise(block_6, block_7)
 
 
 # TODO: add tests with torch & torch scripting/tracing
-
-if __name__ == "__main__":
-    unittest.main()

--- a/python/tests/operations/equal_metadata.py
+++ b/python/tests/operations/equal_metadata.py
@@ -39,63 +39,63 @@ def tensor_map() -> TensorMap:
     """
     block_1 = TensorBlock(
         values=np.full((3, 1, 1), 1.0),
-        samples=Labels(["samples"], np.array([[0], [2], [4]])),
-        components=[Labels(["components"], np.array([[0]]))],
-        properties=Labels(["properties"], np.array([[0]])),
+        samples=Labels(["s"], np.array([[0], [2], [4]])),
+        components=[Labels(["c"], np.array([[0]]))],
+        properties=Labels(["p"], np.array([[0]])),
     )
     block_1.add_gradient(
-        "parameter",
-        samples=Labels(["sample", "parameter"], np.array([[0, -2], [2, 3]])),
+        "g",
+        samples=Labels(["sample", "g"], np.array([[0, -2], [2, 3]])),
         data=np.full((2, 1, 1), 11.0),
-        components=[Labels(["components"], np.array([[0]]))],
+        components=[Labels(["c"], np.array([[0]]))],
     )
 
     block_2 = TensorBlock(
         values=np.full((3, 1, 3), 2.0),
-        samples=Labels(["samples"], np.array([[0], [1], [3]])),
-        components=[Labels(["components"], np.array([[0]]))],
-        properties=Labels(["properties"], np.array([[3], [4], [5]])),
+        samples=Labels(["s"], np.array([[0], [1], [3]])),
+        components=[Labels(["c"], np.array([[0]]))],
+        properties=Labels(["p"], np.array([[3], [4], [5]])),
     )
     block_2.add_gradient(
-        "parameter",
+        "g",
         data=np.full((3, 1, 3), 12.0),
         samples=Labels(
-            ["sample", "parameter"],
+            ["sample", "g"],
             np.array([[0, -2], [0, 3], [2, -2]]),
         ),
-        components=[Labels(["components"], np.array([[0]]))],
+        components=[Labels(["c"], np.array([[0]]))],
     )
 
     block_3 = TensorBlock(
         values=np.full((4, 3, 1), 3.0),
-        samples=Labels(["samples"], np.array([[0], [3], [6], [8]])),
-        components=[Labels.arange("components", 3)],
-        properties=Labels(["properties"], np.array([[0]])),
+        samples=Labels(["s"], np.array([[0], [3], [6], [8]])),
+        components=[Labels.arange("c", 3)],
+        properties=Labels(["p"], np.array([[0]])),
     )
     block_3.add_gradient(
-        "parameter",
+        "g",
         data=np.full((1, 3, 1), 13.0),
         samples=Labels(
-            ["sample", "parameter"],
+            ["sample", "g"],
             np.array([[1, -2]]),
         ),
-        components=[Labels.arange("components", 3)],
+        components=[Labels.arange("c", 3)],
     )
 
     block_4 = TensorBlock(
         values=np.full((4, 3, 1), 4.0),
-        samples=Labels(["samples"], np.array([[0], [1], [2], [5]])),
-        components=[Labels.arange("components", 3)],
-        properties=Labels(["properties"], np.array([[0]])),
+        samples=Labels(["s"], np.array([[0], [1], [2], [5]])),
+        components=[Labels.arange("c", 3)],
+        properties=Labels(["p"], np.array([[0]])),
     )
     block_4.add_gradient(
-        "parameter",
+        "g",
         data=np.full((2, 3, 1), 14.0),
         samples=Labels(
-            ["sample", "parameter"],
+            ["sample", "g"],
             np.array([[0, 1], [3, 3]]),
         ),
-        components=[Labels.arange("components", 3)],
+        components=[Labels.arange("c", 3)],
     )
 
     # TODO: different number of components?

--- a/python/tests/operations/lstsq.py
+++ b/python/tests/operations/lstsq.py
@@ -14,28 +14,28 @@ class TestLstsq(unittest.TestCase):
     def test_self_lstsq_nograd(self):
         block_1 = TensorBlock(
             values=np.array([[1, 2], [3, 5]]),
-            samples=Labels(["samples"], np.array([[0], [2]])),
+            samples=Labels(["s"], np.array([[0], [2]])),
             components=[],
-            properties=Labels.arange("properties", 2),
+            properties=Labels.arange("p", 2),
         )
         block_2 = TensorBlock(
             values=np.array([[1, 2], [3, 4], [5, 6]]),
-            samples=Labels(["samples"], np.array([[0], [2], [7]])),
+            samples=Labels(["s"], np.array([[0], [2], [7]])),
             components=[],
-            properties=Labels.arange("properties", 2),
+            properties=Labels.arange("p", 2),
         )
 
         block_3 = TensorBlock(
             values=np.array([[1], [2]]),
-            samples=Labels(["samples"], np.array([[0], [2]])),
+            samples=Labels(["s"], np.array([[0], [2]])),
             components=[],
-            properties=Labels(["properties"], np.array([[0]])),
+            properties=Labels(["p"], np.array([[0]])),
         )
         block_4 = TensorBlock(
             values=np.array([[23], [53], [83]]),
-            samples=Labels(["samples"], np.array([[0], [2], [7]])),
+            samples=Labels(["s"], np.array([[0], [2], [7]])),
             components=[],
-            properties=Labels(["properties"], np.array([[6]])),
+            properties=Labels(["p"], np.array([[6]])),
         )
         keys = Labels(names=["key_1", "key_2"], values=np.array([[0, 0], [1, 0]]))
         X = TensorMap(keys, [block_1, block_2])
@@ -70,9 +70,9 @@ class TestLstsq(unittest.TestCase):
         Xval, Xgradval, Yval, Ygradval = get_value_linear_solve()
         block_X = TensorBlock(
             values=Xval,
-            samples=Labels.arange("samples", 5),
+            samples=Labels.arange("s", 5),
             components=[],
-            properties=Labels.arange("properties", 2),
+            properties=Labels.arange("p", 2),
         )
         block_X.add_gradient(
             "positions",
@@ -81,14 +81,14 @@ class TestLstsq(unittest.TestCase):
                 ["sample", "positions"],
                 np.array([[0, 1], [1, 1], [2, 1], [3, 1], [4, 1]]),
             ),
-            components=[Labels.arange("components", 3)],
+            components=[Labels.arange("c", 3)],
         )
 
         block_Y = TensorBlock(
             values=Yval,
-            samples=Labels.arange("samples", 5),
+            samples=Labels.arange("s", 5),
             components=[],
-            properties=Labels(["properties"], np.array([[2]])),
+            properties=Labels(["p"], np.array([[2]])),
         )
         block_Y.add_gradient(
             "positions",
@@ -97,7 +97,7 @@ class TestLstsq(unittest.TestCase):
                 ["sample", "positions"],
                 np.array([[0, 1], [1, 1], [2, 1], [3, 1], [4, 1]]),
             ),
-            components=[Labels.arange("components", 3)],
+            components=[Labels.arange("c", 3)],
         )
 
         keys = Labels(names=["key_1", "key_2"], values=np.array([[0, 0]]))
@@ -125,9 +125,9 @@ class TestLstsq(unittest.TestCase):
         ydim = len(Yval)
         block_X = TensorBlock(
             values=Xval.reshape((1, xdim, Xval.shape[-1])),
-            samples=Labels(["samples"], np.array([[0]])),
-            components=[Labels.arange("components", 5)],
-            properties=Labels.arange("properties", 2),
+            samples=Labels(["s"], np.array([[0]])),
+            components=[Labels.arange("c", 5)],
+            properties=Labels.arange("p", 2),
         )
         block_X.add_gradient(
             "positions",
@@ -138,15 +138,15 @@ class TestLstsq(unittest.TestCase):
             ),
             components=[
                 Labels.arange("der_components", 3),
-                Labels.arange("components", 5),
+                Labels.arange("c", 5),
             ],
         )
 
         block_Y = TensorBlock(
             values=Yval.reshape((1, ydim, Yval.shape[-1])),
-            samples=Labels(["samples"], np.array([[0]])),
-            components=[Labels.arange("components", 5)],
-            properties=Labels(["properties"], np.array([[2]])),
+            samples=Labels(["s"], np.array([[0]])),
+            components=[Labels.arange("c", 5)],
+            properties=Labels(["p"], np.array([[2]])),
         )
         block_Y.add_gradient(
             "positions",
@@ -154,7 +154,7 @@ class TestLstsq(unittest.TestCase):
             samples=Labels(["sample", "positions"], np.array([[0, 1]])),
             components=[
                 Labels.arange("der_components", 3),
-                Labels.arange("components", 5),
+                Labels.arange("c", 5),
             ],
         )
 

--- a/python/tests/operations/multiply.py
+++ b/python/tests/operations/multiply.py
@@ -14,40 +14,40 @@ class TestMultiply(unittest.TestCase):
     def test_self_multiply_tensors_nogradient(self):
         block_1 = TensorBlock(
             values=np.array([[1, 2], [3, 5]]),
-            samples=Labels(["samples"], np.array([[0], [2]])),
+            samples=Labels(["s"], np.array([[0], [2]])),
             components=[],
-            properties=Labels.arange("properties", 2),
+            properties=Labels.arange("p", 2),
         )
         block_2 = TensorBlock(
             values=np.array([[1, 2], [3, 4], [5, 6]]),
-            samples=Labels(["samples"], np.array([[0], [2], [7]])),
+            samples=Labels(["s"], np.array([[0], [2], [7]])),
             components=[],
-            properties=Labels.arange("properties", 2),
+            properties=Labels.arange("p", 2),
         )
         block_3 = TensorBlock(
             values=np.array([[1.5, 2.1], [6.7, 10.2]]),
-            samples=Labels(["samples"], np.array([[0], [2]])),
+            samples=Labels(["s"], np.array([[0], [2]])),
             components=[],
-            properties=Labels.arange("properties", 2),
+            properties=Labels.arange("p", 2),
         )
         block_4 = TensorBlock(
             values=np.array([[10, 200.8], [3.76, 4.432], [545, 26]]),
-            samples=Labels(["samples"], np.array([[0], [2], [7]])),
+            samples=Labels(["s"], np.array([[0], [2], [7]])),
             components=[],
-            properties=Labels.arange("properties", 2),
+            properties=Labels.arange("p", 2),
         )
 
         block_res1 = TensorBlock(
             values=np.array([[1.5, 4.2], [20.1, 51.0]]),
-            samples=Labels(["samples"], np.array([[0], [2]])),
+            samples=Labels(["s"], np.array([[0], [2]])),
             components=[],
-            properties=Labels.arange("properties", 2),
+            properties=Labels.arange("p", 2),
         )
         block_res2 = TensorBlock(
             values=np.array([[10.0, 401.6], [11.28, 17.728], [2725.0, 156.0]]),
-            samples=Labels(["samples"], np.array([[0], [2], [7]])),
+            samples=Labels(["s"], np.array([[0], [2], [7]])),
             components=[],
-            properties=Labels.arange("properties", 2),
+            properties=Labels.arange("p", 2),
         )
         keys = Labels(names=["key_1", "key_2"], values=np.array([[0, 0], [1, 0]]))
         A = TensorMap(keys, [block_1, block_2])
@@ -65,27 +65,27 @@ class TestMultiply(unittest.TestCase):
     def test_self_multiply_tensors_gradient(self):
         block_1 = TensorBlock(
             values=np.array([[14, 24], [43, 45]]),
-            samples=Labels(["samples"], np.array([[0], [2]])),
+            samples=Labels(["s"], np.array([[0], [2]])),
             components=[],
-            properties=Labels.arange("properties", 2),
+            properties=Labels.arange("p", 2),
         )
         block_1.add_gradient(
-            "parameter",
+            "g",
             data=np.array([[[6, 1], [7, 2]], [[8, 3], [9, 4]]]),
             samples=Labels(["sample", "positions"], np.array([[0, 1], [1, 1]])),
             components=[
-                Labels.arange("components", 2),
+                Labels.arange("c", 2),
             ],
         )
 
         block_2 = TensorBlock(
             values=np.array([[15, 25], [53, 54], [55, 65]]),
-            samples=Labels(["samples"], np.array([[0], [2], [7]])),
+            samples=Labels(["s"], np.array([[0], [2], [7]])),
             components=[],
-            properties=Labels.arange("properties", 2),
+            properties=Labels.arange("p", 2),
         )
         block_2.add_gradient(
-            "parameter",
+            "g",
             data=np.array(
                 [[[10, 11], [12, 13]], [[14, 15], [10, 11]], [[12, 13], [14, 15]]]
             ),
@@ -94,32 +94,32 @@ class TestMultiply(unittest.TestCase):
                 np.array([[0, 1], [1, 1], [2, 1]]),
             ),
             components=[
-                Labels.arange("components", 2),
+                Labels.arange("c", 2),
             ],
         )
 
         block_3 = TensorBlock(
             values=np.array([[1.45, 2.41], [6.47, 10.42]]),
-            samples=Labels(["samples"], np.array([[0], [2]])),
+            samples=Labels(["s"], np.array([[0], [2]])),
             components=[],
-            properties=Labels.arange("properties", 2),
+            properties=Labels.arange("p", 2),
         )
         block_3.add_gradient(
-            "parameter",
+            "g",
             data=np.array([[[1, 0.1], [2, 0.2]], [[3, 0.3], [4.5, 0.4]]]),
             samples=Labels(["sample", "positions"], np.array([[0, 1], [1, 1]])),
             components=[
-                Labels.arange("components", 2),
+                Labels.arange("c", 2),
             ],
         )
         block_4 = TensorBlock(
             values=np.array([[105, 200.58], [3.756, 4.4325], [545.5, 26.05]]),
-            samples=Labels(["samples"], np.array([[0], [2], [7]])),
+            samples=Labels(["s"], np.array([[0], [2], [7]])),
             components=[],
-            properties=Labels.arange("properties", 2),
+            properties=Labels.arange("p", 2),
         )
         block_4.add_gradient(
-            "parameter",
+            "g",
             data=np.array(
                 [
                     [[1.0, 1.1], [1.2, 1.3]],
@@ -132,34 +132,34 @@ class TestMultiply(unittest.TestCase):
                 np.array([[0, 1], [1, 1], [2, 1]]),
             ),
             components=[
-                Labels.arange("components", 2),
+                Labels.arange("c", 2),
             ],
         )
 
         block_res1 = TensorBlock(
             values=np.array([[20.3, 57.84], [278.21, 468.9]]),
-            samples=Labels(["samples"], np.array([[0], [2]])),
+            samples=Labels(["s"], np.array([[0], [2]])),
             components=[],
-            properties=Labels.arange("properties", 2),
+            properties=Labels.arange("p", 2),
         )
         block_res1.add_gradient(
-            "parameter",
+            "g",
             data=np.array(
                 [[[22.7, 4.81], [38.15, 9.62]], [[180.76, 44.76], [251.73, 59.68]]]
             ),
             samples=Labels(["sample", "positions"], np.array([[0, 1], [1, 1]])),
             components=[
-                Labels.arange("components", 2),
+                Labels.arange("c", 2),
             ],
         )
         block_res2 = TensorBlock(
             values=np.array([[1575.0, 5014.5], [199.068, 239.355], [30002.5, 1693.25]]),
-            samples=Labels(["samples"], np.array([[0], [2], [7]])),
+            samples=Labels(["s"], np.array([[0], [2], [7]])),
             components=[],
-            properties=Labels.arange("properties", 2),
+            properties=Labels.arange("p", 2),
         )
         block_res2.add_gradient(
-            "parameter",
+            "g",
             data=np.array(
                 [
                     [[1065.0, 2233.88], [1278.0, 2640.04]],
@@ -172,7 +172,7 @@ class TestMultiply(unittest.TestCase):
                 np.array([[0, 1], [1, 1], [2, 1]]),
             ),
             components=[
-                Labels.arange("components", 2),
+                Labels.arange("c", 2),
             ],
         )
         keys = Labels(names=["key_1", "key_2"], values=np.array([[0, 0], [1, 0]]))
@@ -191,26 +191,26 @@ class TestMultiply(unittest.TestCase):
     def test_self_multiply_scalar_gradient(self):
         block_1 = TensorBlock(
             values=np.array([[1, 2], [3, 5]]),
-            samples=Labels(["samples"], np.array([[0], [2]])),
+            samples=Labels(["s"], np.array([[0], [2]])),
             components=[],
-            properties=Labels.arange("properties", 2),
+            properties=Labels.arange("p", 2),
         )
         block_1.add_gradient(
-            "parameter",
+            "g",
             data=np.array([[[6, 1], [7, 2]], [[8, 3], [9, 4]]]),
             samples=Labels(["sample", "positions"], np.array([[0, 1], [1, 1]])),
             components=[
-                Labels.arange("components", 2),
+                Labels.arange("c", 2),
             ],
         )
         block_2 = TensorBlock(
             values=np.array([[11, 12], [13, 14], [15, 16]]),
-            samples=Labels(["samples"], np.array([[0], [2], [7]])),
+            samples=Labels(["s"], np.array([[0], [2], [7]])),
             components=[],
-            properties=Labels.arange("properties", 2),
+            properties=Labels.arange("p", 2),
         )
         block_2.add_gradient(
-            "parameter",
+            "g",
             data=np.array(
                 [[[10, 11], [12, 13]], [[14, 15], [10, 11]], [[12, 13], [14, 15]]]
             ),
@@ -219,32 +219,32 @@ class TestMultiply(unittest.TestCase):
                 np.array([[0, 1], [1, 1], [2, 1]]),
             ),
             components=[
-                Labels.arange("components", 2),
+                Labels.arange("c", 2),
             ],
         )
 
         block_res1 = TensorBlock(
             values=np.array([[5.1, 10.2], [15.3, 25.5]]),
-            samples=Labels(["samples"], np.array([[0], [2]])),
+            samples=Labels(["s"], np.array([[0], [2]])),
             components=[],
-            properties=Labels.arange("properties", 2),
+            properties=Labels.arange("p", 2),
         )
         block_res1.add_gradient(
-            "parameter",
+            "g",
             data=np.array([[[30.6, 5.1], [35.7, 10.2]], [[40.8, 15.3], [45.9, 20.4]]]),
             samples=Labels(["sample", "positions"], np.array([[0, 1], [1, 1]])),
             components=[
-                Labels.arange("components", 2),
+                Labels.arange("c", 2),
             ],
         )
         block_res2 = TensorBlock(
             values=np.array([[56.1, 61.2], [66.3, 71.4], [76.5, 81.6]]),
-            samples=Labels(["samples"], np.array([[0], [2], [7]])),
+            samples=Labels(["s"], np.array([[0], [2], [7]])),
             components=[],
-            properties=Labels.arange("properties", 2),
+            properties=Labels.arange("p", 2),
         )
         block_res2.add_gradient(
-            "parameter",
+            "g",
             data=np.array(
                 [
                     [[51.0, 56.1], [61.2, 66.3]],
@@ -257,7 +257,7 @@ class TestMultiply(unittest.TestCase):
                 np.array([[0, 1], [1, 1], [2, 1]]),
             ),
             components=[
-                Labels.arange("components", 2),
+                Labels.arange("c", 2),
             ],
         )
 
@@ -276,9 +276,9 @@ class TestMultiply(unittest.TestCase):
     def test_self_multiply_error(self):
         block_1 = TensorBlock(
             values=np.array([[1, 2], [3, 5]]),
-            samples=Labels(["samples"], np.array([[0], [2]])),
+            samples=Labels(["s"], np.array([[0], [2]])),
             components=[],
-            properties=Labels.arange("properties", 2),
+            properties=Labels.arange("p", 2),
         )
         keys = Labels(names=["key_1", "key_2"], values=np.array([[0, 0]]))
         A = TensorMap(keys, [block_1])

--- a/python/tests/operations/ones_like.py
+++ b/python/tests/operations/ones_like.py
@@ -130,8 +130,7 @@ class TestOnes_like(unittest.TestCase):
             tensor = equistore.ones_like(tensor, parameters=["positions", "err"])
         self.assertEqual(
             str(cm.exception),
-            "The requested parameter 'err' in ones_like_block "
-            "is not a valid parameterfor the TensorBlock",
+            "requested gradient 'err' in ones_like is not defined in this tensor",
         )
 
 

--- a/python/tests/operations/pow.py
+++ b/python/tests/operations/pow.py
@@ -28,33 +28,33 @@ class TestPow:
 
         block_1 = TensorBlock(
             values=np.vstack([b1_s0, b1_s2]),
-            samples=Labels(["samples"], np.array([[0], [2]])),
+            samples=Labels(["s"], np.array([[0], [2]])),
             components=[],
-            properties=Labels.arange("properties", 2),
+            properties=Labels.arange("p", 2),
         )
         block_1.add_gradient(
-            "parameter",
+            "g",
             data=np.vstack([[b1grad_s01], [b1grad_s11]]),
-            samples=Labels(["sample", "positions"], np.array([[0, 1], [1, 1]])),
+            samples=Labels(["sample", "g"], np.array([[0, 1], [1, 1]])),
             components=[
-                Labels.arange("components", 2),
+                Labels.arange("c", 2),
             ],
         )
         block_2 = TensorBlock(
             values=np.vstack([b2_s0, b2_s2, b2_s7]),
-            samples=Labels(["samples"], np.array([[0], [2], [7]])),
+            samples=Labels(["s"], np.array([[0], [2], [7]])),
             components=[],
-            properties=Labels.arange("properties", 2),
+            properties=Labels.arange("p", 2),
         )
         block_2.add_gradient(
-            "parameter",
+            "g",
             data=np.vstack([[b2grad_s01], [b2grad_s11], [b2grad_s21]]),
             samples=Labels(
-                ["sample", "positions"],
+                ["sample", "g"],
                 np.array([[0, 1], [1, 1], [2, 1]]),
             ),
             components=[
-                Labels.arange("components", 2),
+                Labels.arange("c", 2),
             ],
         )
 
@@ -68,31 +68,31 @@ class TestPow:
 
         block_res1 = TensorBlock(
             values=rvalues1,
-            samples=Labels(["samples"], np.array([[0], [2]])),
+            samples=Labels(["s"], np.array([[0], [2]])),
             components=[],
-            properties=Labels.arange("properties", 2),
+            properties=Labels.arange("p", 2),
         )
         block_res1.add_gradient(
-            "parameter",
+            "g",
             data=np.vstack(
                 [
                     [B * b1grad_s01 * (b1_s0 ** (B - 1))],
                     [B * b1grad_s11 * (b1_s2 ** (B - 1))],
                 ]
             ),
-            samples=Labels(["sample", "positions"], np.array([[0, 1], [1, 1]])),
+            samples=Labels(["sample", "g"], np.array([[0, 1], [1, 1]])),
             components=[
-                Labels.arange("components", 2),
+                Labels.arange("c", 2),
             ],
         )
         block_res2 = TensorBlock(
             values=rvalues2,
-            samples=Labels(["samples"], np.array([[0], [2], [7]])),
+            samples=Labels(["s"], np.array([[0], [2], [7]])),
             components=[],
-            properties=Labels.arange("properties", 2),
+            properties=Labels.arange("p", 2),
         )
         block_res2.add_gradient(
-            "parameter",
+            "g",
             data=np.vstack(
                 [
                     [B * b2grad_s01 * (b2_s0 ** (B - 1))],
@@ -101,11 +101,11 @@ class TestPow:
                 ]
             ),
             samples=Labels(
-                ["sample", "positions"],
+                ["sample", "g"],
                 np.array([[0, 1], [1, 1], [2, 1]]),
             ),
             components=[
-                Labels.arange("components", 2),
+                Labels.arange("c", 2),
             ],
         )
 
@@ -139,16 +139,16 @@ class TestPow:
                     [[[b1_s0_c00], [b1_s2_c01]], [[b1_s0_c10], [b1_s2_c11]]],
                 ]
             ),
-            samples=Labels(["samples"], np.array([[0], [2]])),
+            samples=Labels(["s"], np.array([[0], [2]])),
             components=[
                 Labels.arange("components_1", 2),
                 Labels(["component2"], np.array([[0]])),
             ],
-            properties=Labels.arange("properties", 2),
+            properties=Labels.arange("p", 2),
         )
 
         block_1.add_gradient(
-            "parameter",
+            "g",
             data=np.vstack(
                 [
                     [
@@ -163,7 +163,7 @@ class TestPow:
                     ],
                 ]
             ),
-            samples=Labels(["sample", "positions"], np.array([[0, 1], [1, 1]])),
+            samples=Labels(["sample", "g"], np.array([[0, 1], [1, 1]])),
             components=[
                 Labels.arange("grad_components", 2),
                 Labels.arange("components_1", 2),
@@ -179,15 +179,15 @@ class TestPow:
 
         block_res1 = TensorBlock(
             values=rvalues1,
-            samples=Labels(["samples"], np.array([[0], [2]])),
+            samples=Labels(["s"], np.array([[0], [2]])),
             components=[
                 Labels.arange("components_1", 2),
                 Labels(["component2"], np.array([[0]])),
             ],
-            properties=Labels.arange("properties", 2),
+            properties=Labels.arange("p", 2),
         )
         block_res1.add_gradient(
-            "parameter",
+            "g",
             data=np.vstack(
                 [
                     [
@@ -216,7 +216,7 @@ class TestPow:
                     ],
                 ]
             ),
-            samples=Labels(["sample", "positions"], np.array([[0, 1], [1, 1]])),
+            samples=Labels(["sample", "g"], np.array([[0, 1], [1, 1]])),
             components=[
                 Labels.arange("grad_components", 2),
                 Labels.arange("components_1", 2),
@@ -251,33 +251,33 @@ class TestPow:
 
         block_1 = TensorBlock(
             values=np.vstack([b1_s0, b1_s2]),
-            samples=Labels(["samples"], np.array([[0], [2]])),
+            samples=Labels(["s"], np.array([[0], [2]])),
             components=[],
-            properties=Labels.arange("properties", 2),
+            properties=Labels.arange("p", 2),
         )
         block_1.add_gradient(
-            "parameter",
+            "g",
             data=np.vstack([[b1grad_s01], [b1grad_s11]]),
-            samples=Labels(["sample", "positions"], np.array([[0, 1], [1, 1]])),
+            samples=Labels(["sample", "g"], np.array([[0, 1], [1, 1]])),
             components=[
-                Labels.arange("components", 2),
+                Labels.arange("c", 2),
             ],
         )
         block_2 = TensorBlock(
             values=np.vstack([b2_s0, b2_s2, b2_s7]),
-            samples=Labels(["samples"], np.array([[0], [2], [7]])),
+            samples=Labels(["s"], np.array([[0], [2], [7]])),
             components=[],
-            properties=Labels.arange("properties", 2),
+            properties=Labels.arange("p", 2),
         )
         block_2.add_gradient(
-            "parameter",
+            "g",
             data=np.vstack([[b2grad_s01], [b2grad_s11], [b2grad_s21]]),
             samples=Labels(
-                ["sample", "positions"],
+                ["sample", "g"],
                 np.array([[0, 1], [1, 1], [2, 1]]),
             ),
             components=[
-                Labels.arange("components", 2),
+                Labels.arange("c", 2),
             ],
         )
 
@@ -290,31 +290,31 @@ class TestPow:
 
         block_res1 = TensorBlock(
             values=rvalues1,
-            samples=Labels(["samples"], np.array([[0], [2]])),
+            samples=Labels(["s"], np.array([[0], [2]])),
             components=[],
-            properties=Labels.arange("properties", 2),
+            properties=Labels.arange("p", 2),
         )
         block_res1.add_gradient(
-            "parameter",
+            "g",
             data=np.vstack(
                 [
                     [B * b1grad_s01 * (b1_s0 ** (B - 1))],
                     [B * b1grad_s11 * (b1_s2 ** (B - 1))],
                 ]
             ),
-            samples=Labels(["sample", "positions"], np.array([[0, 1], [1, 1]])),
+            samples=Labels(["sample", "g"], np.array([[0, 1], [1, 1]])),
             components=[
-                Labels.arange("components", 2),
+                Labels.arange("c", 2),
             ],
         )
         block_res2 = TensorBlock(
             values=rvalues2,
-            samples=Labels(["samples"], np.array([[0], [2], [7]])),
+            samples=Labels(["s"], np.array([[0], [2], [7]])),
             components=[],
-            properties=Labels.arange("properties", 2),
+            properties=Labels.arange("p", 2),
         )
         block_res2.add_gradient(
-            "parameter",
+            "g",
             data=np.vstack(
                 [
                     [B * b2grad_s01 * (b2_s0 ** (B - 1))],
@@ -323,11 +323,11 @@ class TestPow:
                 ]
             ),
             samples=Labels(
-                ["sample", "positions"],
+                ["sample", "g"],
                 np.array([[0, 1], [1, 1], [2, 1]]),
             ),
             components=[
-                Labels.arange("components", 2),
+                Labels.arange("c", 2),
             ],
         )
 
@@ -345,9 +345,9 @@ class TestPow:
     def test_self_pow_error(self):
         block_1 = TensorBlock(
             values=np.array([[1, 2], [3, 5]]),
-            samples=Labels(["samples"], np.array([[0], [2]])),
+            samples=Labels(["s"], np.array([[0], [2]])),
             components=[],
-            properties=Labels.arange("properties", 2),
+            properties=Labels.arange("p", 2),
         )
         keys = Labels(names=["key_1", "key_2"], values=np.array([[0, 0]]))
         A = TensorMap(keys, [block_1])

--- a/python/tests/operations/random_like.py
+++ b/python/tests/operations/random_like.py
@@ -9,60 +9,44 @@ import equistore
 DATA_ROOT = os.path.join(os.path.dirname(__file__), "..", "data")
 
 
-class TestRandomLike:
-    @pytest.fixture
-    def tensor(self):
-        tensor = equistore.load(
-            os.path.join(DATA_ROOT, "qm7-power-spectrum.npz"),
-            # the npz is using DEFLATE compression, equistore only supports STORED
-            use_numpy=True,
-        )
-        return tensor
+def test_random_uniform_like():
+    tensor = equistore.load(
+        os.path.join(DATA_ROOT, "qm7-spherical-expansion.npz"),
+        # the npz is using DEFLATE compression, equistore only supports STORED
+        use_numpy=True,
+    )
+    random_tensor = equistore.random_uniform_like(tensor)
+    random_tensor_positions = equistore.random_uniform_like(
+        tensor, gradients="positions"
+    )
 
-    @pytest.fixture
-    def tensor_positions(self, tensor):
-        tensor_positions = equistore.remove_gradients(tensor, "cell")
-        return tensor_positions
+    assert equistore.equal_metadata(random_tensor, tensor)
 
-    def test_random_uniform_like_nocomponent(self, tensor):
-        rand_tensor = equistore.random_uniform_like(tensor)
-        assert equistore.equal_metadata(tensor, rand_tensor)
+    tensor_no_cell = equistore.remove_gradients(tensor, "cell")
+    assert equistore.equal_metadata(random_tensor_positions, tensor_no_cell)
 
-        for _, rand_block in rand_tensor:
-            assert np.all(rand_block.values >= 0)
-            assert np.all(rand_block.values <= 1)
-            for _, rand_gradient in rand_block.gradients():
-                assert np.all(rand_gradient.data >= 0)
-                assert np.all(rand_gradient.data <= 1)
+    # check the values
+    for _, random_block in random_tensor:
+        assert np.all(random_block.values >= 0)
+        assert np.all(random_block.values < 1)
 
-    def test_random_uniform_like_component(self, tensor, tensor_positions):
-        rand_tensor = equistore.random_uniform_like(tensor)
-        rand_tensor_positions = equistore.random_uniform_like(
-            tensor, parameters="positions"
-        )
+        for _, random_gradient in random_block.gradients():
+            assert np.all(random_gradient.data >= 0)
+            assert np.all(random_gradient.data < 1)
 
-        assert equistore.equal_metadata(tensor, rand_tensor)
-        assert equistore.equal_metadata(tensor_positions, rand_tensor_positions)
 
-        for key, rand_block in rand_tensor:
-            rand_block_pos = rand_tensor_positions.block(key)
-            assert np.all(rand_block.values >= 0)
-            assert np.all(rand_block.values <= 1)
-            assert np.all(rand_block_pos.values >= 0)
-            assert np.all(rand_block_pos.values <= 1)
-            for _, rand_gradient in rand_block.gradients():
-                assert np.all(rand_gradient.data >= 0)
-                assert np.all(rand_gradient.data <= 1)
-            for _, rand_gradient_pos in rand_block_pos.gradients():
-                assert np.all(rand_gradient_pos.data >= 0)
-                assert np.all(rand_gradient_pos.data <= 1)
+def test_random_uniform_like_error():
+    tensor = equistore.load(
+        os.path.join(DATA_ROOT, "qm7-spherical-expansion.npz"),
+        # the npz is using DEFLATE compression, equistore only supports STORED
+        use_numpy=True,
+    )
 
-    def test_random_uniform_like_error(self, tensor):
-        msg = (
-            "requested gradient 'err' in random_uniform_like "
-            "is not defined in this tensor"
-        )
-        with pytest.raises(ValueError, match=msg):
-            tensor = equistore.random_uniform_like(
-                tensor, parameters=["positions", "err"]
-            )
+    message = (
+        "requested gradient 'err' in random_uniform_like is not defined in this tensor"
+    )
+    with pytest.raises(ValueError, match=message):
+        tensor = equistore.random_uniform_like(tensor, gradients=["positions", "err"])
+
+
+# TODO: add tests with torch & torch scripting/tracing

--- a/python/tests/operations/random_like.py
+++ b/python/tests/operations/random_like.py
@@ -59,8 +59,8 @@ class TestRandomLike:
 
     def test_random_uniform_like_error(self, tensor):
         msg = (
-            "The requested parameter 'err' in random_uniform_like_block "
-            + "is not a valid parameterfor the TensorBlock"
+            "requested gradient 'err' in random_uniform_like "
+            "is not defined in this tensor"
         )
         with pytest.raises(ValueError, match=msg):
             tensor = equistore.random_uniform_like(

--- a/python/tests/operations/reduce_over_samples.py
+++ b/python/tests/operations/reduce_over_samples.py
@@ -169,7 +169,7 @@ class TestSumSamples(unittest.TestCase):
                 ),
             ),
             components=[],
-            properties=Labels(["properties"], np.array([[0], [1], [5]])),
+            properties=Labels(["p"], np.array([[0], [1], [5]])),
         )
 
         keys = Labels(names=["key_1", "key_2"], values=np.array([[0, 0]]))
@@ -428,7 +428,7 @@ class TestMeanSamples(unittest.TestCase):
                 ),
             ),
             components=[],
-            properties=Labels(["properties"], np.array([[0], [1], [5]])),
+            properties=Labels(["p"], np.array([[0], [1], [5]])),
         )
 
         keys = Labels(names=["key_1", "key_2"], values=np.array([[0, 0]]))
@@ -527,17 +527,17 @@ class TestReductionAllSamples(unittest.TestCase):
                     [-1.3, 26.7, 4.54],
                 ]
             ),
-            samples=Labels.arange("samples", 3),
+            samples=Labels.arange("s", 3),
             components=[],
-            properties=Labels(["properties"], np.array([[0], [1], [5]])),
+            properties=Labels(["p"], np.array([[0], [1], [5]])),
         )
         keys = Labels(names=["key_1", "key_2"], values=np.array([[0, 0]]))
         X = TensorMap(keys, [block_1])
 
-        sum_X = equistore.sum_over_samples(X, sample_names=["samples"])
-        mean_X = equistore.mean_over_samples(X, sample_names=["samples"])
-        var_X = equistore.var_over_samples(X, sample_names=["samples"])
-        std_X = equistore.std_over_samples(X, sample_names=["samples"])
+        sum_X = equistore.sum_over_samples(X, sample_names=["s"])
+        mean_X = equistore.mean_over_samples(X, sample_names=["s"])
+        var_X = equistore.var_over_samples(X, sample_names=["s"])
+        std_X = equistore.std_over_samples(X, sample_names=["s"])
 
         self.assertTrue(equistore.equal_metadata(sum_X, mean_X))
         self.assertTrue(equistore.equal_metadata(sum_X, std_X))
@@ -742,7 +742,7 @@ class TestStdSamples(unittest.TestCase):
                 ]
             ),
             samples=Labels(
-                ["samples1", "samples2", "samples3"],
+                ["s_1", "s_2", "s_3"],
                 np.array(
                     [
                         [0, 0, 0],
@@ -757,17 +757,15 @@ class TestStdSamples(unittest.TestCase):
                 ),
             ),
             components=[],
-            properties=Labels(["properties"], np.array([[0], [1], [5]])),
+            properties=Labels(["p"], np.array([[0], [1], [5]])),
         )
 
         keys = Labels(names=["key_1", "key_2"], values=np.array([[0, 0]]))
         X = TensorMap(keys, [block_1])
 
-        reduce_X_12 = equistore.std_over_samples(X, sample_names=["samples3"])
-        reduce_X_23 = equistore.std_over_samples(X, sample_names="samples1")
-        reduce_X_2 = equistore.std_over_samples(
-            X, sample_names=["samples1", "samples3"]
-        )
+        reduce_X_12 = equistore.std_over_samples(X, sample_names=["s_3"])
+        reduce_X_23 = equistore.std_over_samples(X, sample_names="s_1")
+        reduce_X_2 = equistore.std_over_samples(X, sample_names=["s_1", "s_3"])
 
         self.assertTrue(
             np.all(
@@ -832,15 +830,15 @@ class TestStdSamples(unittest.TestCase):
         self.assertTrue(np.all(reduce_X_2.block(0).properties == X.block(0).properties))
 
         samples_12 = Labels(
-            names=["samples1", "samples2"],
+            names=["s_1", "s_2"],
             values=np.array([[0, 0], [0, 1], [1, 0], [1, 1], [2, 1]]),
         )
         samples_23 = Labels(
-            names=["samples2", "samples3"],
+            names=["s_2", "s_3"],
             values=np.array([[0, 0], [0, 1], [0, 2], [1, 0], [1, 1]]),
         )
         samples_2 = Labels(
-            names=["samples2"],
+            names=["s_2"],
             values=np.array([[0], [1]]),
         )
         self.assertTrue(np.all(reduce_X_12.block(0).samples == samples_12))
@@ -850,27 +848,25 @@ class TestStdSamples(unittest.TestCase):
     def test_reduction_of_one_element(self):
         block_1 = TensorBlock(
             values=np.array([[1, 2, 4], [3, 5, 6], [-1.3, 26.7, 4.54]]),
-            samples=Labels(
-                ["samples1", "samples2"], np.array([[0, 0], [1, 1], [2, 2]])
-            ),
+            samples=Labels(["s_1", "s_2"], np.array([[0, 0], [1, 1], [2, 2]])),
             components=[],
-            properties=Labels(["properties"], np.array([[0], [1], [5]])),
+            properties=Labels(["p"], np.array([[0], [1], [5]])),
         )
 
         block_1.add_gradient(
-            parameter="parameter",
+            parameter="g",
             data=np.array([[1, 2, 3], [3, 4, 5], [5, 6, 7.8]]),
-            samples=Labels(["sample", "samples2"], np.array([[0, 0], [1, 1], [2, 2]])),
+            samples=Labels(["sample", "g"], np.array([[0, 0], [1, 1], [2, 2]])),
             components=[],
         )
 
         keys = Labels(names=["key_1"], values=np.array([[0]]))
         X = TensorMap(keys, [block_1])
 
-        add_X = equistore.sum_over_samples(X, sample_names=["samples1"])
-        mean_X = equistore.mean_over_samples(X, sample_names=["samples1"])
-        var_X = equistore.var_over_samples(X, sample_names=["samples1"])
-        std_X = equistore.std_over_samples(X, sample_names=["samples1"])
+        add_X = equistore.sum_over_samples(X, sample_names=["s_1"])
+        mean_X = equistore.mean_over_samples(X, sample_names=["s_1"])
+        var_X = equistore.var_over_samples(X, sample_names=["s_1"])
+        std_X = equistore.std_over_samples(X, sample_names=["s_1"])
 
         # print(add_X[0])
         # print(X[0].values, add_X[0].values)
@@ -885,41 +881,29 @@ class TestStdSamples(unittest.TestCase):
 
         # Gradients
         grad_sample_label = Labels(
-            names=["sample", "samples2"],
+            names=["sample", "g"],
             values=np.array([[0, 0], [1, 1], [2, 2]]),
         )
-        self.assertTrue(
-            std_X[0].gradient("parameter").samples.names == grad_sample_label.names
-        )
-        self.assertTrue(
-            np.all(std_X[0].gradient("parameter").samples == grad_sample_label)
-        )
-        self.assertTrue(
-            np.all(
-                X[0].gradient("parameter").data == add_X[0].gradient("parameter").data
-            )
-        )
-        self.assertTrue(
-            np.all(
-                X[0].gradient("parameter").data == mean_X[0].gradient("parameter").data
-            )
-        )
-        self.assertTrue(np.all(np.zeros((3, 3)) == std_X[0].gradient("parameter").data))
-        self.assertTrue(np.all(np.zeros((3, 3)) == var_X[0].gradient("parameter").data))
+        self.assertTrue(std_X[0].gradient("g").samples.names == grad_sample_label.names)
+        self.assertTrue(np.all(std_X[0].gradient("g").samples == grad_sample_label))
+        self.assertTrue(np.all(X[0].gradient("g").data == add_X[0].gradient("g").data))
+        self.assertTrue(np.all(X[0].gradient("g").data == mean_X[0].gradient("g").data))
+        self.assertTrue(np.all(np.zeros((3, 3)) == std_X[0].gradient("g").data))
+        self.assertTrue(np.all(np.zeros((3, 3)) == var_X[0].gradient("g").data))
 
 
 class TestZeroSamples(unittest.TestCase):
     def test_zeros_sample_block(self):
         block = TensorBlock(
             values=np.zeros([0, 1]),
-            properties=Labels(["prop"], np.zeros([1, 1], dtype=int)),
-            samples=Labels(["structure"], np.empty((0, 1))),
+            properties=Labels(["p"], np.zeros([1, 1], dtype=int)),
+            samples=Labels(["s"], np.empty((0, 1))),
             components=[],
         )
 
         result_block = TensorBlock(
             values=np.zeros([0, 1]),
-            properties=Labels(["prop"], np.zeros([1, 1], dtype=int)),
+            properties=Labels(["p"], np.zeros([1, 1], dtype=int)),
             samples=Labels([], np.empty((0, 0))),
             components=[],
         )
@@ -927,10 +911,10 @@ class TestZeroSamples(unittest.TestCase):
         tensor = TensorMap(Labels.single(), [block])
         result_tensor = TensorMap(Labels.single(), [result_block])
 
-        tensor_sum = equistore.sum_over_samples(tensor, "structure")
-        tensor_mean = equistore.mean_over_samples(tensor, "structure")
-        tensor_std = equistore.std_over_samples(tensor, "structure")
-        tensor_var = equistore.var_over_samples(tensor, "structure")
+        tensor_sum = equistore.sum_over_samples(tensor, "s")
+        tensor_mean = equistore.mean_over_samples(tensor, "s")
+        tensor_std = equistore.std_over_samples(tensor, "s")
+        tensor_var = equistore.var_over_samples(tensor, "s")
 
         self.assertTrue(equistore.equal(result_tensor, tensor_sum))
         self.assertTrue(equistore.equal(result_tensor, tensor_mean))
@@ -939,25 +923,25 @@ class TestZeroSamples(unittest.TestCase):
 
         block = TensorBlock(
             values=np.zeros([0, 1]),
-            properties=Labels(["prop"], np.zeros([1, 1], dtype=int)),
-            samples=Labels(["structure", "s1"], np.empty((0, 1))),
+            properties=Labels(["p"], np.zeros([1, 1], dtype=int)),
+            samples=Labels(["s_1", "s_2"], np.empty((0, 1))),
             components=[],
         )
 
         result_block = TensorBlock(
             values=np.zeros([0, 1]),
-            properties=Labels(["prop"], np.zeros([1, 1], dtype=int)),
-            samples=Labels(["s1"], np.empty((0, 1))),
+            properties=Labels(["p"], np.zeros([1, 1], dtype=int)),
+            samples=Labels(["s_2"], np.empty((0, 1))),
             components=[],
         )
 
         tensor = TensorMap(Labels.single(), [block])
         result_tensor = TensorMap(Labels.single(), [result_block])
 
-        tensor_sum = equistore.sum_over_samples(tensor, "structure")
-        tensor_mean = equistore.mean_over_samples(tensor, "structure")
-        tensor_std = equistore.std_over_samples(tensor, "structure")
-        tensor_var = equistore.var_over_samples(tensor, "structure")
+        tensor_sum = equistore.sum_over_samples(tensor, "s_1")
+        tensor_mean = equistore.mean_over_samples(tensor, "s_1")
+        tensor_std = equistore.std_over_samples(tensor, "s_1")
+        tensor_var = equistore.var_over_samples(tensor, "s_1")
 
         self.assertTrue(equistore.equal(result_tensor, tensor_sum))
         self.assertTrue(equistore.equal(result_tensor, tensor_mean))
@@ -970,48 +954,41 @@ class TestZeroSamples(unittest.TestCase):
                 [[1, 2, 4], [3, 5, 6], [-1.3, 26.7, 4.54], [3.5, 5.3, 6.87]]
             ),
             samples=Labels(
-                ["structure", "samples1"],
-                np.array(
-                    [
-                        [0, 0],
-                        [0, 1],
-                        [1, 0],
-                        [1, 1],
-                    ]
-                ),
+                ["s_1", "s_2"],
+                np.array([[0, 0], [0, 1], [1, 0], [1, 1]]),
             ),
             components=[],
-            properties=Labels(["properties"], np.array([[0], [1], [5]])),
+            properties=Labels(["p"], np.array([[0], [1], [5]])),
         )
 
         block.add_gradient(
-            parameter="positions",
+            parameter="g",
             data=np.zeros((0, 3)),
-            samples=Labels(["sample", "structure", "atom"], np.empty((0, 3))),
+            samples=Labels(["sample", "g"], np.empty((0, 3))),
             components=[],
         )
 
         sum_block = TensorBlock(
             values=np.array([[-0.3, 28.7, 8.54], [6.5, 10.3, 12.87]]),
-            samples=Labels.arange("samples1", 2),
+            samples=Labels.arange("s_2", 2),
             components=[],
-            properties=Labels(["properties"], np.array([[0], [1], [5]])),
+            properties=Labels(["p"], np.array([[0], [1], [5]])),
         )
 
         sum_block.add_gradient(
-            parameter="positions",
+            parameter="g",
             data=np.zeros((0, 3)),
-            samples=Labels(["sample", "structure", "atom"], np.empty((0, 3))),
+            samples=Labels(["sample", "g"], np.empty((0, 3))),
             components=[],
         )
 
         tensor = TensorMap(Labels.single(), [block])
         tensor_sum_result = TensorMap(Labels.single(), [sum_block])
 
-        tensor_sum = equistore.sum_over_samples(tensor, "structure")
-        tensor_mean = equistore.mean_over_samples(tensor, "structure")
-        tensor_std = equistore.std_over_samples(tensor, "structure")
-        tensor_var = equistore.var_over_samples(tensor, "structure")
+        tensor_sum = equistore.sum_over_samples(tensor, "s_1")
+        tensor_mean = equistore.mean_over_samples(tensor, "s_1")
+        tensor_std = equistore.std_over_samples(tensor, "s_1")
+        tensor_var = equistore.var_over_samples(tensor, "s_1")
 
         self.assertTrue(equistore.allclose(tensor_sum_result, tensor_sum, atol=1e-14))
         self.assertTrue(equistore.equal_metadata(tensor_sum, tensor_mean))

--- a/python/tests/operations/slice.py
+++ b/python/tests/operations/slice.py
@@ -148,7 +148,7 @@ def _check_sliced_block_properties(block, sliced_block, radial_to_keep):
 def _check_empty_block(block, sliced_block, axis):
     # Define the axis that should be sliced to zero (axis1)
     # and the one that should not be sliced (axis2)
-    if axis == "samples":
+    if axis == "s":
         sliced_axis, unsliced_axis = 0, -1
     else:
         sliced_axis, unsliced_axis = -1, 0
@@ -162,7 +162,7 @@ def _check_empty_block(block, sliced_block, axis):
     for parameter, gradient in block.gradients():
         sliced_gradient = sliced_block.gradient(parameter)
         # no slicing of samples has occurred
-        if axis == "samples":
+        if axis == "s":
             assert np.all(sliced_gradient.properties == gradient.properties)
         else:
             assert np.all(sliced_gradient.samples == gradient.samples)
@@ -202,7 +202,7 @@ def test_slice_block_samples(tensor):
         labels=samples,
     )
 
-    _check_empty_block(block, sliced_block, "samples")
+    _check_empty_block(block, sliced_block, "s")
 
 
 def test_slice_samples(tensor):
@@ -240,7 +240,7 @@ def test_slice_samples(tensor):
 
     for _, block in sliced_tensor:
         # all blocks are empty
-        _check_empty_block(block, sliced_tensor.block(key), "samples")
+        _check_empty_block(block, sliced_tensor.block(key), "s")
 
 
 # ===== Tests for slicing along properties =====
@@ -275,7 +275,7 @@ def test_slice_block_properties(tensor):
         labels=properties,
     )
 
-    _check_empty_block(block, sliced_block, "properties")
+    _check_empty_block(block, sliced_block, "p")
 
 
 def test_slice_properties(tensor):
@@ -314,7 +314,7 @@ def test_slice_properties(tensor):
 
     for key, block in tensor:
         sliced_block = sliced_tensor.block(key)
-        _check_empty_block(block, sliced_block, "properties")
+        _check_empty_block(block, sliced_block, "p")
 
 
 # ===== Tests slicing both samples and properties =====

--- a/python/tests/operations/solve.py
+++ b/python/tests/operations/solve.py
@@ -14,27 +14,27 @@ class TestSolve(unittest.TestCase):
     def test_self_solve_nograd(self):
         block_1 = TensorBlock(
             values=np.array([[1, 2], [3, 5]]),
-            samples=Labels(["samples"], np.array([[0], [2]])),
+            samples=Labels(["s"], np.array([[0], [2]])),
             components=[],
-            properties=Labels.arange("properties", 2),
+            properties=Labels.arange("p", 2),
         )
         block_2 = TensorBlock(
             values=np.array([[1, 2], [3, 5]]),
-            samples=Labels(["samples"], np.array([[0], [2]])),
+            samples=Labels(["s"], np.array([[0], [2]])),
             components=[],
-            properties=Labels.arange("properties", 2),
+            properties=Labels.arange("p", 2),
         )
         block_3 = TensorBlock(
             values=np.array([[1], [2]]),
-            samples=Labels(["samples"], np.array([[0], [2]])),
+            samples=Labels(["s"], np.array([[0], [2]])),
             components=[],
-            properties=Labels(["properties"], np.array([[0]])),
+            properties=Labels(["p"], np.array([[0]])),
         )
         block_4 = TensorBlock(
             values=np.array([[2], [4]]),
-            samples=Labels(["samples"], np.array([[0], [2]])),
+            samples=Labels(["s"], np.array([[0], [2]])),
             components=[],
-            properties=Labels(["properties"], np.array([[0]])),
+            properties=Labels(["p"], np.array([[0]])),
         )
         keys = Labels(names=["key_1", "key_2"], values=np.array([[0, 0], [1, 0]]))
         X = TensorMap(keys, [block_1, block_2])

--- a/python/tests/operations/split.py
+++ b/python/tests/operations/split.py
@@ -42,8 +42,10 @@ class TestSplitSamples(unittest.TestCase):
         # Checks on each split block
         for i, split_block in enumerate(split_blocks):
             # Check samples indices
-            target_idxs = _searchable_labels(grouped_labels[i])
-            actual_idxs = _unique_indices(split_block, "samples", target_names)
+            target_idxs = grouped_labels[i]
+            actual_idxs = _unique_indices(
+                split_block, axis="samples", names=target_names
+            )
             self.assertTrue(_labels_equal(actual_idxs, target_idxs, exact_order=False))
             # No properties split
             self.assertEqual(len(split_block.properties), p_size)
@@ -52,10 +54,7 @@ class TestSplitSamples(unittest.TestCase):
                 self.assertEqual(len(split_block.components[c_i]), c_size)
             # Equal values tensor
             samples_filter = np.array(
-                [
-                    s in _searchable_labels(grouped_labels[i])
-                    for s in block.samples[target_names]
-                ]
+                [s in grouped_labels[i] for s in block.samples[target_names]]
             )
             self.assertTrue(
                 np.all(split_block.values == block.values[samples_filter, ...])
@@ -119,7 +118,9 @@ class TestSplitSamples(unittest.TestCase):
         self.assertEqual(len(split_tensors), len(grouped_labels))
         # Number of unique idxs in each tensor equal to respective group size
         for i, tensor in enumerate(split_tensors):
-            unique_idxs = _unique_indices(tensor, "samples", grouped_labels[i].names)
+            unique_idxs = _unique_indices(
+                tensor, axis="samples", names=grouped_labels[i].names
+            )
             self.assertEqual(len(unique_idxs), len(grouped_labels[i]))
 
     def _check_empty_tensor(self, tensor, split_tensor):
@@ -138,7 +139,9 @@ class TestSplitSamples(unittest.TestCase):
             Labels(names=["structure"], values=np.array([[2], [3], [4]])),
             Labels(names=["structure"], values=np.array([[1], [5], [8], [9]])),
         ]
-        split_blocks = equistore.split_block(block, "samples", grouped_labels)
+        split_blocks = equistore.split_block(
+            block, axis="samples", grouped_labels=grouped_labels
+        )
         self.assertEqual(
             np.sum([len(b.samples) for b in split_blocks]), len(block.samples)
         )
@@ -151,7 +154,9 @@ class TestSplitSamples(unittest.TestCase):
             Labels(names=["structure"], values=np.array([[4], [6]])),
             Labels(names=["structure"], values=np.array([[5]])),
         ]
-        split_blocks = equistore.split_block(block, "samples", grouped_labels)
+        split_blocks = equistore.split_block(
+            block, axis="samples", grouped_labels=grouped_labels
+        )
         self.assertEqual(
             np.sum([len(b.samples) for b in split_blocks]), len(block.samples)
         )
@@ -162,7 +167,9 @@ class TestSplitSamples(unittest.TestCase):
             Labels(names=["structure"], values=np.array([[4], [6]])),  # present
             Labels(names=["structure"], values=np.array([[5]])),  # present
         ]
-        split_blocks = equistore.split_block(block, "samples", grouped_labels_empty)
+        split_blocks = equistore.split_block(
+            block, axis="samples", grouped_labels=grouped_labels_empty
+        )
         self._check_split_blocks(block, split_blocks[1:], grouped_labels_empty[1:])
         self._check_empty_block(block, split_blocks[0])
 
@@ -173,7 +180,11 @@ class TestSplitSamples(unittest.TestCase):
             Labels(names=["structure"], values=np.array([[2], [3], [4]])),
             Labels(names=["structure"], values=np.array([[1], [5], [8], [9]])),
         ]
-        split_tensors = equistore.split(self.tensor, "samples", grouped_labels)
+        split_tensors = equistore.split(
+            self.tensor,
+            axis="samples",
+            grouped_labels=grouped_labels,
+        )
         self._check_num_blocks_tensor(split_tensors)
         self._check_group_sizes_tensors(split_tensors, grouped_labels)
         # Third returned tensor should be empty
@@ -184,7 +195,11 @@ class TestSplitSamples(unittest.TestCase):
                 names=["structure"], values=np.array([[1], [5], [8], [9]]) * -1
             ),  # not present
         ]
-        split_tensors = equistore.split(self.tensor, "samples", grouped_labels)
+        split_tensors = equistore.split(
+            self.tensor,
+            axis="samples",
+            grouped_labels=grouped_labels,
+        )
         self._check_num_blocks_tensor(split_tensors)
         self._check_group_sizes_tensors(split_tensors[:2], grouped_labels[:2])
         self._check_empty_tensor(self.tensor, split_tensors[2])
@@ -199,7 +214,9 @@ class TestSplitSamples(unittest.TestCase):
             Labels(names=["structure"], values=np.array([[2], [6], [4]])),
             Labels(names=["structure"], values=np.array([[1], [0], [6], [4]])),
         ]
-        split_blocks = equistore.split_block(block, "samples", grouped_labels)
+        split_blocks = equistore.split_block(
+            block, axis="samples", grouped_labels=grouped_labels
+        )
         self._check_split_blocks(block, split_blocks, grouped_labels)
 
     def test_no_splitting(self):
@@ -246,8 +263,10 @@ class TestSplitProperties(unittest.TestCase):
         # Checks on each split block
         for i, split_block in enumerate(split_blocks):
             # Check properties indices
-            target_idxs = _searchable_labels(grouped_labels[i])
-            actual_idxs = _unique_indices(split_block, "properties", target_names)
+            target_idxs = grouped_labels[i]
+            actual_idxs = _unique_indices(
+                split_block, axis="properties", names=target_names
+            )
             self.assertTrue(_labels_equal(actual_idxs, target_idxs, exact_order=False))
             # No samples split
             self.assertEqual(len(split_block.samples), s_size)
@@ -256,10 +275,7 @@ class TestSplitProperties(unittest.TestCase):
                 self.assertEqual(len(split_block.components[c_i]), c_size)
             # Equal values tensor
             properties_filter = np.array(
-                [
-                    p in _searchable_labels(grouped_labels[i])
-                    for p in block.properties[target_names]
-                ]
+                [p in grouped_labels[i] for p in block.properties[target_names]]
             )
             self.assertTrue(
                 np.all(split_block.values == block.values[..., properties_filter])
@@ -324,7 +340,9 @@ class TestSplitProperties(unittest.TestCase):
         self.assertEqual(len(split_tensors), len(grouped_labels))
         # Number of unique idxs in each tensor equal to respective group size
         for i, tensor in enumerate(split_tensors):
-            unique_idxs = _unique_indices(tensor, "properties", grouped_labels[i].names)
+            unique_idxs = _unique_indices(
+                tensor, axis="properties", names=grouped_labels[i].names
+            )
             self.assertEqual(len(unique_idxs), len(grouped_labels[i]))
 
     def _check_empty_tensor(self, tensor, split_tensor):
@@ -343,7 +361,9 @@ class TestSplitProperties(unittest.TestCase):
             Labels(names=["l", "n2"], values=np.array([[4, 2], [4, 3], [4, 1]])),
             Labels(names=["l", "n2"], values=np.array([[3, 2], [1, 1]])),
         ]
-        split_blocks = equistore.split_block(block, "properties", grouped_labels)
+        split_blocks = equistore.split_block(
+            block, axis="properties", grouped_labels=grouped_labels
+        )
         self._check_split_blocks(block, split_blocks, grouped_labels)
         # Indices not present for last group
         grouped_labels_empty = [
@@ -357,7 +377,9 @@ class TestSplitProperties(unittest.TestCase):
                 names=["l", "n2"], values=np.array([[3, 2], [1, 1]]) * -1
             ),  # not present
         ]
-        split_blocks = equistore.split_block(block, "properties", grouped_labels_empty)
+        split_blocks = equistore.split_block(
+            block, axis="properties", grouped_labels=grouped_labels_empty
+        )
         self._check_split_blocks(block, split_blocks[:2], grouped_labels_empty[:2])
         self._check_empty_block(block, split_blocks[2])
 
@@ -368,7 +390,11 @@ class TestSplitProperties(unittest.TestCase):
             Labels(names=["l", "n2"], values=np.array([[4, 2], [4, 3], [4, 1]])),
             Labels(names=["l", "n2"], values=np.array([[3, 2], [1, 1]])),
         ]
-        split_tensors = equistore.split(self.tensor, "properties", grouped_labels)
+        split_tensors = equistore.split(
+            self.tensor,
+            axis="properties",
+            grouped_labels=grouped_labels,
+        )
         self._check_num_blocks_tensor(split_tensors)
         self._check_group_sizes_tensors(split_tensors, grouped_labels)
         # Second returned tensor should be empty
@@ -381,7 +407,11 @@ class TestSplitProperties(unittest.TestCase):
             ),  # not present
             Labels(names=["l", "n2"], values=np.array([[3, 2], [1, 1]])),  # present
         ]
-        split_tensors = equistore.split(self.tensor, "properties", grouped_labels)
+        split_tensors = equistore.split(
+            self.tensor,
+            axis="properties",
+            grouped_labels=grouped_labels,
+        )
         self._check_num_blocks_tensor(split_tensors)
         self._check_group_sizes_tensors(
             [split_tensors[0], split_tensors[2]], [grouped_labels[0], grouped_labels[2]]
@@ -429,7 +459,7 @@ class TestSplitErrors(unittest.TestCase):
         with self.assertRaises(TypeError) as cm:
             equistore.split(self.tensor, axis=3.14, grouped_labels=self.grouped_labels),
         self.assertEqual(str(cm.exception), "``axis`` should be passed as a ``str``")
-        # axis not "samples" or "properties"
+        # axis not "s" or "p"
         with self.assertRaises(ValueError) as cm:
             equistore.split(
                 self.tensor,
@@ -485,7 +515,11 @@ class TestSplitErrors(unittest.TestCase):
             ),
         ]
         with self.assertRaises(ValueError) as cm:
-            equistore.split(self.tensor, axis="samples", grouped_labels=grouped_labels),
+            equistore.split(
+                self.tensor,
+                axis="samples",
+                grouped_labels=grouped_labels,
+            )
 
         self.assertEqual(
             str(cm.exception),
@@ -511,8 +545,8 @@ def _unique_indices(
     names: Union[List[str], str],
 ):
     """
-    For a given ``axis`` (either "samples" or "properties"), and for the given
-    samples/proeprties ``names``, returns a :py:class:`Labels` object of the
+    For a given ``axis`` (either "s" or "p"), and for the given
+    samples/properties ``names``, returns a :py:class:`Labels` object of the
     unique indices in the input ``tensor``, which can be either a
     :py:class:`TensorMap` or :py:class:`TensorBlock` object.
     """
@@ -529,9 +563,11 @@ def _unique_indices(
     # Extract indices from each block
     all_idxs = []
     for block in blocks:
-        block_idxs = (
-            block.samples[names] if axis == "samples" else block.properties[names]
-        )
+        if axis == "samples":
+            block_idxs = block.samples[names]
+        else:
+            block_idxs = block.properties[names]
+
         for idx in block_idxs:
             all_idxs.append(idx)
     if len(all_idxs) == 0:  # return an empty Labels, with the correct name
@@ -542,19 +578,6 @@ def _unique_indices(
     # Define the unique indices, convert to a Labels obj, and return
     unique_idxs = np.unique(all_idxs, axis=0)  # this also sorts the idxs
     return Labels(names=names, values=np.array([[j for j in i] for i in unique_idxs]))
-
-
-def _searchable_labels(labels: Labels):
-    """
-    Returns the input Labels object but after being used to construct a
-    TensorBlock, so that look-ups can be performed.
-    """
-    return TensorBlock(
-        values=np.full((len(labels), 1), 0.0),
-        samples=labels,
-        components=[],
-        properties=Labels(["p"], np.array([[0]])),
-    ).samples
 
 
 if __name__ == "__main__":

--- a/python/tests/operations/subtract.py
+++ b/python/tests/operations/subtract.py
@@ -14,40 +14,40 @@ class TestSubtract(unittest.TestCase):
     def test_self_subtract_tensors_nogradient(self):
         block_1 = TensorBlock(
             values=np.array([[1, 2], [3, 5]]),
-            samples=Labels(["samples"], np.array([[0], [2]])),
+            samples=Labels(["s"], np.array([[0], [2]])),
             components=[],
-            properties=Labels.arange("properties", 2),
+            properties=Labels.arange("p", 2),
         )
         block_2 = TensorBlock(
             values=np.array([[1, 2], [3, 4], [5, 6]]),
-            samples=Labels(["samples"], np.array([[0], [2], [7]])),
+            samples=Labels(["s"], np.array([[0], [2], [7]])),
             components=[],
-            properties=Labels.arange("properties", 2),
+            properties=Labels.arange("p", 2),
         )
         block_3 = TensorBlock(
             values=np.array([[1.5, 2.1], [6.7, 10.2]]),
-            samples=Labels(["samples"], np.array([[0], [2]])),
+            samples=Labels(["s"], np.array([[0], [2]])),
             components=[],
-            properties=Labels.arange("properties", 2),
+            properties=Labels.arange("p", 2),
         )
         block_4 = TensorBlock(
             values=np.array([[10, 200.8], [3.76, 4.432], [545, 26]]),
-            samples=Labels(["samples"], np.array([[0], [2], [7]])),
+            samples=Labels(["s"], np.array([[0], [2], [7]])),
             components=[],
-            properties=Labels.arange("properties", 2),
+            properties=Labels.arange("p", 2),
         )
 
         block_res1 = TensorBlock(
             values=np.array([[-0.5, -0.1], [-3.7, -5.2]]),
-            samples=Labels(["samples"], np.array([[0], [2]])),
+            samples=Labels(["s"], np.array([[0], [2]])),
             components=[],
-            properties=Labels.arange("properties", 2),
+            properties=Labels.arange("p", 2),
         )
         block_res2 = TensorBlock(
             values=np.array([[-9, -198.8], [-0.76, -0.432], [-540, -20]]),
-            samples=Labels(["samples"], np.array([[0], [2], [7]])),
+            samples=Labels(["s"], np.array([[0], [2], [7]])),
             components=[],
-            properties=Labels.arange("properties", 2),
+            properties=Labels.arange("p", 2),
         )
         keys = Labels(names=["key_1", "key_2"], values=np.array([[0, 0], [1, 0]]))
         A = TensorMap(keys, [block_1, block_2])
@@ -65,61 +65,61 @@ class TestSubtract(unittest.TestCase):
     def test_self_subtract_tensors_gradient(self):
         block_1 = TensorBlock(
             values=np.array([[1, 2], [3, 5]]),
-            samples=Labels(["samples"], np.array([[0], [2]])),
+            samples=Labels(["s"], np.array([[0], [2]])),
             components=[],
-            properties=Labels.arange("properties", 2),
+            properties=Labels.arange("p", 2),
         )
         block_1.add_gradient(
-            "parameter",
+            "g",
             data=np.array([[[6, 1], [7, 2]], [[8, 3], [9, 4]]]),
-            samples=Labels(["sample", "positions"], np.array([[0, 1], [1, 1]])),
+            samples=Labels(["sample", "g"], np.array([[0, 1], [1, 1]])),
             components=[
-                Labels.arange("components", 2),
+                Labels.arange("c", 2),
             ],
         )
 
         block_2 = TensorBlock(
             values=np.array([[-1, -2], [-3, -4], [5, 6]]),
-            samples=Labels(["samples"], np.array([[0], [2], [7]])),
+            samples=Labels(["s"], np.array([[0], [2], [7]])),
             components=[],
-            properties=Labels.arange("properties", 2),
+            properties=Labels.arange("p", 2),
         )
         block_2.add_gradient(
-            "parameter",
+            "g",
             data=np.array(
                 [[[-10, -11], [-12, -13]], [[14, 15], [10, 11]], [[12, 13], [14, 15]]]
             ),
             samples=Labels(
-                ["sample", "positions"],
+                ["sample", "g"],
                 np.array([[0, 1], [1, 1], [2, 1]]),
             ),
             components=[
-                Labels.arange("components", 2),
+                Labels.arange("c", 2),
             ],
         )
 
         block_3 = TensorBlock(
             values=np.array([[1.5, 2.1], [6.7, 10.2]]),
-            samples=Labels(["samples"], np.array([[0], [2]])),
+            samples=Labels(["s"], np.array([[0], [2]])),
             components=[],
-            properties=Labels.arange("properties", 2),
+            properties=Labels.arange("p", 2),
         )
         block_3.add_gradient(
-            "parameter",
+            "g",
             data=np.array([[[-1, -0.1], [-2, -0.2]], [[-3, -0.3], [-4.5, -0.4]]]),
-            samples=Labels(["sample", "positions"], np.array([[0, 1], [1, 1]])),
+            samples=Labels(["sample", "g"], np.array([[0, 1], [1, 1]])),
             components=[
-                Labels.arange("components", 2),
+                Labels.arange("c", 2),
             ],
         )
         block_4 = TensorBlock(
             values=np.array([[10, 200.8], [3.76, 4.432], [-545, -26]]),
-            samples=Labels(["samples"], np.array([[0], [2], [7]])),
+            samples=Labels(["s"], np.array([[0], [2], [7]])),
             components=[],
-            properties=Labels.arange("properties", 2),
+            properties=Labels.arange("p", 2),
         )
         block_4.add_gradient(
-            "parameter",
+            "g",
             data=np.array(
                 [
                     [[1.0, 1.1], [1.2, 1.3]],
@@ -128,36 +128,36 @@ class TestSubtract(unittest.TestCase):
                 ]
             ),
             samples=Labels(
-                ["sample", "positions"],
+                ["sample", "g"],
                 np.array([[0, 1], [1, 1], [2, 1]]),
             ),
             components=[
-                Labels.arange("components", 2),
+                Labels.arange("c", 2),
             ],
         )
 
         block_res1 = TensorBlock(
             values=np.array([[-0.5, -0.1], [-3.7, -5.2]]),
-            samples=Labels(["samples"], np.array([[0], [2]])),
+            samples=Labels(["s"], np.array([[0], [2]])),
             components=[],
-            properties=Labels.arange("properties", 2),
+            properties=Labels.arange("p", 2),
         )
         block_res1.add_gradient(
-            "parameter",
+            "g",
             data=np.array(np.array([[[7, 1.1], [9, 2.2]], [[11, 3.3], [13.5, 4.4]]])),
-            samples=Labels(["sample", "positions"], np.array([[0, 1], [1, 1]])),
+            samples=Labels(["sample", "g"], np.array([[0, 1], [1, 1]])),
             components=[
-                Labels.arange("components", 2),
+                Labels.arange("c", 2),
             ],
         )
         block_res2 = TensorBlock(
             values=np.array([[-11, -202.8], [-6.76, -8.432], [550, 32]]),
-            samples=Labels(["samples"], np.array([[0], [2], [7]])),
+            samples=Labels(["s"], np.array([[0], [2], [7]])),
             components=[],
-            properties=Labels.arange("properties", 2),
+            properties=Labels.arange("p", 2),
         )
         block_res2.add_gradient(
-            "parameter",
+            "g",
             data=np.array(
                 [
                     [[-11.0, -12.1], [-13.2, -14.3]],
@@ -166,11 +166,11 @@ class TestSubtract(unittest.TestCase):
                 ]
             ),
             samples=Labels(
-                ["sample", "positions"],
+                ["sample", "g"],
                 np.array([[0, 1], [1, 1], [2, 1]]),
             ),
             components=[
-                Labels.arange("components", 2),
+                Labels.arange("c", 2),
             ],
         )
         keys = Labels(names=["key_1", "key_2"], values=np.array([[0, 0], [1, 0]]))
@@ -189,69 +189,69 @@ class TestSubtract(unittest.TestCase):
     def test_self_subtract_scalar_gradient(self):
         block_1 = TensorBlock(
             values=np.array([[1, 2], [3, 5]]),
-            samples=Labels(["samples"], np.array([[0], [2]])),
+            samples=Labels(["s"], np.array([[0], [2]])),
             components=[],
-            properties=Labels.arange("properties", 2),
+            properties=Labels.arange("p", 2),
         )
         block_1.add_gradient(
-            "parameter",
+            "g",
             data=np.array([[[6, 1], [7, 2]], [[8, 3], [9, 4]]]),
-            samples=Labels(["sample", "positions"], np.array([[0, 1], [1, 1]])),
+            samples=Labels(["sample", "g"], np.array([[0, 1], [1, 1]])),
             components=[
-                Labels.arange("components", 2),
+                Labels.arange("c", 2),
             ],
         )
         block_2 = TensorBlock(
             values=np.array([[11, 12], [13, 14], [15, 16]]),
-            samples=Labels(["samples"], np.array([[0], [2], [7]])),
+            samples=Labels(["s"], np.array([[0], [2], [7]])),
             components=[],
-            properties=Labels.arange("properties", 2),
+            properties=Labels.arange("p", 2),
         )
         block_2.add_gradient(
-            "parameter",
+            "g",
             data=np.array(
                 [[[10, 11], [12, 13]], [[14, 15], [10, 11]], [[12, 13], [14, 15]]]
             ),
             samples=Labels(
-                ["sample", "positions"],
+                ["sample", "g"],
                 np.array([[0, 1], [1, 1], [2, 1]]),
             ),
             components=[
-                Labels.arange("components", 2),
+                Labels.arange("c", 2),
             ],
         )
 
         block_res1 = TensorBlock(
             values=np.array([[6.1, 7.1], [8.1, 10.1]]),
-            samples=Labels(["samples"], np.array([[0], [2]])),
+            samples=Labels(["s"], np.array([[0], [2]])),
             components=[],
-            properties=Labels.arange("properties", 2),
+            properties=Labels.arange("p", 2),
         )
         block_res1.add_gradient(
-            "parameter",
+            "g",
             data=np.array([[[6, 1], [7, 2]], [[8, 3], [9, 4]]]),
-            samples=Labels(["sample", "positions"], np.array([[0, 1], [1, 1]])),
+            samples=Labels(["sample", "g"], np.array([[0, 1], [1, 1]])),
             components=[
-                Labels.arange("components", 2),
+                Labels.arange("c", 2),
             ],
         )
         block_res2 = TensorBlock(
             values=np.array([[16.1, 17.1], [18.1, 19.1], [20.1, 21.1]]),
-            samples=Labels(["samples"], np.array([[0], [2], [7]])),
+            samples=Labels(["s"], np.array([[0], [2], [7]])),
             components=[],
-            properties=Labels.arange("properties", 2),
+            properties=Labels.arange("p", 2),
         )
         block_res2.add_gradient(
-            "parameter",
+            "g",
             data=np.array(
                 [[[10, 11], [12, 13]], [[14, 15], [10, 11]], [[12, 13], [14, 15]]]
             ),
             samples=Labels(
-                ["sample", "positions"],
+                ["sample", "g"],
                 np.array([[0, 1], [1, 1], [2, 1]]),
             ),
             components=[
-                Labels.arange("components", 2),
+                Labels.arange("c", 2),
             ],
         )
 
@@ -270,9 +270,9 @@ class TestSubtract(unittest.TestCase):
     def test_self_subtract_error(self):
         block_1 = TensorBlock(
             values=np.array([[1, 2], [3, 5]]),
-            samples=Labels(["samples"], np.array([[0], [2]])),
+            samples=Labels(["s"], np.array([[0], [2]])),
             components=[],
-            properties=Labels.arange("properties", 2),
+            properties=Labels.arange("p", 2),
         )
         keys = Labels(names=["key_1", "key_2"], values=np.array([[0, 0]]))
         A = TensorMap(keys, [block_1])

--- a/python/tests/operations/unique_metadata.py
+++ b/python/tests/operations/unique_metadata.py
@@ -31,45 +31,41 @@ def real_tensor():
 
 def test_unique_metadata_block(large_tensor):
     # unique metadata along sample axis
-    target_samples = Labels(
-        names=["samples"], values=np.array([0, 1, 3]).reshape(-1, 1)
-    )
+    target_samples = Labels(names=["s"], values=np.array([0, 1, 3]).reshape(-1, 1))
     actual_samples = equistore.unique_metadata_block(
         large_tensor.block(1),
         axis="samples",
-        names="samples",
+        names="s",
     )
     assert _labels_equal(target_samples, actual_samples, exact_order=True)
 
     # unique metadata of gradient along sample axis
-    names = ["sample", "parameter"]
+    names = ["sample", "g"]
     target_samples = Labels(names=names, values=np.array([[0, -2], [0, 3], [2, -2]]))
     actual_samples = equistore.unique_metadata_block(
         large_tensor.block(1),
         axis="samples",
         names=names,
-        gradient="parameter",
+        gradient="g",
     )
     assert _labels_equal(target_samples, actual_samples, exact_order=True)
 
     # unique metadata along properties axis
     properties = [3, 4, 5]
-    target_properties = Labels(
-        names=["properties"], values=np.array([[p] for p in properties])
-    )
+    target_properties = Labels(names=["p"], values=np.array([[p] for p in properties]))
     actual_properties = equistore.unique_metadata_block(
-        large_tensor.block(1), axis="properties", names="properties"
+        large_tensor.block(1), axis="properties", names="p"
     )
     assert _labels_equal(target_properties, actual_properties, exact_order=True)
 
     # unique metadata of gradient along properties axis
-    names = ["properties"]
+    names = ["p"]
     target_properties = Labels(names=names, values=np.array([[3], [4], [5]]))
     actual_properties = equistore.unique_metadata_block(
         large_tensor.block(1),
         axis="properties",
         names=names,
-        gradient="parameter",
+        gradient="g",
     )
     assert _labels_equal(target_properties, actual_properties, exact_order=True)
 
@@ -108,17 +104,17 @@ def test_empty_block(real_tensor):
 def test_unique_metadata(tensor, large_tensor):
     # unique metadata along samples
     target_samples = Labels(
-        names=["samples"],
+        names=["s"],
         values=np.array([0, 1, 2, 3, 4, 5, 6, 8]).reshape(-1, 1),
     )
-    actual_samples = equistore.unique_metadata(tensor, "samples", "samples")
+    actual_samples = equistore.unique_metadata(tensor, "samples", "s")
     assert _labels_equal(target_samples, actual_samples, exact_order=True)
 
-    actual_samples = equistore.unique_metadata(large_tensor, "samples", "samples")
+    actual_samples = equistore.unique_metadata(large_tensor, "samples", "s")
     assert _labels_equal(actual_samples, target_samples, exact_order=True)
 
     # unique metadata along samples for gradients
-    names = ["sample", "parameter"]
+    names = ["sample", "g"]
     target_samples = Labels(
         names=names,
         values=np.array([[0, -2], [0, 1], [0, 3], [1, -2], [2, -2], [2, 3], [3, 3]]),
@@ -127,38 +123,38 @@ def test_unique_metadata(tensor, large_tensor):
         tensor,
         axis="samples",
         names=names,
-        gradient="parameter",
+        gradient="g",
     )
     assert _labels_equal(actual_samples, target_samples, exact_order=True)
 
     # unique metadata along properties
     target_properties = Labels(
-        names=["properties"], values=np.array([0, 3, 4, 5]).reshape(-1, 1)
+        names=["p"], values=np.array([0, 3, 4, 5]).reshape(-1, 1)
     )
     actual_properties = equistore.unique_metadata(
         tensor,
         axis="properties",
-        names=["properties"],  # names passed as list
+        names=["p"],  # names passed as list
     )
     assert _labels_equal(target_properties, actual_properties, exact_order=True)
 
     target_properties = Labels(
-        names=["properties"], values=np.array([0, 1, 2, 3, 4, 5, 6, 7]).reshape(-1, 1)
+        names=["p"], values=np.array([0, 1, 2, 3, 4, 5, 6, 7]).reshape(-1, 1)
     )
     actual_properties = equistore.unique_metadata(
         large_tensor,
         axis="properties",
-        names=("properties",),  # names passed as tuple
+        names=("p",),  # names passed as tuple
     )
     assert _labels_equal(target_properties, actual_properties, exact_order=True)
 
-    names = ["properties"]
+    names = ["p"]
     target_properties = Labels(
         names=names,
         values=np.array([0, 3, 4, 5]).reshape(-1, 1),
     )
     actual_properties = equistore.unique_metadata(
-        tensor, axis="properties", names=names, gradient="parameter"
+        tensor, axis="properties", names=names, gradient="g"
     )
     assert _labels_equal(target_properties, actual_properties, exact_order=True)
 

--- a/python/tests/operations/unique_metadata.py
+++ b/python/tests/operations/unique_metadata.py
@@ -1,679 +1,255 @@
 import os
-import unittest
 
 import numpy as np
+import pytest
 
 import equistore
-from equistore import Labels, TensorBlock, TensorMap
+from equistore import Labels
 from equistore.operations.equal_metadata import _labels_equal
+
+from .. import utils
 
 
 DATA_ROOT = os.path.join(os.path.dirname(__file__), "..", "data")
 TEST_FILE = "qm7-spherical-expansion.npz"
 
 
-class TestUniqueMetadata(unittest.TestCase):
-    """Finding unique_metadata metadata along a given axis of a TensorMap or
-    TensorBlock"""
+@pytest.fixture
+def tensor():
+    return utils.tensor()
 
-    def setUp(self):
-        self.tensor1 = tensor_map()  # Test case 1
-        self.tensor2 = large_tensor_map()  # Test case 2
-        self.tensor3 = equistore.load(  # Test case 3
-            os.path.join(DATA_ROOT, TEST_FILE),
-            use_numpy=True,
+
+@pytest.fixture
+def large_tensor():
+    return utils.large_tensor()
+
+
+@pytest.fixture
+def real_tensor():
+    return equistore.load(os.path.join(DATA_ROOT, TEST_FILE), use_numpy=True)
+
+
+def test_unique_metadata_block(large_tensor):
+    # unique metadata along sample axis
+    target_samples = Labels(
+        names=["samples"], values=np.array([0, 1, 3]).reshape(-1, 1)
+    )
+    actual_samples = equistore.unique_metadata_block(
+        large_tensor.block(1),
+        axis="samples",
+        names="samples",
+    )
+    assert _labels_equal(target_samples, actual_samples, exact_order=True)
+
+    # unique metadata of gradient along sample axis
+    names = ["sample", "parameter"]
+    target_samples = Labels(names=names, values=np.array([[0, -2], [0, 3], [2, -2]]))
+    actual_samples = equistore.unique_metadata_block(
+        large_tensor.block(1),
+        axis="samples",
+        names=names,
+        gradient="parameter",
+    )
+    assert _labels_equal(target_samples, actual_samples, exact_order=True)
+
+    # unique metadata along properties axis
+    properties = [3, 4, 5]
+    target_properties = Labels(
+        names=["properties"], values=np.array([[p] for p in properties])
+    )
+    actual_properties = equistore.unique_metadata_block(
+        large_tensor.block(1), axis="properties", names="properties"
+    )
+    assert _labels_equal(target_properties, actual_properties, exact_order=True)
+
+    # unique metadata of gradient along properties axis
+    names = ["properties"]
+    target_properties = Labels(names=names, values=np.array([[3], [4], [5]]))
+    actual_properties = equistore.unique_metadata_block(
+        large_tensor.block(1),
+        axis="properties",
+        names=names,
+        gradient="parameter",
+    )
+    assert _labels_equal(target_properties, actual_properties, exact_order=True)
+
+
+def test_empty_block(real_tensor):
+    target_samples = Labels(names=["structure"], values=np.empty((0, 1)))
+    # slice block to be empty
+    sliced_block = equistore.slice_block(
+        real_tensor.block(0),
+        axis="samples",
+        labels=Labels(names=["structure"], values=np.array([[-1]])),
+    )
+    actual_samples = equistore.unique_metadata_block(
+        sliced_block,
+        axis="samples",
+        names="structure",
+    )
+    assert _labels_equal(target_samples, actual_samples, exact_order=True)
+    assert len(actual_samples) == 0
+
+    target_properties = Labels(names=["n"], values=np.empty((0, 1)))
+    sliced_block = equistore.slice_block(
+        real_tensor.block(0),
+        axis="properties",
+        labels=Labels(names=["n"], values=np.array([[-1]])),
+    )
+    actual_properties = equistore.unique_metadata_block(
+        sliced_block,
+        axis="properties",
+        names="n",
+    )
+    assert _labels_equal(target_properties, actual_properties, exact_order=True)
+    assert len(actual_properties) == 0
+
+
+def test_unique_metadata(tensor, large_tensor):
+    # unique metadata along samples
+    target_samples = Labels(
+        names=["samples"],
+        values=np.array([0, 1, 2, 3, 4, 5, 6, 8]).reshape(-1, 1),
+    )
+    actual_samples = equistore.unique_metadata(tensor, "samples", "samples")
+    assert _labels_equal(target_samples, actual_samples, exact_order=True)
+
+    actual_samples = equistore.unique_metadata(large_tensor, "samples", "samples")
+    assert _labels_equal(actual_samples, target_samples, exact_order=True)
+
+    # unique metadata along samples for gradients
+    names = ["sample", "parameter"]
+    target_samples = Labels(
+        names=names,
+        values=np.array([[0, -2], [0, 1], [0, 3], [1, -2], [2, -2], [2, 3], [3, 3]]),
+    )
+    actual_samples = equistore.unique_metadata(
+        tensor,
+        axis="samples",
+        names=names,
+        gradient="parameter",
+    )
+    assert _labels_equal(actual_samples, target_samples, exact_order=True)
+
+    # unique metadata along properties
+    target_properties = Labels(
+        names=["properties"], values=np.array([0, 3, 4, 5]).reshape(-1, 1)
+    )
+    actual_properties = equistore.unique_metadata(
+        tensor,
+        axis="properties",
+        names=["properties"],  # names passed as list
+    )
+    assert _labels_equal(target_properties, actual_properties, exact_order=True)
+
+    target_properties = Labels(
+        names=["properties"], values=np.array([0, 1, 2, 3, 4, 5, 6, 7]).reshape(-1, 1)
+    )
+    actual_properties = equistore.unique_metadata(
+        large_tensor,
+        axis="properties",
+        names=("properties",),  # names passed as tuple
+    )
+    assert _labels_equal(target_properties, actual_properties, exact_order=True)
+
+    names = ["properties"]
+    target_properties = Labels(
+        names=names,
+        values=np.array([0, 3, 4, 5]).reshape(-1, 1),
+    )
+    actual_properties = equistore.unique_metadata(
+        tensor, axis="properties", names=names, gradient="parameter"
+    )
+    assert _labels_equal(target_properties, actual_properties, exact_order=True)
+
+
+def test_unique_metadata_different_names(tensor):
+    # these names are not in the samples/properties
+    names = ["ciao", "bonjour", "hello"]
+    target_labels = Labels(names=names, values=np.arange(len(names)).reshape(1, -1))[:0]
+
+    # block/samples
+    actual_labels = equistore.unique_metadata_block(
+        tensor.block(0), axis="samples", names=names
+    )
+    assert _labels_equal(target_labels, actual_labels, exact_order=True)
+
+    # tensor/samples
+    actual_labels = equistore.unique_metadata(tensor, axis="samples", names=names)
+    assert _labels_equal(target_labels, actual_labels, exact_order=True)
+
+    # block/properties
+    actual_labels = equistore.unique_metadata_block(
+        tensor.block(0), axis="properties", names=names
+    )
+    assert _labels_equal(target_labels, actual_labels, exact_order=True)
+
+    # tensor/properties
+    actual_labels = equistore.unique_metadata(tensor, axis="properties", names=names)
+    assert _labels_equal(target_labels, actual_labels, exact_order=True)
+
+
+def test_unique_metadata_block_errors(real_tensor):
+    message = "`block` argument must be an equistore TensorBlock"
+    with pytest.raises(TypeError, match=message):
+        equistore.unique_metadata_block(real_tensor, "samples", ["structure"])
+
+    message = "`tensor` argument must be an equistore TensorMap"
+    with pytest.raises(TypeError, match=message):
+        equistore.unique_metadata(real_tensor.block(0), "samples", ["structure"])
+
+    message = (
+        "`axis` argument must be a str, either `'samples'` or `'properties'`,"
+        " not <class 'float'>"
+    )
+    with pytest.raises(TypeError, match=message):
+        equistore.unique_metadata_block(
+            real_tensor.block(0),
+            axis=3.14,
+            names=["structure"],
         )
 
-    def test_unique_metadata_block_samples(self):
-        """Tests getting unique metadata along properties axis w/ 3 test cases"""
-        # Test case 1
-        samples = [0, 1, 2, 5]
-        target_samples = Labels(
-            names=["samples"], values=np.array([[s] for s in samples])
-        )
-        actual_samples = equistore.unique_metadata_block(
-            self.tensor1.block(3), "samples", "samples"
-        )
-        self.assertTrue(_labels_equal(target_samples, actual_samples, exact_order=True))
-        # Test case 2
-        samples = [0, 2, 4]
-        target_samples = Labels(
-            names=["samples"], values=np.array([[s] for s in samples])
-        )
-        actual_samples = equistore.unique_metadata_block(
-            self.tensor2.block(0), "samples", "samples"
-        )
-        self.assertTrue(_labels_equal(target_samples, actual_samples, exact_order=True))
-        # Test case 3
-        samples = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
-        target_samples = Labels(
-            names=["structure"], values=np.array([[s] for s in samples])
-        )
-        actual_samples = equistore.unique_metadata_block(
-            self.tensor3.block(0), "samples", "structure"
-        )
-        self.assertTrue(_labels_equal(target_samples, actual_samples, exact_order=True))
-
-    def test_unique_metadata_block_samples_to_zero(self):
-        """Tests getting unique samples metadata of a block sliced to zero
-        dimension"""
-        # Slice block to zero along samples and check labels return is empty
-        # with correct names
-        target_samples = Labels(names=["structure"], values=np.array([[0]])[:0])
-        sliced_block = equistore.slice_block(
-            self.tensor3.block(0),
-            axis="samples",
-            labels=Labels(names=["structure"], values=np.array([[-1]])),
-        )
-        actual_samples = equistore.unique_metadata_block(
-            sliced_block, "samples", "structure"
-        )
-        self.assertTrue(_labels_equal(target_samples, actual_samples, exact_order=True))
-        self.assertTrue(len(actual_samples) == 0)
-
-    def test_unique_metadata_block_properties(self):
-        """Tests getting unique metadata along properties axis w/ 3 test
-        cases"""
-        properties = [0]
-        target_properties = Labels(
-            names=["properties"], values=np.array([[p] for p in properties])
-        )
-        actual_properties = equistore.unique_metadata_block(
-            self.tensor1.block(3), "properties", "properties"
-        )
-        self.assertTrue(
-            _labels_equal(target_properties, actual_properties, exact_order=True)
-        )
-        # Test case 2
-        properties = [3, 4, 5]
-        target_properties = Labels(
-            names=["properties"], values=np.array([[p] for p in properties])
-        )
-        actual_properties = equistore.unique_metadata_block(
-            self.tensor2.block(1), "properties", "properties"
-        )
-        self.assertTrue(
-            _labels_equal(target_properties, actual_properties, exact_order=True)
-        )
-        # Test case 3
-        properties = [0, 1, 2, 3]
-        target_properties = Labels(
-            names=["n"], values=np.array([[p] for p in properties])
-        )
-        actual_properties = equistore.unique_metadata_block(
-            self.tensor3.block(0), "properties", "n"
-        )
-        self.assertTrue(
-            _labels_equal(target_properties, actual_properties, exact_order=True)
-        )
-
-    def test_unique_metadata_block_properties_to_zero(self):
-        """Tests getting unique properties metadata of a block sliced to zero
-        dimension"""
-        # Slice block to zero along properties and check labels return is empty
-        # with correct names
-        target_properties = Labels(names=["n"], values=np.array([[0]])[:0])
-        sliced_block = equistore.slice_block(
-            self.tensor3.block(0),
+    message = "`names` argument must be a list of str, not <class 'float'>"
+    with pytest.raises(TypeError, match=message):
+        equistore.unique_metadata_block(
+            real_tensor.block(0),
             axis="properties",
-            labels=Labels(names=["n"], values=np.array([[-1]])),
-        )
-        actual_properties = equistore.unique_metadata_block(
-            sliced_block, "properties", "n"
-        )
-        self.assertTrue(
-            _labels_equal(target_properties, actual_properties, exact_order=True)
-        )
-        self.assertTrue(len(actual_properties) == 0)
-
-    def test_unique_metadata_block_gradient_samples(self):
-        # Test case 1
-        parameter = "parameter"
-        samples = [0, 2]
-        target_samples = Labels(
-            names=["sample"], values=np.array([[s] for s in samples])
-        )
-        actual_samples = equistore.unique_metadata_block(
-            self.tensor1.block(0), "samples", "sample", parameter
-        )
-        self.assertTrue(_labels_equal(target_samples, actual_samples, exact_order=True))
-        # Test case 2
-        parameter = "parameter"
-        samples, sname = [[0, -2], [0, 3], [2, -2]], ["sample", "parameter"]
-        target_samples = Labels(names=sname, values=np.array([s for s in samples]))
-        actual_samples = equistore.unique_metadata_block(
-            self.tensor2.block(1), "samples", sname, parameter
-        )
-        self.assertTrue(_labels_equal(target_samples, actual_samples, exact_order=True))
-        # Test case 3
-        target_samples = Labels.arange("sample", 52)
-        actual_samples = equistore.unique_metadata_block(
-            self.tensor3.block(1), "samples", "sample", "cell"
-        )
-        self.assertTrue(_labels_equal(target_samples, actual_samples, exact_order=True))
-
-    def test_unique_metadata_block_gradient_samples_to_zero(self):
-        """Test unique samples metadata of block sliced to zero"""
-        # Slice block to zero along samples and check labels return is empty
-        # with correct names
-        target_samples = Labels(names=["sample"], values=np.array([[0]])[:0])
-        sliced_block = equistore.slice_block(
-            self.tensor3.block(0),
-            axis="samples",
-            labels=Labels(names=["structure"], values=np.array([[-1]])),
-        )
-        actual_samples = equistore.unique_metadata_block(
-            sliced_block, "samples", "sample", gradient_param="cell"
-        )
-        self.assertTrue(_labels_equal(target_samples, actual_samples, exact_order=True))
-        self.assertTrue(len(actual_samples) == 0)
-
-    def test_unique_metadata_block_gradient_properties(self):
-        """Test unique properties metadata of gradient blocks"""
-        # Test case 1
-        parameter = "parameter"
-        properties = [0]
-        target_properties = Labels(
-            names=["properties"], values=np.array([[p] for p in properties])
-        )
-        actual_properties = equistore.unique_metadata_block(
-            self.tensor1.block(0), "properties", "properties", parameter
-        )
-        self.assertTrue(
-            _labels_equal(target_properties, actual_properties, exact_order=True)
-        )
-        # Test case 2
-        parameter = "parameter"
-        properties, pname = [[3], [4], [5]], ["properties"]
-        target_properties = Labels(
-            names=pname, values=np.array([p for p in properties])
-        )
-        actual_properties = equistore.unique_metadata_block(
-            self.tensor2.block(1), "properties", pname, parameter
-        )
-        self.assertTrue(
-            _labels_equal(target_properties, actual_properties, exact_order=True)
-        )
-        # By definition the unique TensorBlock and Gradient block properties
-        # should be equivalent
-        actual_properties_tensorblock = equistore.unique_metadata_block(
-            self.tensor2.block(1),
-            "properties",
-            pname,
-        )
-        self.assertTrue(
-            _labels_equal(
-                actual_properties_tensorblock, actual_properties, exact_order=True
-            )
-        )
-        # Test case 3
-        target_properties = Labels.arange("n", 4)
-        actual_properties = equistore.unique_metadata_block(
-            self.tensor3.block(1), "properties", "n", "positions"
-        )
-        self.assertTrue(
-            _labels_equal(target_properties, actual_properties, exact_order=True)
-        )
-        # Passing names as list
-        actual_properties = equistore.unique_metadata_block(
-            self.tensor3.block(1), "properties", ["n"], "positions"
-        )
-        self.assertTrue(
-            _labels_equal(target_properties, actual_properties, exact_order=True)
-        )
-        # Passing names as tuple
-        actual_properties = equistore.unique_metadata_block(
-            self.tensor3.block(1), "properties", ("n",), "positions"
-        )
-        self.assertTrue(
-            _labels_equal(target_properties, actual_properties, exact_order=True)
+            names=3.14,
         )
 
-    def test_unique_metadata_block_gradient_properties_to_zero(self):
-        """Test unique samples metadata of block sliced to zero"""
-        # Slice block to zero along properties and check labels return is empty
-        # with correct names
-        target_properties = Labels(names=["n"], values=np.array([[0]])[:0])
-        sliced_block = equistore.slice_block(
-            self.tensor3.block(0),
+    message = (
+        "`names` argument must be a list of str, not "
+        + r"\[<class 'str'>, <class 'float'>\]"
+    )
+    with pytest.raises(TypeError, match=message):
+        equistore.unique_metadata_block(
+            real_tensor.block(0),
             axis="properties",
-            labels=Labels(names=["n"], values=np.array([[-1]])),
-        )
-        actual_properties = equistore.unique_metadata_block(
-            sliced_block, "properties", "n", gradient_param="cell"
-        )
-        self.assertTrue(
-            _labels_equal(target_properties, actual_properties, exact_order=True)
-        )
-        self.assertTrue(len(actual_properties) == 0)
-
-    def test_unique_metadata_samples(self):
-        """Test unique on whole TensorMap along samples"""
-        # Test case 1
-        samples = [0, 1, 2, 3, 4, 5, 6, 8]
-        target_samples = Labels(
-            names=["samples"], values=np.array([[s] for s in samples])
-        )
-        actual_samples = equistore.unique_metadata(self.tensor1, "samples", "samples")
-        self.assertTrue(_labels_equal(target_samples, actual_samples, exact_order=True))
-        # Test case 2
-        actual_samples = equistore.unique_metadata(self.tensor2, "samples", "samples")
-        self.assertTrue(_labels_equal(actual_samples, target_samples, exact_order=True))
-
-    def test_unique_metadata_samples_different_types(self):
-        """Passign names as different types"""
-        samples = [0, 1, 2, 3, 4, 5, 6, 8]
-        target_samples = Labels(
-            names=["samples"], values=np.array([[s] for s in samples])
-        )
-        # Passing names as list
-        actual_samples = equistore.unique_metadata(self.tensor2, "samples", ["samples"])
-        self.assertTrue(_labels_equal(target_samples, actual_samples, exact_order=True))
-        # Passing names as tuple
-        actual_samples = equistore.unique_metadata(
-            self.tensor2, "samples", ("samples",)
-        )
-        self.assertTrue(_labels_equal(target_samples, actual_samples, exact_order=True))
-
-    def test_unique_metadata_properties(self):
-        """Test unique on whole TensorMap along samples"""
-        # Test case 1
-        properties = [0, 3, 4, 5]
-        target_properties = Labels(
-            names=["properties"], values=np.array([[p] for p in properties])
-        )
-        actual_properties = equistore.unique_metadata(
-            self.tensor1, "properties", "properties"
-        )
-        self.assertTrue(
-            _labels_equal(target_properties, actual_properties, exact_order=True)
-        )
-        # Test case 2
-        properties = [0, 1, 2, 3, 4, 5, 6, 7]
-        target_properties = Labels(
-            names=["properties"], values=np.array([[p] for p in properties])
-        )
-        actual_properties = equistore.unique_metadata(
-            self.tensor2, "properties", "properties"
-        )
-        self.assertTrue(
-            _labels_equal(target_properties, actual_properties, exact_order=True)
+            names=["structure", 3.14],
         )
 
-    def test_unique_metadata_properties_different_types(self):
-        """Passing names as different types"""
-        properties = [0, 1, 2, 3, 4, 5, 6, 7]
-        target_properties = Labels(
-            names=["properties"], values=np.array([[p] for p in properties])
-        )
-        # Passing names as list
-        actual_properties = equistore.unique_metadata(
-            self.tensor2, "properties", ["properties"]
-        )
-        self.assertTrue(
-            _labels_equal(target_properties, actual_properties, exact_order=True)
-        )
-        # Passing names as tuple
-        actual_properties = equistore.unique_metadata(
-            self.tensor2, "properties", ("properties",)
-        )
-        self.assertTrue(
-            _labels_equal(target_properties, actual_properties, exact_order=True)
+    message = "`gradient` argument must be a str, not <class 'float'>"
+    with pytest.raises(TypeError, match=message):
+        equistore.unique_metadata_block(
+            real_tensor.block(0),
+            axis="properties",
+            names=["structure"],
+            gradient=3.14,
         )
 
-    def test_unique_metadata_gradients_samples(self):
-        """Tests getting unique metadata of gradients on whole TensorMap along
-        samples"""
-        parameter = "parameter"
-        samples = np.array([[0, -2], [0, 1], [0, 3], [1, -2], [2, -2], [2, 3], [3, 3]])
-        snames = ["sample", "parameter"]
-        target_samples = Labels(names=snames, values=samples)
-        actual_samples = equistore.unique_metadata(
-            self.tensor1, "samples", snames, parameter
-        )
-        self.assertTrue(_labels_equal(actual_samples, target_samples, exact_order=True))
-
-    def test_unique_metadata_gradients_samples_incorrect_order(self):
-        """
-        Tests false of getting unique metadata of gradients on whole TensorMap
-        along samples with incorrect order
-        """
-        parameter = "parameter"
-        # Incorrect order samples - [1, -2] and [2, -2] switched around
-        samples = np.array([[0, -2], [0, 1], [0, 3], [2, -2], [1, -2], [2, 3], [3, 3]])
-        snames = ["sample", "parameter"]
-        target_samples = Labels(names=snames, values=samples)
-        actual_samples = equistore.unique_metadata(
-            self.tensor1, "samples", snames, parameter
-        )
-        self.assertFalse(
-            _labels_equal(actual_samples, target_samples, exact_order=True)
+    message = "`axis` argument must be either `'samples'` or `'properties'`"
+    with pytest.raises(ValueError, match=message):
+        equistore.unique_metadata_block(
+            real_tensor.block(0),
+            axis="ciao",
+            names=["structure"],
         )
 
-    def test_unique_metadata_gradients_properties(self):
-        """Tests getting unique metadata of gradients on whole TensorMap along
-        properties"""
-        parameter = "parameter"
-        properties, pnames = [0, 3, 4, 5], ["properties"]
-        target_properties = Labels(
-            names=pnames, values=np.array([[p] for p in properties])
+    message = "`gradient` argument must be a str, not <class 'float'>"
+    with pytest.raises(TypeError, match=message):
+        equistore.unique_metadata_block(
+            real_tensor.block(0),
+            axis="properties",
+            names=["structure"],
+            gradient=3.14,
         )
-        actual_properties = equistore.unique_metadata(
-            self.tensor1, "properties", pnames, parameter
-        )
-        self.assertTrue(
-            _labels_equal(target_properties, actual_properties, exact_order=True)
-        )
-
-    def test_unique_metadata_gradients_properties_incorrect_order(self):
-        """
-        Tests false of getting unique metadata of gradients on whole TensorMap
-        along properties with incorrect order
-        """
-        # 3 and 4 switched
-        parameter = "parameter"
-        properties, pnames = [0, 4, 3, 5], ["properties"]
-        target_properties = Labels(
-            names=pnames, values=np.array([[p] for p in properties])
-        )
-        actual_properties = equistore.unique_metadata(
-            self.tensor1, "properties", pnames, parameter
-        )
-        self.assertFalse(
-            _labels_equal(target_properties, actual_properties, exact_order=True)
-        )
-
-    def test_unique_metadata_block_empty_labels(self):
-        """Tests empty labels returned when passing names not in block"""
-        names = ["ciao", "bonjour", "hello"]
-        target_labels = Labels(
-            names=names, values=np.arange(len(names)).reshape(1, -1)
-        )[:0]
-        # names not in block - samples
-        actual_labels = equistore.unique_metadata_block(
-            self.tensor1.block(0), "samples", names=names
-        )
-        self.assertTrue(_labels_equal(target_labels, actual_labels, exact_order=True))
-        # names not in block - properties
-        actual_labels = equistore.unique_metadata_block(
-            self.tensor1.block(0), "properties", names=names
-        )
-        self.assertTrue(_labels_equal(target_labels, actual_labels, exact_order=True))
-
-    def test_unique_metadata_empty_labels(self):
-        """Tests empty labels returned when passing names not in tensor"""
-        names = ["ciao", "bonjour", "hello"]
-        target_labels = Labels(
-            names=names, values=np.arange(len(names)).reshape(1, -1)
-        )[:0]
-        # names not in block - samples
-        actual_labels = equistore.unique_metadata(self.tensor1, "samples", names=names)
-        self.assertTrue(_labels_equal(target_labels, actual_labels, exact_order=True))
-        # names not in block - properties
-        actual_labels = equistore.unique_metadata(
-            self.tensor1, "properties", names=names
-        )
-        self.assertTrue(_labels_equal(target_labels, actual_labels, exact_order=True))
-
-
-class TestUniqueMetadataErrors(unittest.TestCase):
-    """
-    Testing the errors raised by :py:func:`unique_metadata` and
-    :py:func:`unique_metadata_block`
-    """
-
-    def setUp(self):
-        self.tensor = equistore.load(
-            os.path.join(DATA_ROOT, TEST_FILE),
-            use_numpy=True,
-        )
-        self.block = self.tensor.block(0)
-
-    def test_unique_metadata_block_type_errors(self):
-        # TypeError with TM
-        with self.assertRaises(TypeError) as cm:
-            equistore.unique_metadata_block(self.tensor, "samples", ["structure"])
-        self.assertEqual(
-            str(cm.exception),
-            "`block` must be an equistore `TensorBlock`",
-        )
-        # TypeError axis as float
-        with self.assertRaises(TypeError) as cm:
-            equistore.unique_metadata_block(self.block, 3.14, ["structure"])
-        self.assertEqual(
-            str(cm.exception),
-            "`axis` must be a `str`, either `'samples'` or `'properties'`,"
-            + f" receieved type {type(3.14)}",
-        )
-        # TypeError names as float
-        with self.assertRaises(TypeError) as cm:
-            equistore.unique_metadata_block(self.block, "properties", 3.14)
-        self.assertEqual(
-            str(cm.exception),
-            f"`names` must be a `list` of `str`, received {type(3.14)}",
-        )
-        # TypeError names as list of [str, float]
-        with self.assertRaises(TypeError) as cm:
-            equistore.unique_metadata_block(
-                self.block, "properties", ["structure", 3.14]
-            )
-        self.assertEqual(
-            str(cm.exception),
-            "`names` must be a `list` of `str`, received"
-            + f" {[type(name) for name in ['structure', 3.14]]}",
-        )
-        # TypeError gradient_param as float
-        with self.assertRaises(TypeError) as cm:
-            equistore.unique_metadata_block(
-                self.block, "properties", ["structure"], gradient_param=3.14
-            )
-        self.assertEqual(
-            str(cm.exception), f"`gradient_param` must be a `str`, not {type(3.14)}"
-        )
-
-    def test_unique_metadata_block_value_errors(self):
-        """tests raising of value errors"""
-        # ValueError axis not "samples" or "properties"
-        with self.assertRaises(ValueError) as cm:
-            equistore.unique_metadata_block(self.block, "ciao", ["structure"])
-        self.assertEqual(
-            str(cm.exception),
-            "`axis` must be passed as either `'samples'` or `'properties'`,"
-            + " ciao was passed",
-        )
-        # ValueError gradient_param not a valid param for gradients
-        with self.assertRaises(TypeError) as cm:
-            equistore.unique_metadata_block(
-                self.block, "properties", ["structure"], gradient_param=3.14
-            )
-        self.assertEqual(
-            str(cm.exception), f"`gradient_param` must be a `str`, not {type(3.14)}"
-        )
-
-    def test_unique_metadata_block_no_errors(self):
-        """tests no raising of errors"""
-        # No error names as str, list of str, or tuple of str
-        equistore.unique_metadata_block(self.block, "samples", "structure")
-        equistore.unique_metadata_block(self.block, "samples", ["structure"])
-        equistore.unique_metadata_block(self.block, "samples", ("structure",))
-
-    def test_unique_type_errors(self):
-        """tests raising of type errors"""
-        # TypeError with TB
-        with self.assertRaises(TypeError) as cm:
-            equistore.unique_metadata(self.block, "samples", ["structure"])
-        self.assertEqual(
-            str(cm.exception),
-            "`tensor` must be an equistore `TensorMap`",
-        )
-        # TypeError axis as float
-        with self.assertRaises(TypeError) as cm:
-            equistore.unique_metadata(self.tensor, 3.14, ["structure"])
-        self.assertEqual(
-            str(cm.exception),
-            "`axis` must be a `str`, either `'samples'` or `'properties'`,"
-            + f" receieved type {type(3.14)}",
-        )
-        # TypeError names as float
-        with self.assertRaises(TypeError) as cm:
-            equistore.unique_metadata(self.tensor, "properties", 3.14)
-        self.assertEqual(
-            str(cm.exception),
-            f"`names` must be a `list` of `str`, received {type(3.14)}",
-        )
-        # TypeError names as list of [str, float]
-        with self.assertRaises(TypeError) as cm:
-            equistore.unique_metadata_block(
-                self.block, "properties", ["structure", 3.14]
-            )
-        self.assertEqual(
-            str(cm.exception),
-            "`names` must be a `list` of `str`, received"
-            + f" {[type(name) for name in ['structure', 3.14]]}",
-        )
-
-    def test_unique_metadata_value_errors(self):
-        """tests raising of value errors"""
-        # ValueError axis not "samples" or "properties"
-        with self.assertRaises(ValueError) as cm:
-            equistore.unique_metadata(self.tensor, "ciao", ["structure"])
-        self.assertEqual(
-            str(cm.exception),
-            "`axis` must be passed as either `'samples'` or `'properties'`,"
-            + f" {'ciao'} was passed",
-        )
-
-    def test_unique_metadata_no_errors(self):
-        """tests no raising of errors"""
-        # No error names as str, list of str, or tuple of str
-        equistore.unique_metadata(self.tensor, "properties", "n")
-        equistore.unique_metadata(self.tensor, "properties", ["n"])
-        equistore.unique_metadata(self.tensor, "properties", ("n",))
-
-
-def tensor_map():
-    """
-    Create a dummy tensor map to be used in tests. This is the same one as the
-    tensor map used in `tensor.rs` tests.
-    """
-    block_1 = TensorBlock(
-        values=np.full((3, 1, 1), 1.0),
-        samples=Labels(["samples"], np.array([[0], [2], [4]])),
-        components=[Labels(["components"], np.array([[0]]))],
-        properties=Labels(["properties"], np.array([[0]])),
-    )
-    block_1.add_gradient(
-        "parameter",
-        samples=Labels(["sample", "parameter"], np.array([[0, -2], [2, 3]])),
-        data=np.full((2, 1, 1), 11.0),
-        components=[Labels(["components"], np.array([[0]]))],
-    )
-
-    block_2 = TensorBlock(
-        values=np.full((3, 1, 3), 2.0),
-        samples=Labels(["samples"], np.array([[0], [1], [3]])),
-        components=[Labels(["components"], np.array([[0]]))],
-        properties=Labels(["properties"], np.array([[3], [4], [5]])),
-    )
-    block_2.add_gradient(
-        "parameter",
-        data=np.full((3, 1, 3), 12.0),
-        samples=Labels(
-            ["sample", "parameter"],
-            np.array([[0, -2], [0, 3], [2, -2]]),
-        ),
-        components=[Labels(["components"], np.array([[0]]))],
-    )
-
-    block_3 = TensorBlock(
-        values=np.full((4, 3, 1), 3.0),
-        samples=Labels(["samples"], np.array([[0], [3], [6], [8]])),
-        components=[Labels.arange("components", 3)],
-        properties=Labels(["properties"], np.array([[0]])),
-    )
-    block_3.add_gradient(
-        "parameter",
-        data=np.full((1, 3, 1), 13.0),
-        samples=Labels(
-            ["sample", "parameter"],
-            np.array([[1, -2]]),
-        ),
-        components=[Labels.arange("components", 3)],
-    )
-
-    block_4 = TensorBlock(
-        values=np.full((4, 3, 1), 4.0),
-        samples=Labels(["samples"], np.array([[0], [1], [2], [5]])),
-        components=[Labels.arange("components", 3)],
-        properties=Labels(["properties"], np.array([[0]])),
-    )
-    block_4.add_gradient(
-        "parameter",
-        data=np.full((2, 3, 1), 14.0),
-        samples=Labels(
-            ["sample", "parameter"],
-            np.array([[0, 1], [3, 3]]),
-        ),
-        components=[Labels.arange("components", 3)],
-    )
-
-    # TODO: different number of components?
-
-    keys = Labels(
-        names=["key_1", "key_2"],
-        values=np.array([[0, 0], [1, 0], [2, 2], [2, 3]]),
-    )
-
-    return TensorMap(keys, [block_1, block_2, block_3, block_4])
-
-
-def large_tensor_map():
-    """
-    Create a dummy tensor map of 16 blocks to be used in tests. This is the same
-    tensor map used in `tensor.rs` tests.
-    """
-    tensor = tensor_map()
-    block_list = [block.copy() for _, block in tensor]
-
-    for i in range(8):
-        tmp_bl = TensorBlock(
-            values=np.full((4, 3, 1), 4.0),
-            samples=Labels(["samples"], np.array([[0], [1], [4], [5]])),
-            components=[Labels.arange("components", 3)],
-            properties=Labels(["properties"], np.array([[i]])),
-        )
-        tmp_bl.add_gradient(
-            "parameter",
-            data=np.full((2, 3, 1), 14.0),
-            samples=Labels(
-                ["sample", "parameter"],
-                np.array([[0, 1], [3, 3]]),
-            ),
-            components=[Labels.arange("components", 3)],
-        )
-        block_list.append(tmp_bl)
-
-    keys = Labels(
-        names=["key_1", "key_2"],
-        values=np.array(
-            [
-                [0, 0],
-                [1, 0],
-                [2, 2],
-                [2, 3],
-                [0, 4],
-                [1, 4],
-                [2, 4],
-                [3, 4],
-                [0, 5],
-                [1, 5],
-                [2, 5],
-                [3, 5],
-            ],
-        ),
-    )
-    return TensorMap(keys, block_list)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/python/tests/operations/zeros_like.py
+++ b/python/tests/operations/zeros_like.py
@@ -134,8 +134,7 @@ class TestZeros_like(unittest.TestCase):
             tensor = equistore.zeros_like(tensor, parameters=["positions", "err"])
         self.assertEqual(
             str(cm.exception),
-            "The requested parameter 'err' in zeros_like_block "
-            "is not a valid parameterfor the TensorBlock",
+            "requested gradient 'err' in zeros_like is not defined in this tensor",
         )
 
 

--- a/python/tests/operations/zeros_like.py
+++ b/python/tests/operations/zeros_like.py
@@ -1,7 +1,7 @@
 import os
-import unittest
 
 import numpy as np
+import pytest
 
 import equistore
 
@@ -9,136 +9,41 @@ import equistore
 DATA_ROOT = os.path.join(os.path.dirname(__file__), "..", "data")
 
 
-class TestZeros_like(unittest.TestCase):
-    def test_zeros_like_nocomponent(self):
-        tensor = equistore.load(
-            os.path.join(DATA_ROOT, "qm7-power-spectrum.npz"),
-            # the npz is using DEFLATE compression, equistore only supports STORED
-            use_numpy=True,
-        )
-        zeros_tensor = equistore.zeros_like(tensor)
+def test_zeros_like():
+    tensor = equistore.load(
+        os.path.join(DATA_ROOT, "qm7-spherical-expansion.npz"),
+        # the npz is using DEFLATE compression, equistore only supports STORED
+        use_numpy=True,
+    )
+    zeros_tensor = equistore.zeros_like(tensor)
+    zeros_tensor_positions = equistore.zeros_like(tensor, gradients="positions")
 
-        self.assertTrue(np.all(tensor.keys == zeros_tensor.keys))
-        for key, zeros_block in zeros_tensor:
-            block = tensor.block(key)
-            self.assertTrue(np.all(zeros_block.samples == block.samples))
-            self.assertTrue(np.all(zeros_block.properties == block.properties))
-            self.assertEqual(len(zeros_block.components), len(block.components))
-            self.assertTrue(
-                np.all(
-                    [
-                        np.all(zeros_block.components[i] == block.components[i])
-                        for i in range(len(block.components))
-                    ]
-                )
-            )
-            self.assertTrue(
-                np.allclose(zeros_block.values, np.zeros_like(block.values))
-            )
-            for zeros_parameter, zeros_gradient in zeros_block.gradients():
-                gradient = block.gradient(zeros_parameter)
-                self.assertTrue(np.all(zeros_gradient.samples == gradient.samples))
-                self.assertEqual(
-                    len(zeros_gradient.components), len(gradient.components)
-                )
-                self.assertTrue(
-                    np.all(
-                        [
-                            np.all(
-                                zeros_gradient.components[i] == gradient.components[i]
-                            )
-                            for i in range(len(gradient.components))
-                        ]
-                    )
-                )
-                self.assertTrue(
-                    np.allclose(zeros_gradient.data, np.zeros_like(gradient.data))
-                )
+    assert equistore.equal_metadata(zeros_tensor, tensor)
 
-    def test_zeros_component(self):
-        tensor = equistore.load(
-            os.path.join(DATA_ROOT, "qm7-spherical-expansion.npz"),
-            # the npz is using DEFLATE compression, equistore only supports STORED
-            use_numpy=True,
-        )
-        zeros_tensor = equistore.zeros_like(tensor)
-        zeros_tensor_positions = equistore.zeros_like(tensor, parameters="positions")
+    tensor_no_cell = equistore.remove_gradients(tensor, "cell")
+    assert equistore.equal_metadata(zeros_tensor_positions, tensor_no_cell)
 
-        self.assertTrue(np.all(tensor.keys == zeros_tensor.keys))
-        self.assertTrue(np.all(tensor.keys == zeros_tensor_positions.keys))
-        for key, zeros_block in zeros_tensor:
-            block = tensor.block(key)
-            zeros_block_pos = zeros_tensor_positions.block(key)
-            self.assertTrue(np.all(zeros_block.samples == block.samples))
-            self.assertTrue(np.all(zeros_block.properties == block.properties))
-            self.assertTrue(
-                np.allclose(zeros_block.values, np.zeros_like(block.values))
-            )
+    # check the values
+    for key, block in tensor:
+        zeros_block = zeros_tensor[key]
 
-            self.assertTrue(np.all(zeros_block_pos.samples == block.samples))
-            self.assertTrue(np.all(zeros_block_pos.properties == block.properties))
-            self.assertTrue(
-                np.allclose(zeros_block_pos.values, np.zeros_like(block.values))
-            )
+        assert np.all(zeros_block.values == np.zeros_like(block.values))
 
-            self.assertTrue(zeros_block.gradients_list() == block.gradients_list())
-            for zeros_parameter, zeros_gradient in zeros_block.gradients():
-                gradient = block.gradient(zeros_parameter)
-                self.assertTrue(np.all(zeros_gradient.samples == gradient.samples))
-                self.assertEqual(
-                    len(zeros_gradient.components), len(gradient.components)
-                )
-                self.assertTrue(
-                    np.all(
-                        [
-                            np.all(
-                                zeros_gradient.components[i] == gradient.components[i]
-                            )
-                            for i in range(len(gradient.components))
-                        ]
-                    )
-                )
-                self.assertTrue(
-                    np.allclose(zeros_gradient.data, np.zeros_like(gradient.data))
-                )
-            self.assertTrue(zeros_block_pos.gradients_list() == ["positions"])
-            for zeros_parameter_pos, zeros_gradient_pos in zeros_block_pos.gradients():
-                gradient = block.gradient(zeros_parameter_pos)
-                self.assertTrue(np.all(zeros_gradient_pos.samples == gradient.samples))
-                self.assertEqual(
-                    len(zeros_gradient_pos.components), len(gradient.components)
-                )
-                self.assertTrue(
-                    np.all(
-                        [
-                            np.all(
-                                zeros_gradient_pos.components[i]
-                                == gradient.components[i]
-                            )
-                            for i in range(len(gradient.components))
-                        ]
-                    )
-                )
-                self.assertTrue(
-                    np.allclose(zeros_gradient_pos.data, np.zeros_like(gradient.data))
-                )
+        for parameter, gradient in block.gradients():
+            zeros_gradient = zeros_block.gradient(parameter)
+            assert np.all(zeros_gradient.data == np.zeros_like(gradient.data))
 
-    def test_zeros_error(self):
-        tensor = equistore.load(
-            os.path.join(DATA_ROOT, "qm7-spherical-expansion.npz"),
-            # the npz is using DEFLATE compression, equistore only supports STORED
-            use_numpy=True,
-        )
 
-        with self.assertRaises(ValueError) as cm:
-            tensor = equistore.zeros_like(tensor, parameters=["positions", "err"])
-        self.assertEqual(
-            str(cm.exception),
-            "requested gradient 'err' in zeros_like is not defined in this tensor",
-        )
+def test_zeros_like_error():
+    tensor = equistore.load(
+        os.path.join(DATA_ROOT, "qm7-spherical-expansion.npz"),
+        # the npz is using DEFLATE compression, equistore only supports STORED
+        use_numpy=True,
+    )
+
+    message = "requested gradient 'err' in zeros_like is not defined in this tensor"
+    with pytest.raises(ValueError, match=message):
+        tensor = equistore.zeros_like(tensor, gradients=["positions", "err"])
 
 
 # TODO: add tests with torch & torch scripting/tracing
-
-if __name__ == "__main__":
-    unittest.main()

--- a/python/tests/tensor.py
+++ b/python/tests/tensor.py
@@ -92,9 +92,9 @@ keys: ['key_1' 'key_2']
 
 
 def test_labels_names(tensor):
-    assert tensor.sample_names == ("samples",)
-    assert tensor.components_names == [("components",)]
-    assert tensor.property_names == ("properties",)
+    assert tensor.sample_names == ("s",)
+    assert tensor.components_names == [("c",)]
+    assert tensor.property_names == ("p",)
 
 
 def test_block(tensor):
@@ -205,7 +205,7 @@ def test_keys_to_properties(tensor):
     assert len(block.components), 1
     assert tuple(block.components[0][0]), (0,)
 
-    assert block.properties.names == ("key_1", "properties")
+    assert block.properties.names == ("key_1", "p")
     assert tuple(block.properties[0]) == (0, 0)
     assert tuple(block.properties[1]) == (1, 3)
     assert tuple(block.properties[2]) == (1, 4)
@@ -222,7 +222,7 @@ def test_keys_to_properties(tensor):
     )
     assert_equal(block.values, expected)
 
-    gradient = block.gradient("parameter")
+    gradient = block.gradient("g")
     assert tuple(gradient.samples[0]) == (0, -2)
     assert tuple(gradient.samples[1]) == (0, 3)
     assert tuple(gradient.samples[2]) == (3, -2)
@@ -240,14 +240,14 @@ def test_keys_to_properties(tensor):
 
     # The new second block contains the old third block
     block = tensor.block(1)
-    assert block.properties.names == ("key_1", "properties")
+    assert block.properties.names == ("key_1", "p")
     assert tuple(block.properties[0]) == (2, 0)
 
     assert_equal(block.values, np.full((4, 3, 1), 3.0))
 
     # The new third block contains the old fourth block
     block = tensor.block(2)
-    assert block.properties.names == ("key_1", "properties")
+    assert block.properties.names == ("key_1", "p")
     assert tuple(block.properties[0]) == (2, 0)
 
     assert_equal(block.values, np.full((4, 3, 1), 4.0))
@@ -263,7 +263,7 @@ def test_keys_to_samples(tensor):
 
     # The first two blocks are not modified
     block = tensor.block(0)
-    assert block.samples.names, ("samples", "key_2")
+    assert block.samples.names, ("s", "key_2")
     assert tuple(block.samples[0]) == (0, 0)
     assert tuple(block.samples[1]) == (2, 0)
     assert tuple(block.samples[2]) == (4, 0)
@@ -271,7 +271,7 @@ def test_keys_to_samples(tensor):
     assert_equal(block.values, np.full((3, 1, 1), 1.0))
 
     block = tensor.block(1)
-    assert block.samples.names == ("samples", "key_2")
+    assert block.samples.names == ("s", "key_2")
     assert tuple(block.samples[0]) == (0, 0)
     assert tuple(block.samples[1]) == (1, 0)
     assert tuple(block.samples[2]) == (3, 0)
@@ -281,7 +281,7 @@ def test_keys_to_samples(tensor):
     # The new third block contains the old third and fourth blocks merged
     block = tensor.block(2)
 
-    assert block.samples.names == ("samples", "key_2")
+    assert block.samples.names == ("s", "key_2")
     assert tuple(block.samples[0]) == (0, 2)
     assert tuple(block.samples[1]) == (0, 3)
     assert tuple(block.samples[2]) == (1, 3)
@@ -305,8 +305,8 @@ def test_keys_to_samples(tensor):
     )
     assert_equal(block.values, expected)
 
-    gradient = block.gradient("parameter")
-    assert gradient.samples.names == ("sample", "parameter")
+    gradient = block.gradient("g")
+    assert gradient.samples.names == ("sample", "g")
     assert tuple(gradient.samples[0]) == (1, 1)
     assert tuple(gradient.samples[1]) == (4, -2)
     assert tuple(gradient.samples[2]) == (5, 3)
@@ -325,7 +325,7 @@ def test_keys_to_samples_unsorted(tensor):
     tensor = tensor.keys_to_samples("key_2", sort_samples=False)
 
     block = tensor.block(2)
-    assert block.samples.names, ("samples", "key_2")
+    assert block.samples.names, ("s", "key_2")
     assert tuple(block.samples[0]) == (0, 2)
     assert tuple(block.samples[1]) == (3, 2)
     assert tuple(block.samples[2]) == (6, 2)
@@ -337,21 +337,21 @@ def test_keys_to_samples_unsorted(tensor):
 
 
 def test_components_to_properties(tensor):
-    tensor = tensor.components_to_properties("components")
+    tensor = tensor.components_to_properties("c")
 
     block = tensor.block(0)
-    assert block.samples.names == ("samples",)
+    assert block.samples.names == ("s",)
     assert tuple(block.samples[0]) == (0,)
     assert tuple(block.samples[1]) == (2,)
     assert tuple(block.samples[2]) == (4,)
 
     assert block.components == []
 
-    assert block.properties.names == ("components", "properties")
+    assert block.properties.names == ("c", "p")
     assert tuple(block.properties[0]) == (0, 0)
 
     block = tensor.block(3)
-    assert block.samples.names, ("samples",)
+    assert block.samples.names, ("s",)
     assert tuple(block.samples[0]) == (0,)
     assert tuple(block.samples[1]) == (1,)
     assert tuple(block.samples[2]) == (2,)
@@ -359,7 +359,7 @@ def test_components_to_properties(tensor):
 
     assert block.components == []
 
-    assert block.properties.names == ("components", "properties")
+    assert block.properties.names == ("c", "p")
     assert tuple(block.properties[0]) == (0, 0)
     assert tuple(block.properties[1]) == (1, 0)
     assert tuple(block.properties[2]) == (2, 0)
@@ -386,7 +386,7 @@ def test_mul(tensor):
 
 
 def test_matmul(tensor):
-    tensor = tensor.components_to_properties("components")
+    tensor = tensor.components_to_properties("c")
     tensor = equistore.remove_gradients(tensor)
 
     assert equistore.dot(tensor, tensor) == (tensor @ tensor)

--- a/python/tests/utils.py
+++ b/python/tests/utils.py
@@ -15,63 +15,63 @@ def tensor():
     """
     block_1 = TensorBlock(
         values=np.full((3, 1, 1), 1.0),
-        samples=Labels(["samples"], np.array([[0], [2], [4]])),
-        components=[Labels(["components"], np.array([[0]]))],
-        properties=Labels(["properties"], np.array([[0]])),
+        samples=Labels(["s"], np.array([[0], [2], [4]])),
+        components=[Labels(["c"], np.array([[0]]))],
+        properties=Labels(["p"], np.array([[0]])),
     )
     block_1.add_gradient(
-        "parameter",
-        samples=Labels(["sample", "parameter"], np.array([[0, -2], [2, 3]])),
+        "g",
+        samples=Labels(["sample", "g"], np.array([[0, -2], [2, 3]])),
         data=np.full((2, 1, 1), 11.0),
-        components=[Labels(["components"], np.array([[0]]))],
+        components=[Labels(["c"], np.array([[0]]))],
     )
 
     block_2 = TensorBlock(
         values=np.full((3, 1, 3), 2.0),
-        samples=Labels(["samples"], np.array([[0], [1], [3]])),
-        components=[Labels(["components"], np.array([[0]]))],
-        properties=Labels(["properties"], np.array([[3], [4], [5]])),
+        samples=Labels(["s"], np.array([[0], [1], [3]])),
+        components=[Labels(["c"], np.array([[0]]))],
+        properties=Labels(["p"], np.array([[3], [4], [5]])),
     )
     block_2.add_gradient(
-        "parameter",
+        "g",
         data=np.full((3, 1, 3), 12.0),
         samples=Labels(
-            ["sample", "parameter"],
+            ["sample", "g"],
             np.array([[0, -2], [0, 3], [2, -2]]),
         ),
-        components=[Labels(["components"], np.array([[0]]))],
+        components=[Labels(["c"], np.array([[0]]))],
     )
 
     block_3 = TensorBlock(
         values=np.full((4, 3, 1), 3.0),
-        samples=Labels(["samples"], np.array([[0], [3], [6], [8]])),
-        components=[Labels.arange("components", 3)],
-        properties=Labels(["properties"], np.array([[0]])),
+        samples=Labels(["s"], np.array([[0], [3], [6], [8]])),
+        components=[Labels.arange("c", 3)],
+        properties=Labels(["p"], np.array([[0]])),
     )
     block_3.add_gradient(
-        "parameter",
+        "g",
         data=np.full((1, 3, 1), 13.0),
         samples=Labels(
-            ["sample", "parameter"],
+            ["sample", "g"],
             np.array([[1, -2]]),
         ),
-        components=[Labels.arange("components", 3)],
+        components=[Labels.arange("c", 3)],
     )
 
     block_4 = TensorBlock(
         values=np.full((4, 3, 1), 4.0),
-        samples=Labels(["samples"], np.array([[0], [1], [2], [5]])),
-        components=[Labels.arange("components", 3)],
-        properties=Labels(["properties"], np.array([[0]])),
+        samples=Labels(["s"], np.array([[0], [1], [2], [5]])),
+        components=[Labels.arange("c", 3)],
+        properties=Labels(["p"], np.array([[0]])),
     )
     block_4.add_gradient(
-        "parameter",
+        "g",
         data=np.full((2, 3, 1), 14.0),
         samples=Labels(
-            ["sample", "parameter"],
+            ["sample", "g"],
             np.array([[0, 1], [3, 3]]),
         ),
-        components=[Labels.arange("components", 3)],
+        components=[Labels.arange("c", 3)],
     )
 
     # TODO: different number of components?
@@ -94,18 +94,18 @@ def large_tensor():
     for i in range(8):
         tmp_bl = TensorBlock(
             values=np.full((4, 3, 1), 4.0),
-            samples=Labels(["samples"], np.array([[0], [1], [4], [5]])),
-            components=[Labels.arange("components", 3)],
-            properties=Labels(["properties"], np.array([[i]])),
+            samples=Labels(["s"], np.array([[0], [1], [4], [5]])),
+            components=[Labels.arange("c", 3)],
+            properties=Labels(["p"], np.array([[i]])),
         )
         tmp_bl.add_gradient(
-            "parameter",
+            "g",
             data=np.full((2, 3, 1), 14.0),
             samples=Labels(
-                ["sample", "parameter"],
+                ["sample", "g"],
                 np.array([[0, 1], [3, 3]]),
             ),
-            components=[Labels.arange("components", 3)],
+            components=[Labels.arange("c", 3)],
         )
         block_list.append(tmp_bl)
 


### PR DESCRIPTION
This PR is better reviewed one commit at the time!

This contains multiple small improvements to:

- operations parameter names
- tests readability
- porting some tests to pytest

This also fix #175 as a side effect

---

I can split the PR in one PR per commit if you prefer!

<!-- readthedocs-preview equistore start -->
----
:books: Documentation preview :books:: https://equistore--252.org.readthedocs.build/en/252/

<!-- readthedocs-preview equistore end -->