### PR TITLE
Fix version specification for Python packages

### DIFF
--- a/python/equistore-operations/setup.py
+++ b/python/equistore-operations/setup.py
@@ -105,7 +105,7 @@ if __name__ == "__main__":
         install_requires.append(f"equistore-core @ file://{EQUISTORE_CORE}?{uuid}")
     else:
         # we are building from a sdist/installing from a wheel
-        install_requires.append("equistore-core ~=0.1.0")
+        install_requires.append("equistore-core ==0.1.0")
 
     setup(
         version=version,

--- a/setup.py
+++ b/setup.py
@@ -49,8 +49,8 @@ if __name__ == "__main__":
         )
     else:
         # we are building from a sdist/installing from a wheel
-        install_requires.append("equistore-core ~=0.1.0")
-        install_requires.append("equistore-operations ~=0.1.0")
+        install_requires.append("equistore-core ==0.1.0")
+        install_requires.append("equistore-operations ==0.1.0")
 
     setup(
         version=version,


### PR DESCRIPTION
`~=` means "not this version"

<!-- readthedocs-preview equistore start -->
----
:books: Documentation preview :books:: https://equistore--279.org.readthedocs.build/en/279/

<!-- readthedocs-preview equistore end -->