### PR TITLE
Re-enable building from a full repo archive

### DIFF
--- a/python/equistore-core/setup.py
+++ b/python/equistore-core/setup.py
@@ -124,20 +124,71 @@ def get_rust_version():
     return version
 
 
+def git_extra_version():
+    """
+    If git is available, it is used to check if we are installing a development
+    version or a released version (by checking how many commits happened since
+    the last tag).
+    """
+
+    # Add pre-release info the version
+    try:
+        tags_list = subprocess.run(
+            ["git", "tag"],
+            stderr=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            check=True,
+        )
+        tags_list = tags_list.stdout.decode("utf8").strip()
+
+        if tags_list == "":
+            first_commit = subprocess.run(
+                ["git", "rev-list", "--max-parents=0", "HEAD"],
+                stderr=subprocess.DEVNULL,
+                stdout=subprocess.PIPE,
+                check=True,
+            )
+            reference = first_commit.stdout.decode("utf8").strip()
+
+        else:
+            last_tag = subprocess.run(
+                ["git", "describe", "--tags", "--abbrev=0"],
+                stderr=subprocess.DEVNULL,
+                stdout=subprocess.PIPE,
+                check=True,
+            )
+
+            reference = last_tag.stdout.decode("utf8").strip()
+
+    except Exception:
+        reference = ""
+        pass
+
+    try:
+        n_commits_since_tag = subprocess.run(
+            ["git", "rev-list", f"{reference}..HEAD", "--count"],
+            stderr=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            check=True,
+        )
+        n_commits_since_tag = n_commits_since_tag.stdout.decode("utf8").strip()
+
+        if n_commits_since_tag != 0:
+            return ".dev" + n_commits_since_tag
+    except Exception:
+        pass
+
+    return ""
+
+
 if __name__ == "__main__":
     with open(os.path.join(ROOT, "AUTHORS")) as fd:
         authors = fd.read().splitlines()
 
     if authors[0].startswith(".."):
-        raise RuntimeError(
-            "AUTHORS file must be a symbolic link or the full file. "
-            + "If you are building from Windows, enable git symlinks "
-            + "(https://gist.github.com/huenisys/1efb64e57c37cfab7054c65702588fce) "
-            + "and clone the code again."
-        )
-
-    sys.path.append(ROOT)
-    from version_from_git import git_extra_version
+        # handle "raw" symlink files (on Windows or from full repo tarball)
+        with open(os.path.join(ROOT, authors[0])) as fd:
+            authors = fd.read().splitlines()
 
     version = get_rust_version() + git_extra_version()
 

--- a/python/equistore-core/version_from_git.py
+++ b/python/equistore-core/version_from_git.py
@@ -1,1 +1,0 @@
-../equistore/version_from_git.py

--- a/python/equistore-operations/setup.py
+++ b/python/equistore-operations/setup.py
@@ -1,4 +1,5 @@
 import os
+import subprocess
 import sys
 import uuid
 
@@ -26,26 +27,77 @@ class bdist_egg_disabled(bdist_egg):
         )
 
 
+def git_extra_version():
+    """
+    If git is available, it is used to check if we are installing a development
+    version or a released version (by checking how many commits happened since
+    the last tag).
+    """
+
+    # Add pre-release info the version
+    try:
+        tags_list = subprocess.run(
+            ["git", "tag"],
+            stderr=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            check=True,
+        )
+        tags_list = tags_list.stdout.decode("utf8").strip()
+
+        if tags_list == "":
+            first_commit = subprocess.run(
+                ["git", "rev-list", "--max-parents=0", "HEAD"],
+                stderr=subprocess.DEVNULL,
+                stdout=subprocess.PIPE,
+                check=True,
+            )
+            reference = first_commit.stdout.decode("utf8").strip()
+
+        else:
+            last_tag = subprocess.run(
+                ["git", "describe", "--tags", "--abbrev=0"],
+                stderr=subprocess.DEVNULL,
+                stdout=subprocess.PIPE,
+                check=True,
+            )
+
+            reference = last_tag.stdout.decode("utf8").strip()
+
+    except Exception:
+        reference = ""
+        pass
+
+    try:
+        n_commits_since_tag = subprocess.run(
+            ["git", "rev-list", f"{reference}..HEAD", "--count"],
+            stderr=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            check=True,
+        )
+        n_commits_since_tag = n_commits_since_tag.stdout.decode("utf8").strip()
+
+        if n_commits_since_tag != 0:
+            return ".dev" + n_commits_since_tag
+    except Exception:
+        pass
+
+    return ""
+
+
 if __name__ == "__main__":
     with open(os.path.join(ROOT, "AUTHORS")) as fd:
         authors = fd.read().splitlines()
 
     if authors[0].startswith(".."):
-        raise RuntimeError(
-            "AUTHORS file must be a symbolic link or the full file. "
-            + "If you are building from Windows, enable git symlinks "
-            + "(https://gist.github.com/huenisys/1efb64e57c37cfab7054c65702588fce) "
-            + "and clone the code again."
-        )
-
-    sys.path.append(ROOT)
-    from version_from_git import git_extra_version
+        # handle "raw" symlink files (on Windows or from full repo tarball)
+        with open(os.path.join(ROOT, authors[0])) as fd:
+            authors = fd.read().splitlines()
 
     version = "0.1.0" + git_extra_version()
 
     install_requires = []
     if os.path.exists(EQUISTORE_CORE):
-        # we are building from a git checkout
+        # we are building from a git checkout or full repo archive
 
         # add a random uuid to the file url to prevent pip from using a cached
         # wheel for equistore-core, and force it to re-build from scratch

--- a/python/equistore-operations/version_from_git.py
+++ b/python/equistore-operations/version_from_git.py
@@ -1,1 +1,0 @@
-../equistore/version_from_git.py


### PR DESCRIPTION
Full repo archive contains raw symlink (similar to windows) which we need to handle when reading `AUTHORS` / `version_from_git`

<!-- readthedocs-preview equistore start -->
----
:books: Documentation preview :books:: https://equistore--273.org.readthedocs.build/en/273/

<!-- readthedocs-preview equistore end -->