### PR TITLE
Upgrade minimal CMake version to 3.16

### DIFF
--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -28,19 +28,14 @@ jobs:
             do-valgrind: true
             extra-name: ", all features, release"
 
-          # MSRV (Minimally Supported Rust Version)
+          # check the build on a stock Ubuntu 20.04, which uses cmake 3.16, and
+          # with our minimal supported rust version
           - os: ubuntu-20.04
             rust-version: 1.61
+            container: ubuntu:20.04
             rust-target: x86_64-unknown-linux-gnu
             cargo-build-flags: --features=rayon
-
-          # check the build on a stock Ubuntu 18.04, including cmake 3.10
-          - os: ubuntu-20.04
-            rust-version: from Ubuntu
-            container: ubuntu:18.04
-            rust-target: x86_64-unknown-linux-gnu
-            cargo-build-flags: --all-features
-            extra-name: ", all features"
+            extra-name: ", cmake 3.16, all features"
 
           - os: macos-11
             rust-version: stable
@@ -49,21 +44,16 @@ jobs:
             extra-name: ", all features"
     steps:
       - name: install dependencies in container
-        if: matrix.container == 'ubuntu:18.04'
+        if: matrix.container == 'ubuntu:20.04'
         run: |
           apt update
           apt install -y software-properties-common
-          add-apt-repository -y ppa:git-core/ppa
-          add-apt-repository ppa:deadsnakes/ppa
-          apt install -y cmake make gcc g++ git curl rustc cargo
-          apt install -y python3.7 python3-pip
-          ln -s /usr/bin/python3.7 /usr/bin/python
+          apt install -y cmake make gcc g++ git curl
 
       - uses: actions/checkout@v3
 
       - name: setup rust
         uses: dtolnay/rust-toolchain@master
-        if: "!matrix.container"
         with:
           toolchain: ${{ matrix.rust-version }}
           target: ${{ matrix.rust-target }}

--- a/equistore-core/CMakeLists.txt
+++ b/equistore-core/CMakeLists.txt
@@ -3,7 +3,7 @@
 # This API is implemented in Rust, in the equistore-core crate, but Rust users
 # of the API should use the equistore crate instead, wrapping equistore-core in
 # an easier to use, idiomatic Rust API.
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.16)
 
 # Is equistore the main project configured by the user? Or is this being used
 # as a submodule/subdirectory?
@@ -24,9 +24,6 @@ if (POLICY CMP0077)
     # use variables to set OPTIONS
     cmake_policy(SET CMP0077 NEW)
 endif()
-
-set(CMAKE_CXX_STANDARD 11)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 file(STRINGS "Cargo.toml" CARGO_TOML_CONTENT)
 foreach(line ${CARGO_TOML_CONTENT})
@@ -209,27 +206,18 @@ set_target_properties(equistore::shared PROPERTIES
     IMPORTED_LOCATION ${EQUISTORE_SHARED_LOCATION}
     INTERFACE_INCLUDE_DIRECTORIES ${EQUISTORE_INCLUDE_DIR}
 )
+target_compile_features(equistore::shared INTERFACE cxx_std_11)
 
 set_target_properties(equistore::static PROPERTIES
     IMPORTED_LOCATION ${EQUISTORE_STATIC_LOCATION}
     INTERFACE_INCLUDE_DIRECTORIES ${EQUISTORE_INCLUDE_DIR}
 )
+target_compile_features(equistore::static INTERFACE cxx_std_11)
 
-if (${CMAKE_VERSION} VERSION_GREATER_EQUAL 3.11)
-    if (BUILD_SHARED_LIBS)
-        add_library(equistore ALIAS equistore::shared)
-    else()
-        add_library(equistore ALIAS equistore::static)
-    endif()
+if (BUILD_SHARED_LIBS)
+    add_library(equistore ALIAS equistore::shared)
 else()
-    # CMake 3.10 (default on Ubuntu 20.04) does not support ALIAS for IMPORTED
-    # libraries
-    add_library(equistore INTERFACE)
-    if (BUILD_SHARED_LIBS)
-        target_link_libraries(equistore INTERFACE equistore::shared)
-    else()
-        target_link_libraries(equistore INTERFACE equistore::static)
-    endif()
+    add_library(equistore ALIAS equistore::static)
 endif()
 
 #------------------------------------------------------------------------------#

--- a/equistore-core/cmake/equistore-config.in.cmake
+++ b/equistore-core/cmake/equistore-config.in.cmake
@@ -1,6 +1,6 @@
 @PACKAGE_INIT@
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.16)
 
 if(equistore_FOUND)
     return()
@@ -29,11 +29,7 @@ if (@EQUISTORE_INSTALL_BOTH_STATIC_SHARED@ OR @BUILD_SHARED_LIBS@)
         INTERFACE_INCLUDE_DIRECTORIES ${EQUISTORE_INCLUDE}
     )
 
-    if (${CMAKE_VERSION} VERSION_GREATER_EQUAL 3.11)
-        # we can not set compile features for imported targets before cmake 3.11
-        # users will have to manually request C++11
-        target_compile_features(equistore::shared INTERFACE cxx_std_11)
-    endif()
+    target_compile_features(equistore::shared INTERFACE cxx_std_11)
 endif()
 
 
@@ -59,31 +55,13 @@ if (@EQUISTORE_INSTALL_BOTH_STATIC_SHARED@ OR NOT @BUILD_SHARED_LIBS@)
         target_link_libraries(equistore::static INTERFACE m)
     endif()
 
