### PR TITLE
Add `equal_metadata_raise` functions

### DIFF
--- a/docs/src/reference/operations/logic/equal_metadata.rst
+++ b/docs/src/reference/operations/logic/equal_metadata.rst
@@ -4,3 +4,7 @@ equal_metadata
 .. autofunction:: equistore.equal_metadata
 
 .. autofunction:: equistore.equal_metadata_block
+
+.. autofunction:: equistore.equal_metadata_raise
+
+.. autofunction:: equistore.equal_metadata_block_raise

--- a/python/equistore-operations/equistore/operations/__init__.py
+++ b/python/equistore-operations/equistore/operations/__init__.py
@@ -34,7 +34,12 @@ from .dot import dot
 from .drop_blocks import drop_blocks
 from .empty_like import empty_like, empty_like_block
 from .equal import equal, equal_block, equal_block_raise, equal_raise
-from .equal_metadata import equal_metadata, equal_metadata_block
+from .equal_metadata import (
+    equal_metadata,
+    equal_metadata_block,
+    equal_metadata_raise,
+    equal_metadata_block_raise,
+)
 from .join import join
 from .lstsq import lstsq
 from .multiply import multiply
@@ -67,9 +72,9 @@ __all__ = [
     "abs",
     "add",
     "allclose",
-    "allclose_raise",
     "allclose_block",
     "allclose_block_raise",
+    "allclose_raise",
     "block_from_array",
     "block_to",
     "checks_enabled",
@@ -79,30 +84,32 @@ __all__ = [
     "empty_like",
     "empty_like_block",
     "equal",
-    "equal_raise",
     "equal_block",
     "equal_block_raise",
     "equal_metadata",
     "equal_metadata_block",
+    "equal_metadata_block_raise",
+    "equal_metadata_raise",
+    "equal_raise",
     "join",
     "lstsq",
     "mean_over_samples",
     "mean_over_samples_block",
+    "multiply",
     "one_hot",
     "ones_like",
     "ones_like_block",
+    "pow",
     "random_uniform_like",
     "random_uniform_like_block",
-    "multiply",
-    "pow",
     "remove_gradients",
     "slice",
     "slice_block",
-    "std_over_samples",
-    "std_over_samples_block",
     "solve",
     "split",
     "split_block",
+    "std_over_samples",
+    "std_over_samples_block",
     "subtract",
     "sum_over_samples",
     "sum_over_samples_block",

--- a/python/equistore-operations/equistore/operations/equal_metadata.py
+++ b/python/equistore-operations/equistore/operations/equal_metadata.py
@@ -91,45 +91,11 @@ def equal_metadata(
     ... )
     True
     """
-    # Check input args
-    if not isinstance(tensor_1, TensorMap):
-        raise TypeError(f"`tensor_1` must be a TensorMap, not {type(tensor_1)}")
-    if not isinstance(tensor_2, TensorMap):
-        raise TypeError(f"`tensor_2` must be a TensorMap, not {type(tensor_2)}")
-    if not isinstance(check, (list, type(None))):
-        raise TypeError(f"`check` must be a list, not {type(check)}")
-    if check is None:
-        check = ["samples", "components", "properties"]
-    for metadata in check:
-        if not isinstance(metadata, str):
-            raise TypeError(
-                f"`check` must be a list of strings, got list of {type(metadata)}"
-            )
-        if metadata not in ["samples", "components", "properties"]:
-            raise ValueError(f"Invalid metadata to check: {metadata}")
-    # Check equivalence in keys
     try:
-        _check_same_keys(tensor_1, tensor_2, "equal_metadata")
+        equal_metadata_raise(tensor_1, tensor_2, check)
+        return True
     except NotEqualError:
         return False
-
-    # Loop over the blocks
-    for key in tensor_1.keys:
-        block_1 = tensor_1[key]
-        block_2 = tensor_2[key]
-
-        # Check metadata of the blocks
-        try:
-            _check_blocks(block_1, block_2, check, "equal_metadata")
-        except NotEqualError:
-            return False
-
-        # Check metadata of the gradients
-        try:
-            _check_same_gradients(block_1, block_2, check, "equal_metadata")
-        except NotEqualError:
-            return False
-    return True
 
 
 def equal_metadata_block(
@@ -181,7 +147,160 @@ def equal_metadata_block(
     ... )
     True
     """
-    # Check input args
+    try:
+        equal_metadata_block_raise(block_1, block_2, check)
+        return True
+    except NotEqualError:
+        return False
+
+
+def equal_metadata_raise(
+    tensor_1: TensorMap, tensor_2: TensorMap, check: Optional[List] = None
+):
+    """
+    Raise a :py:class:`NotEqualError` if two :py:class:`TensorMap` have unequal
+    metadata.
+
+    The equivalence of the keys of the two :py:class:`TensorMap` objects is
+    always checked. If ``check`` is none (the default), all metadata (i.e. the
+    samples, components, and properties of each block) is checked to contain the
+    same values in the same order.
+
+    Passing ``check`` as a list of strings will only check the metadata specified.
+    Allowed values to pass are "samples", "components", and "properties".
+
+    :param tensor_1: The first :py:class:`TensorMap`.
+    :param tensor_2: The second :py:class:`TensorMap` to compare to the first.
+    :param check: A list of strings specifying which metadata of each block to
+        check. If none, all metadata is checked. Allowed values are "samples",
+        "components", and "properties".
+    :raises NotEqualError: If the metadata is not the same.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> import equistore
+    >>> from equistore import Labels, TensorBlock, TensorMap
+    >>> tensor_1 = TensorMap(
+    ...     keys=Labels(
+    ...         names=["key_1", "key_2"],
+    ...         values=np.array([[1, 0], [2, 2]]),
+    ...     ),
+    ...     blocks=[
+    ...         TensorBlock(
+    ...             values=np.full((4, 3, 1), 4.0),
+    ...             samples=Labels(["samples"], np.array([[0], [1], [4], [5]])),
+    ...             components=[Labels.arange("components", 3)],
+    ...             properties=Labels(["p_1", "p_2"], np.array([[0, 1]])),
+    ...         ),
+    ...         TensorBlock(
+    ...             values=np.full((4, 3, 1), 4.0),
+    ...             samples=Labels(["samples"], np.array([[0], [1], [4], [5]])),
+    ...             components=[Labels.arange("components", 3)],
+    ...             properties=Labels(["p_1", "p_2"], np.array([[0, 1]])),
+    ...         ),
+    ...     ],
+    ... )
+    >>> tensor_2 = TensorMap(
+    ...     keys=Labels(
+    ...         names=["key_1", "key_2"],
+    ...         values=np.array([[1, 0], [2, 2]]),
+    ...     ),
+    ...     blocks=[
+    ...         TensorBlock(
+    ...             values=np.full((4, 3, 1), 4.0),
+    ...             samples=Labels(["samples"], np.array([[0], [1], [4], [5]])),
+    ...             components=[Labels.arange("components", 3)],
+    ...             properties=Labels(["p_3", "p_4"], np.array([[0, 1]])),
+    ...         ),
+    ...         TensorBlock(
+    ...             values=np.full((4, 3, 1), 4.0),
+    ...             samples=Labels(["samples"], np.array([[0], [1], [4], [5]])),
+    ...             components=[Labels.arange("components", 3)],
+    ...             properties=Labels(["p_3", "p_4"], np.array([[0, 1]])),
+    ...         ),
+    ...     ],
+    ... )
+    >>> equistore.equal_metadata_raise(tensor_1, tensor_2)
+    Traceback (most recent call last):
+        ...
+    equistore.operations._utils.NotEqualError: inputs to 'equal_metadata_block_raise' should have the same properties:
+    properties names are not the same or not in the same order
+    >>> equistore.equal_metadata_raise(
+    ...     tensor_1,
+    ...     tensor_2,
+    ...     check=["samples", "components"],
+    ... )
+    """  # noqa: E501
+    if not isinstance(tensor_1, TensorMap):
+        raise TypeError(f"`tensor_1` must be a TensorMap, not {type(tensor_1)}")
+    if not isinstance(tensor_2, TensorMap):
+        raise TypeError(f"`tensor_2` must be a TensorMap, not {type(tensor_2)}")
+    if not isinstance(check, (list, type(None))):
+        raise TypeError(f"`check` must be a list, not {type(check)}")
+    if check is None:
+        check = ["samples", "components", "properties"]
+    for metadata in check:
+        if not isinstance(metadata, str):
+            raise TypeError(
+                f"`check` must be a list of strings, got list of {type(metadata)}"
+            )
+        if metadata not in ["samples", "components", "properties"]:
+            raise ValueError(f"Invalid metadata to check: {metadata}")
+
+    _check_same_keys(tensor_1, tensor_2, "equal_metadata_raise")
+
+    for key in tensor_1.keys:
+        equal_metadata_block_raise(tensor_1[key], tensor_2[key], check=check)
+
+
+def equal_metadata_block_raise(
+    block_1: TensorBlock, block_2: TensorBlock, check: Optional[List] = None
+):
+    """
+    Raise a :py:class:`NotEqualError` if two :py:class:`TensorBlock` have unequal
+    metadata.
+
+    If ``check`` is none (the default), all metadata (i.e. the samples,
+    components, and properties of each block) is checked to contain the same
+    values in the same order.
+
+    Passing ``check`` as a list of strings will only check the metadata specified.
+    Allowed values to pass are "samples", "components", and "properties".
+
+    :param block_1: The first :py:class:`TensorBlock`.
+    :param block_2: The second :py:class:`TensorBlock` to compare to the first.
+    :param check: A list of strings specifying which metadata of each block to
+        check. If none, all metadata is checked. Allowed values are "samples",
+        "components", and "properties".
+    :raises NotEqualError: If the metadata is not the same.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> import equistore
+    >>> from equistore import Labels, TensorBlock
+    >>> block_1 = TensorBlock(
+    ...     values=np.full((4, 3, 1), 4.0),
+    ...     samples=Labels(["samples"], np.array([[0], [1], [4], [5]])),
+    ...     components=[Labels.arange("components", 3)],
+    ...     properties=Labels(["p_1", "p_2"], np.array([[0, 1]])),
+    ... )
+    >>> block_2 = TensorBlock(
+    ...     values=np.full((4, 3, 1), 4.0),
+    ...     samples=Labels(["samples"], np.array([[0], [1], [4], [5]])),
+    ...     components=[Labels.arange("components", 3)],
+    ...     properties=Labels(["p_3", "p_4"], np.array([[0, 1]])),
+    ... )
+    >>> equistore.equal_metadata_block_raise(block_1, block_2)
+    Traceback (most recent call last):
+        ...
+    equistore.operations._utils.NotEqualError: inputs to 'equal_metadata_block_raise' should have the same properties:
+    properties names are not the same or not in the same order
+    >>> equistore.equal_metadata_block_raise(
+    ...     block_1, block_2, check=["samples", "components"]
+    ... )
+    """  # noqa: E501
     if not isinstance(block_1, TensorBlock):
         raise TypeError(f"`block_1` must be a TensorBlock, not {type(block_1)}")
     if not isinstance(block_2, TensorBlock):
@@ -198,15 +317,5 @@ def equal_metadata_block(
         if metadata not in ["samples", "components", "properties"]:
             raise ValueError(f"Invalid metadata to check: {metadata}")
 
-    # Check metadata of the blocks
-    try:
-        _check_blocks(block_1, block_2, check, "equal_metadata_block")
-    except NotEqualError:
-        return False
-
-    # Check metadata of the gradients
-    try:
-        _check_same_gradients(block_1, block_2, check, "equal_metadata_block")
-    except NotEqualError:
-        return False
-    return True
+    _check_blocks(block_1, block_2, check, "equal_metadata_block_raise")
+    _check_same_gradients(block_1, block_2, check, "equal_metadata_block_raise")

--- a/python/equistore-operations/tests/equal_metadata.py
+++ b/python/equistore-operations/tests/equal_metadata.py
@@ -5,6 +5,7 @@ import pytest
 
 import equistore
 from equistore import Labels, TensorBlock, TensorMap
+from equistore.operations._utils import NotEqualError
 
 
 DATA_ROOT = os.path.join(os.path.dirname(__file__), "data")
@@ -134,27 +135,51 @@ def tensor_map() -> TensorMap:
 
 
 def test_self(test_tensor_map_1):
-    # check if the metadata of the same tensor are equal
+    """check if the metadata of the same tensor are equal"""
     assert equistore.equal_metadata(test_tensor_map_1, test_tensor_map_1)
 
 
+def test_self_raise(test_tensor_map_1):
+    """check no error raise the metadata of the same tensor are equal"""
+    equistore.equal_metadata_raise(test_tensor_map_1, test_tensor_map_1)
+
+
 def test_self_block(test_tensor_block_1):
-    # check if the metadata of the same tensor are equal
+    """check if the metadata of the same tensor are equal"""
     assert equistore.equal_metadata_block(test_tensor_block_1, test_tensor_block_1)
 
 
+def test_self_block_raise(test_tensor_block_1):
+    """check no error raise if the metadata of the same tensor are equal"""
+    equistore.equal_metadata_block_raise(test_tensor_block_1, test_tensor_block_1)
+
+
 def test_two_tensors(test_tensor_map_1, test_tensor_map_2):
-    # check if the metadata of two tensor maps are equal
+    """check if the metadata of two tensor maps are equal"""
     assert not equistore.equal_metadata(test_tensor_map_1, test_tensor_map_2)
 
 
+def test_two_tensors_raise(test_tensor_map_1, test_tensor_map_2):
+    """check error raise if the metadata of two tensor maps are equal"""
+    error_message = "should have the same keys names"
+    with pytest.raises(NotEqualError, match=error_message):
+        equistore.equal_metadata_raise(test_tensor_map_1, test_tensor_map_2)
+
+
 def test_two_tensors_block(test_tensor_block_1, test_tensor_block_2):
-    # check if the metadata of two tensor maps are equal
+    """check if the metadata of two tensor maps are equal"""
     assert not equistore.equal_metadata_block(test_tensor_block_1, test_tensor_block_2)
 
 
+def test_two_tensors_block_raise(test_tensor_block_1, test_tensor_block_2):
+    """check error raise if the metadata of two tensor maps are equal"""
+    error_message = "components of the two `TensorBlock` have different lengths"
+    with pytest.raises(NotEqualError, match=error_message):
+        equistore.equal_metadata_block_raise(test_tensor_block_1, test_tensor_block_2)
+
+
 def test_after_drop(test_tensor_map_1):
-    # check if dropping an existing block changes the metadata
+    """check if dropping an existing block changes the metadata"""
     new_key = Labels(
         test_tensor_map_1.keys.names, np.array([tuple(test_tensor_map_1.keys[0])])
     )
@@ -162,8 +187,19 @@ def test_after_drop(test_tensor_map_1):
     assert not equistore.equal_metadata(test_tensor_map_1, new_tesnor)
 
 
+def test_after_drop_raise(test_tensor_map_1):
+    """check if dropping an existing block changes the metadata"""
+    new_key = Labels(
+        test_tensor_map_1.keys.names, np.array([tuple(test_tensor_map_1.keys[0])])
+    )
+    new_tesnor = equistore.drop_blocks(test_tensor_map_1, new_key)
+    error_message = "should have the same number of blocks, got 17 and 16"
+    with pytest.raises(NotEqualError, match=error_message):
+        equistore.equal_metadata_raise(test_tensor_map_1, new_tesnor)
+
+
 def test_single_nonexisting_meta(test_tensor_map_1, test_tensor_map_2):
-    # check behavior if non existing metadata is provided
+    """check behavior if non existing metadata is provided"""
     # wrong metadata key alone
     wrong_meta = "species"
     error_message = f"Invalid metadata to check: {wrong_meta}"
@@ -196,7 +232,7 @@ def test_single_nonexisting_meta(test_tensor_map_1, test_tensor_map_2):
 
 
 def test_single_nonexisting_meta_block(test_tensor_block_1, test_tensor_block_2):
-    # check behavior if non existing metadata is provided
+    """check behavior if non existing metadata is provided"""
     # wrong metadata key alone
     wrong_meta = "species"
     error_message = f"Invalid metadata to check: {wrong_meta}"
@@ -229,7 +265,7 @@ def test_single_nonexisting_meta_block(test_tensor_block_1, test_tensor_block_2)
 
 
 def test_changing_tensor_key_order(test_tensor_map_1):
-    # check changing the key order
+    """check changing the key order"""
     keys = test_tensor_map_1.keys
     new_keys = keys[::-1]
     new_blocks = [test_tensor_map_1[key].copy() for key in new_keys]
@@ -238,7 +274,7 @@ def test_changing_tensor_key_order(test_tensor_map_1):
 
 
 def test_changing_samples_key_order(test_tensor_map_1):
-    # changing the order of the values of the samples should yield False
+    """Test changing the order of the values of the samples should yield False"""
     new_blocks = []
     for key in test_tensor_map_1.keys:
         block = test_tensor_map_1[key].copy()
@@ -266,7 +302,7 @@ def test_changing_samples_key_order(test_tensor_map_1):
 
 
 def test_changing_samples_key_order_block(test_tensor_block_1):
-    # changing the order of the values of the samples should yield False
+    """Changing the order of the values of the samples should yield False"""
     block = test_tensor_block_1.copy()
     samples = block.samples[::-1]
     new_block = TensorBlock(
@@ -290,7 +326,7 @@ def test_changing_samples_key_order_block(test_tensor_block_1):
 
 
 def test_changing_properties_key_order(test_tensor_map_1):
-    # changing the order of the values of the properties should yield False
+    """changing the order of the values of the properties should yield False"""
     new_blocks = []
     for key in test_tensor_map_1.keys:
         block = test_tensor_map_1[key].copy()
@@ -318,7 +354,7 @@ def test_changing_properties_key_order(test_tensor_map_1):
 
 
 def test_changing_properties_key_order_block(test_tensor_block_1):
-    # changing the order of the values of the samples should yield False
+    """changing the order of the values of the samples should yield False"""
     block = test_tensor_block_1.copy()
     properties = block.properties[::-1]
     new_block = TensorBlock(
@@ -342,7 +378,7 @@ def test_changing_properties_key_order_block(test_tensor_block_1):
 
 
 def test_add_components_key_order(tensor_map):
-    # changing the order of the values of the components should yield False
+    """changing the order of the values of the components should yield False"""
     new_blocks = []
     for key in tensor_map.keys:
         block = tensor_map[key].copy()
@@ -370,7 +406,7 @@ def test_add_components_key_order(tensor_map):
 
 
 def test_remove_last_sample(tensor_map):
-    # removing the last sample should yield False
+    """removing the last sample should yield False"""
     new_blocks = []
     for key in tensor_map.keys:
         block = tensor_map[key].copy()
@@ -397,7 +433,7 @@ def test_remove_last_sample(tensor_map):
 
 
 def test_remove_last_property(tensor_map):
-    # removing the last property should yield False
+    """removing the last property should yield False"""
     new_blocks = []
     for key in tensor_map.keys:
         block = tensor_map[key].copy()
@@ -424,7 +460,7 @@ def test_remove_last_property(tensor_map):
 
 
 def test_remove_last_component(tensor_map):
-    # removing the last component should yield False
+    """removing the last component should yield False"""
     new_blocks = []
     for key in tensor_map.keys:
         block = tensor_map[key].copy()


### PR DESCRIPTION
The functions `equal_metadata` and `equal_metadata_block` are useful but they lack feedback what actually is going wrong even though the underlying functions give a quite good feedback. This PR adds the two `equal_metadata_raise ` and `equal_metadata_block_raise` which will raise an error and give a propper error message. 