### PR TITLE
Fix all function for torch array when axis is None

### DIFF
--- a/python/equistore-operations/equistore/operations/_dispatch.py
+++ b/python/equistore-operations/equistore/operations/_dispatch.py
@@ -32,7 +32,12 @@ def all(a, axis=None):
     if isinstance(a, np.ndarray):
         return np.all(a=a, axis=axis)
     elif isinstance(a, TorchTensor):
-        return torch.all(input=a, dim=axis)
+        # torch.all has two implementation, and picks one depending if more than one
+        # parameter is given. The second one does not supports setting dim to `None`
+        if axis is None:
+            return torch.all(input=a)
+        else:
+            return torch.all(input=a, dim=axis)
     else:
         raise TypeError(UNKNOWN_ARRAY_TYPE)
 

--- a/python/equistore-operations/tests/dispatch.py
+++ b/python/equistore-operations/tests/dispatch.py
@@ -1,0 +1,29 @@
+import numpy as np
+import pytest
+
+import equistore
+
+
+try:
+    import torch
+
+    HAS_TORCH = True
+except ImportError:
+    HAS_TORCH = False
+
+if HAS_TORCH:
+    create_array_functions = [np.array, torch.tensor]
+else:
+    create_array_functions = [np.array]
+
+
+all_true_array = [True, True, True]
+all_false_array = [True, True, False]
+
+
+@pytest.mark.parametrize("create_array_function", create_array_functions)
+def test_all(create_array_function):
+    assert equistore.operations._dispatch.all(create_array_function(all_true_array))
+    assert not equistore.operations._dispatch.all(
+        create_array_function(all_false_array)
+    )


### PR DESCRIPTION
dim=None results in an error, because torch uses a different function when dim is not given.

I would like to add a test, but it seems like one has to to adapt the tests that they also run for torch arrays and that is a bit too much for me now.

<!-- readthedocs-preview equistore start -->
----
:books: Documentation preview :books:: https://equistore--269.org.readthedocs.build/en/269/

<!-- readthedocs-preview equistore end -->