-    if (${CMAKE_VERSION} VERSION_GREATER_EQUAL 3.11)
-        # we can not set compile features for imported targets before cmake 3.11
-        # users will have to manually request C++11
-        target_compile_features(equistore::static INTERFACE cxx_std_11)
-    endif()
+    target_compile_features(equistore::static INTERFACE cxx_std_11)
 endif()
 
 
 # Export either the shared or static library as the equistore target
 if (@BUILD_SHARED_LIBS@)
-    if (${CMAKE_VERSION} VERSION_GREATER_EQUAL 3.11)
-        add_library(equistore ALIAS equistore::shared)
-    else()
-        # CMake 3.10 (default on Ubuntu 20.04) does not support ALIAS for IMPORTED
-        # libraries
-        add_library(equistore INTERFACE)
-        target_link_libraries(equistore INTERFACE equistore::shared)
-    endif()
+    add_library(equistore ALIAS equistore::shared)
 else()
-    if (${CMAKE_VERSION} VERSION_GREATER_EQUAL 3.11)
-        add_library(equistore ALIAS equistore::static)
-    else()
-        # CMake 3.10 (default on Ubuntu 20.04) does not support ALIAS for IMPORTED
-        # libraries
-        add_library(equistore INTERFACE)
-        target_link_libraries(equistore INTERFACE equistore::static)
-    endif()
+    add_library(equistore ALIAS equistore::static)
 endif()

--- a/equistore-core/tests/cmake-project/CMakeLists.txt
+++ b/equistore-core/tests/cmake-project/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.16)
 
 project(equistore-test-cmake-project C CXX)
 
@@ -10,17 +10,11 @@ target_link_libraries(c-main equistore)
 add_executable(c-main-static src/main.c)
 target_link_libraries(c-main-static equistore::static)
 
-if (${CMAKE_VERSION} VERSION_LESS 3.11)
-    set(CMAKE_CXX_STANDARD 11)
-    set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
-endif()
-
 add_executable(cxx-main src/main.cpp)
 target_link_libraries(cxx-main equistore)
 
 add_executable(cxx-main-static src/main.cpp)
 target_link_libraries(cxx-main-static equistore::static)
-
 
 enable_testing()
 add_test(NAME c-main COMMAND c-main)

--- a/equistore-core/tests/cpp/CMakeLists.txt
+++ b/equistore-core/tests/cpp/CMakeLists.txt
@@ -1,9 +1,5 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.16)
 project(equistore-tests)
-
-set(CMAKE_CXX_STANDARD 11)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_NO_SYSTEM_FROM_IMPORTED ON)
 
 if (${CMAKE_CURRENT_SOURCE_DIR} STREQUAL ${CMAKE_SOURCE_DIR})
     if("${CMAKE_BUILD_TYPE}" STREQUAL "" AND "${CMAKE_CONFIGURATION_TYPES}" STREQUAL "")
@@ -63,6 +59,7 @@ foreach(_file_ ${ALL_TESTS})
         # cmake does not find the library on the filesystem and does not add the
         # RPATH to executables linking to it
         BUILD_RPATH ${EQUISTORE_DIR}
+        NO_SYSTEM_FROM_IMPORTED ON
     )
     target_compile_definitions(${_name_} PRIVATE "-DDATA_NPZ=\"${CMAKE_CURRENT_SOURCE_DIR}/../../../equistore/tests/data.npz\"")
 

--- a/equistore-core/tests/cpp/external/CMakeLists.txt
+++ b/equistore-core/tests/cpp/external/CMakeLists.txt
@@ -1,33 +1,3 @@
-function(unpack_library _name_)
-    set(_archive_ ${CMAKE_CURRENT_SOURCE_DIR}/${_name_}.tar.gz)
-    file(SHA256 ${_archive_} _shasum_)
-    if(NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}/${_name_}/${_shasum_}")
-        message(STATUS "Unpacking ${_name_} sources")
-        execute_process(
-            COMMAND ${CMAKE_COMMAND} -E remove_directory ${_name_}
-            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-        )
-        execute_process(
-            COMMAND ${CMAKE_COMMAND} -E tar xf ${_archive_}
-            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-        )
-        execute_process(
-            COMMAND ${CMAKE_COMMAND} -E touch ${_name_}/${_shasum_}
-            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-        )
-    endif()
-
-    if(EXISTS "${CMAKE_CURRENT_BINARY_DIR}/${_name_}/.git")
-        # .git directories can get huge and increase the size of this repository
-        message(FATAL_ERROR "${_name_} archive contains a .git directory, please remove it")
-    endif()
-
-    # make sure cmake re-runs whenever the file changes
-    get_directory_property(_previous_list_ CMAKE_CONFIGURE_DEPENDS)
-    set_directory_properties(PROPERTIES CMAKE_CONFIGURE_DEPENDS "${_previous_list_};${_name_}.tar.gz")
-endfunction()
-
-
-
 add_library(catch STATIC catch/catch.cpp)
 target_include_directories(catch PUBLIC catch)
+target_compile_features(catch PUBLIC cxx_std_11)


### PR DESCRIPTION
This is the default for Ubuntu 20.04, and it is relatively easy to get a newer version if someone needs it on a different system.

<!-- readthedocs-preview equistore start -->
----
:books: Documentation preview :books:: https://equistore--267.org.readthedocs.build/en/267/

<!-- readthedocs-preview equistore end -->