### PR TITLE
When converting between npz formats, save files uncompressed

### DIFF
--- a/python/scripts/convert-equistore-npz.py
+++ b/python/scripts/convert-equistore-npz.py
@@ -40,5 +40,5 @@ if __name__ == "__main__":
         data = transform_equistore_npz(path)
         if data is not None:
             shutil.copyfile(path, path + ".bak")
-            np.savez_compressed(path, **data)
+            np.savez(path, **data)
             print(f"converted {path}, a backup is at {path}.bak")


### PR DESCRIPTION
This is a follow-up to #253. I used `savez_compressed` there to update the tests data, but this should not be the default since equistore-core does not know how to read such files.

<!-- readthedocs-preview equistore start -->
----
:books: Documentation preview :books:: https://equistore--259.org.readthedocs.build/en/259/

<!-- readthedocs-preview equistore end -->