### PR TITLE
Do not call std::slice::from_raw_parts with null pointer

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -40,6 +40,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+
       - name: setup rust
         uses: dtolnay/rust-toolchain@master
         with:

--- a/equistore-core/src/c_api/blocks.rs
+++ b/equistore-core/src/c_api/blocks.rs
@@ -69,8 +69,11 @@ pub unsafe extern fn eqs_block(
         let samples = eqs_labels_to_rust(&samples)?;
 
         let mut rust_components = Vec::new();
-        for component in std::slice::from_raw_parts(components, components_count) {
-            rust_components.push(eqs_labels_to_rust(component)?);
+        if components_count != 0 {
+            check_pointers!(components);
+            for component in std::slice::from_raw_parts(components, components_count) {
+                rust_components.push(eqs_labels_to_rust(component)?);
+            }
         }
 
         let properties = eqs_labels_to_rust(&properties)?;

--- a/equistore-core/src/data.rs
+++ b/equistore-core/src/data.rs
@@ -279,6 +279,8 @@ impl eqs_array_t {
             });
         }
 
+        assert!(len > 0);
+        assert!(!data_ptr.is_null());
         let data = unsafe {
             std::slice::from_raw_parts(data_ptr, len)
         };
@@ -311,6 +313,8 @@ impl eqs_array_t {
             });
         }
 
+        assert!(len > 0);
+        assert!(!data_ptr.is_null());
         let data = unsafe {
             std::slice::from_raw_parts_mut(data_ptr, len)
         };
@@ -340,6 +344,8 @@ impl eqs_array_t {
             });
         }
 
+        assert!(shape_count > 0);
+        assert!(!shape.is_null());
         let shape = unsafe {
             std::slice::from_raw_parts(shape, shape_count)
         };

--- a/equistore/src/block/block_ref.rs
+++ b/equistore/src/block/block_ref.rs
@@ -192,6 +192,7 @@ impl<'a> TensorBlockRef<'a> {
             )).expect("failed to get gradient list");
         }
 
+        assert!(!parameters_ptr.is_null());
         unsafe {
             let parameters = std::slice::from_raw_parts(parameters_ptr, parameters_count);
             return parameters.iter()

--- a/equistore/src/data/array_ref.rs
+++ b/equistore/src/data/array_ref.rs
@@ -294,6 +294,7 @@ impl eqs_array_t {
             )?;
         }
 
+        assert!(shape_count > 0);
         let shape = unsafe {
             std::slice::from_raw_parts(shape, shape_count)
         };
@@ -317,6 +318,7 @@ impl eqs_array_t {
                 function(self.ptr, &mut data_ptr),
                 "eqs_array_t.data"
             )?;
+            assert!(len != 0);
             std::slice::from_raw_parts_mut(data_ptr, len)
         };
 

--- a/equistore/src/io.rs
+++ b/equistore/src/io.rs
@@ -80,6 +80,7 @@ unsafe extern fn create_ndarray(
     c_array: *mut eqs_array_t,
 ) -> eqs_status_t {
     crate::errors::catch_unwind(|| {
+        assert!(shape_count != 0);
         let shape = std::slice::from_raw_parts(shape_ptr, shape_count);
         let array = ndarray::ArrayD::from_elem(shape, 0.0);
         *c_array = (Box::new(array) as Box<dyn Array>).into();

--- a/equistore/src/labels.rs
+++ b/equistore/src/labels.rs
@@ -234,9 +234,15 @@ impl Labels {
     /// Get the names of the entries/columns in this set of labels
     #[inline]
     pub fn names(&self) -> Vec<&str> {
-        unsafe {
-            let names = std::slice::from_raw_parts(self.raw.names, self.raw.size);
-            names.iter().map(|&ptr| CStr::from_ptr(ptr).to_str().expect("invalid UTF8")).collect()
+        if self.raw.size == 0 {
+            return Vec::new();
+        } else {
+            unsafe {
+                let names = std::slice::from_raw_parts(self.raw.names, self.raw.size);
+                return names.iter()
+                            .map(|&ptr| CStr::from_ptr(ptr).to_str().expect("invalid UTF8"))
+                            .collect();
+            }
         }
     }
 
@@ -310,8 +316,12 @@ impl Labels {
     }
 
     pub(crate) fn values(&self) -> &[LabelValue] {
-        unsafe {
-            std::slice::from_raw_parts(self.raw.values.cast(), self.count() * self.size())
+        if self.count() == 0 || self.size() == 0 {
+            return &[]
+        } else {
+            unsafe {
+                std::slice::from_raw_parts(self.raw.values.cast(), self.count() * self.size())
+            }
         }
     }
 }


### PR DESCRIPTION
Extracted from #263. 

This function can not be called with a null pointer, even if the length of the slice is zero, cf https://doc.rust-lang.org/std/slice/fn.from_raw_parts.html.

So in cases where the C API allow the pointer to be null when the length is zero, we manually create an empty slice.

<!-- readthedocs-preview equistore start -->
----
:books: Documentation preview :books:: https://equistore--276.org.readthedocs.build/en/276/

<!-- readthedocs-preview equistore end -->