### PR TITLE
Removing try-catch blocks from equistore-operations

### DIFF
--- a/python/equistore-core/equistore/core/block.py
+++ b/python/equistore-core/equistore/core/block.py
@@ -226,7 +226,7 @@ class TensorBlock:
             (e.g. ``positions``, ``cell``, ...)
 
         >>> import numpy as np
-        >>> from equistore import TensorBlock, Labels
+        >>> from equistore import Labels, TensorBlock
         >>> block = TensorBlock(
         ...     values=np.full((3, 1, 5), 1.0),
         ...     samples=Labels(["structure"], np.array([[0], [2], [4]])),
@@ -305,7 +305,7 @@ class TensorBlock:
             :py:class:`TensorBlock` containing values.
 
         >>> import numpy as np
-        >>> from equistore import TensorBlock, Labels
+        >>> from equistore import Labels, TensorBlock
         >>> block = TensorBlock(
         ...     values=np.full((3, 1, 1), 1.0),
         ...     samples=Labels(["structure"], np.array([[0], [2], [4]])),

--- a/python/equistore-operations/equistore/operations/_utils.py
+++ b/python/equistore-operations/equistore/operations/_utils.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Union
 
 import numpy as np
 
@@ -11,7 +11,17 @@ class NotEqualError(Exception):
     pass
 
 
-def _check_same_keys(a: TensorMap, b: TensorMap, fname: str):
+def _check_same_keys(a: TensorMap, b: TensorMap, fname: str) -> bool:
+    return not bool(_check_same_keys_impl(a, b, fname))
+
+
+def _check_same_keys_raise(a: TensorMap, b: TensorMap, fname: str) -> None:
+    message = _check_same_keys_impl(a, b, fname)
+    if message != "":
+        raise NotEqualError(message)
+
+
+def _check_same_keys_impl(a: TensorMap, b: TensorMap, fname: str) -> str:
     """Check if metadata between two TensorMaps is consistent for an operation.
 
     The functions verifies that
@@ -22,28 +32,46 @@ def _check_same_keys(a: TensorMap, b: TensorMap, fname: str):
 
     :param a: first :py:class:`TensorMap` for check
     :param b: second :py:class:`TensorMap` for check
+    :param fname: name of the function where the check is performed. The input will be
+                  used to generate a meaningful error message.
     """
 
     keys_a = a.keys
     keys_b = b.keys
 
     if keys_a.names != keys_b.names:
-        raise NotEqualError(
+        return (
             f"inputs to {fname} should have the same keys names, "
             f"got '{keys_a.names}' and '{keys_b.names}'"
         )
 
     if len(keys_a) != len(keys_b):
-        raise NotEqualError(
+        return (
             f"inputs to {fname} should have the same number of blocks, "
             f"got {len(keys_a)} and {len(keys_b)}"
         )
 
     if not np.all([key in keys_a for key in keys_b]):
-        raise NotEqualError(f"inputs to {fname} should have the same keys")
+        return f"inputs to {fname} should have the same keys"
+
+    return ""
 
 
-def _check_blocks(a: TensorBlock, b: TensorBlock, props: List[str], fname: str):
+def _check_blocks(a: TensorBlock, b: TensorBlock, props: List[str], fname: str) -> str:
+    return not bool(_check_blocks_impl(a, b, props, fname))
+
+
+def _check_blocks_raise(
+    a: TensorBlock, b: TensorBlock, props: List[str], fname: str
+) -> None:
+    message = _check_blocks_impl(a, b, props, fname)
+    if message != "":
+        raise NotEqualError(message)
+
+
+def _check_blocks_impl(
+    a: TensorBlock, b: TensorBlock, props: List[str], fname: str
+) -> str:
     """Check if metadata between two TensorBlocks is consistent for an operation.
 
     The functions verifies that that the metadata of the given props is the same
@@ -63,42 +91,45 @@ def _check_blocks(a: TensorBlock, b: TensorBlock, props: List[str], fname: str):
 
         if prop == "samples":
             if not len(a.samples) == len(b.samples):
-                raise NotEqualError(err_msg + err_msg_len)
+                return err_msg + err_msg_len
             if not a.samples.names == b.samples.names:
-                raise NotEqualError(err_msg + err_msg_names)
+                return err_msg + err_msg_names
             if not np.all(a.samples == b.samples):
-                raise NotEqualError(err_msg + err_msg_1)
+                return err_msg + err_msg_1
 
         elif prop == "properties":
             if not len(a.properties) == len(b.properties):
-                raise NotEqualError(err_msg + err_msg_len)
+                return err_msg + err_msg_len
             if not a.properties.names == b.properties.names:
-                raise NotEqualError(err_msg + err_msg_names)
+                return err_msg + err_msg_names
             if not np.all(a.properties == b.properties):
-                raise NotEqualError(err_msg + err_msg_1)
+                return err_msg + err_msg_1
 
         elif prop == "components":
             if len(a.components) != len(b.components):
-                raise NotEqualError(err_msg + err_msg_len)
+                return err_msg + err_msg_len
 
             for c1, c2 in zip(a.components, b.components):
                 if not (c1.names == c2.names):
-                    raise NotEqualError(err_msg + err_msg_names)
+                    return err_msg + err_msg_names
 
                 if not (len(c1) == len(c2)):
-                    raise NotEqualError(err_msg + err_msg_1)
+                    return err_msg + err_msg_1
 
                 if not np.all(c1 == c2):
-                    raise NotEqualError(err_msg + err_msg_1)
+                    return err_msg + err_msg_1
 
         else:
             raise ValueError(
                 f"{prop} is not a valid property to check, "
                 "choose from ['samples', 'properties', 'components']"
             )
+    return ""
 
 
-def _check_same_gradients(a: TensorBlock, b: TensorBlock, props: List[str], fname: str):
+def _check_same_gradients(
+    a: TensorBlock, b: TensorBlock, props: List[str], fname: str
+) -> bool:
     """
     Check if metadata between two gradients's TensorBlocks is consistent
      for an operation.
@@ -116,6 +147,45 @@ def _check_same_gradients(a: TensorBlock, b: TensorBlock, props: List[str], fnam
                  ``props=None``, using ``'parameters'`` is allowed
                   even though deprecated.
     """
+    return not bool(_check_same_gradients_impl(a, b, props, fname))
+
+
+def _check_same_gradients_raise(
+    a: TensorBlock, b: TensorBlock, props: List[str], fname: str
+) -> None:
+    """
+    Check if metadata between two gradients's TensorBlocks is consistent for an
+    operation.
+
+    The message associated with the exception will contain more information on where the
+    gradients of the two :py:class:`TensorBlock` differ. See
+    :py:func:`_check_same_gradients` for more information on when gradients of
+    :py:class:`TensorBlock` are considered as equal.
+
+    :raises: :py:class:`equistore.NotEqualError` if the gradients of the blocks are
+        different
+
+    :param a: first :py:class:`TensorBlock` for check
+    :param b: second :py:class:`TensorBlock` for check
+    :param props: A list of strings containing the property to check. Allowed values are
+                 ``'samples'`` or ``'properties'``, ``'components'``. To check only if
+                 the ``'parameters'`` are consistent use ``props=None``, using
+                 ``'parameters'`` is allowed
+                  even though deprecated.
+
+    :raises: :py:class:`NotImplementedError` if one of :py:class:`TensorBlock` inputs
+             has gradients of gradients
+    :raises: :py:class:`ValueError` if an invalid prop name in :param props: is given.
+             See :param props: description for valid prop names
+    """
+    message = _check_same_gradients_impl(a, b, props, fname)
+    if message != "":
+        raise NotEqualError(message)
+
+
+def _check_same_gradients_impl(
+    a: TensorBlock, b: TensorBlock, props: List[str], fname: str
+) -> Union[str, None]:
     err_msg = f"inputs to {fname} should have the same gradients:\n"
     gradients_list_a = a.gradients_list()
     gradients_list_b = b.gradients_list()
@@ -123,9 +193,7 @@ def _check_same_gradients(a: TensorBlock, b: TensorBlock, props: List[str], fnam
     if len(gradients_list_a) != len(gradients_list_b) or (
         not np.all([parameter in gradients_list_b for parameter in gradients_list_a])
     ):
-        raise NotEqualError(
-            f"inputs to {fname} should have the same gradient parameters"
-        )
+        return f"inputs to {fname} should have the same gradient parameters"
 
     for parameter, grad_a in a.gradients():
         grad_b = b.gradient(parameter)
@@ -151,29 +219,29 @@ def _check_same_gradients(a: TensorBlock, b: TensorBlock, props: List[str], fnam
 
                 if prop == "samples":
                     if not len(grad_a.samples) == len(grad_b.samples):
-                        raise NotEqualError(err_msg + err_msg_len)
+                        return err_msg + err_msg_len
                     if not grad_a.samples.names == grad_b.samples.names:
-                        raise NotEqualError(err_msg + err_msg_names)
+                        return err_msg + err_msg_names
                     if not np.all(grad_a.samples == grad_b.samples):
-                        raise NotEqualError(err_msg + err_msg_1)
+                        return err_msg + err_msg_1
 
                 elif prop == "properties":
                     if not len(grad_a.properties) == len(grad_b.properties):
-                        raise NotEqualError(err_msg + err_msg_len)
+                        return err_msg + err_msg_len
                     if not grad_a.properties.names == grad_b.properties.names:
-                        raise NotEqualError(err_msg + err_msg_names)
+                        return err_msg + err_msg_names
                     if not np.all(grad_a.properties == grad_b.properties):
-                        raise NotEqualError(err_msg + err_msg_1)
+                        return err_msg + err_msg_1
                 elif prop == "components":
                     if len(grad_a.components) != len(grad_b.components):
-                        raise NotEqualError(err_msg + err_msg_len)
+                        return err_msg + err_msg_len
 
                     for c1, c2 in zip(grad_a.components, grad_b.components):
                         if not (c1.names == c2.names):
-                            raise NotEqualError(err_msg + err_msg_names)
+                            return err_msg + err_msg_names
 
                         if not np.all(c1 == c2):
-                            raise NotEqualError(err_msg + err_msg_1)
+                            return err_msg + err_msg_1
 
                 elif prop != "parameters":
                     # parameters are already checked at the beginning but i want
@@ -183,6 +251,7 @@ def _check_same_gradients(a: TensorBlock, b: TensorBlock, props: List[str], fnam
                         f"{prop} is not a valid property to check, "
                         "choose from ['samples', 'properties', 'components']"
                     )
+    return ""
 
 
 def _check_gradient_presence(block: TensorBlock, parameters: List[str], fname: str):

--- a/python/equistore-operations/equistore/operations/equal_metadata.py
+++ b/python/equistore-operations/equistore/operations/equal_metadata.py
@@ -7,10 +7,71 @@ from equistore.core import TensorBlock, TensorMap
 
 from ._utils import (
     NotEqualError,
-    _check_blocks,
-    _check_same_gradients,
-    _check_same_keys,
+    _check_blocks_impl,
+    _check_same_gradients_impl,
+    _check_same_keys_impl,
 )
+
+
+def _equal_metadata_impl(
+    tensor_1: TensorMap, tensor_2: TensorMap, check: Optional[List] = None
+) -> str:
+    if not isinstance(tensor_1, TensorMap):
+        return f"`tensor_1` must be a TensorMap, not {type(tensor_1)}"
+    if not isinstance(tensor_2, TensorMap):
+        return f"`tensor_2` must be a TensorMap, not {type(tensor_2)}"
+    if not isinstance(check, (list, type(None))):
+        return f"`check` must be a list, not {type(check)}"
+    if check is None:
+        check = ["samples", "components", "properties"]
+    for metadata in check:
+        if not isinstance(metadata, str):
+            return f"`check` must be a list of strings, got list of {type(metadata)}"
+
+        if metadata not in ["samples", "components", "properties"]:
+            return f"Invalid metadata to check: {metadata}"
+
+    message = _check_same_keys_impl(tensor_1, tensor_2, "equal_metadata_raise")
+    if message != "":
+        return message
+
+    for key in tensor_1.keys:
+        message = _equal_metadata_block_impl(tensor_1[key], tensor_2[key], check=check)
+        if message != "":
+            return message
+
+    return ""
+
+
+def _equal_metadata_block_impl(
+    block_1: TensorBlock, block_2: TensorBlock, check: Optional[List] = None
+) -> str:
+    if not isinstance(block_1, TensorBlock):
+        return f"`block_1` must be a TensorBlock, not {type(block_1)}"
+    if not isinstance(block_2, TensorBlock):
+        return f"`block_2` must be a TensorBlock, not {type(block_2)}"
+    if not isinstance(check, (list, type(None))):
+        return f"`check` must be a list, not {type(check)}"
+    if check is None:
+        check = ["samples", "components", "properties"]
+    for metadata in check:
+        if not isinstance(metadata, str):
+            return f"`check` must be a list of strings, got list of {type(metadata)}"
+        if metadata not in ["samples", "components", "properties"]:
+            return f"Invalid metadata to check: {metadata}"
+
+    check_blocks_message = _check_blocks_impl(
+        block_1, block_2, check, "equal_metadata_block_raise"
+    )
+    if check_blocks_message != "":
+        return check_blocks_message
+    check_same_gradient_message = _check_same_gradients_impl(
+        block_1, block_2, check, "equal_metadata_block_raise"
+    )
+    if check_same_gradient_message != "":
+        return check_same_gradient_message
+
+    return ""
 
 
 def equal_metadata(
@@ -91,67 +152,7 @@ def equal_metadata(
     ... )
     True
     """
-    try:
-        equal_metadata_raise(tensor_1, tensor_2, check)
-        return True
-    except NotEqualError:
-        return False
-
-
-def equal_metadata_block(
-    block_1: TensorBlock, block_2: TensorBlock, check: Optional[List] = None
-) -> bool:
-    """
-    Checks if two :py:class:`TensorBlock` objects have the same metadata,
-    returning a bool.
-
-    If ``check`` is none (the default), all metadata (i.e. the samples,
-    components, and properties of each block) is checked to contain the same
-    values in the same order.
-
-    Passing ``check`` as a list of strings will only check the metadata specified.
-    Allowed values to pass are "samples", "components", and "properties".
-
-    :param block_1: The first :py:class:`TensorBlock`.
-    :param block_2: The second :py:class:`TensorBlock` to compare to the first.
-    :param check: A list of strings specifying which metadata of each block to
-        check. If none, all metadata is checked. Allowed values are "samples",
-        "components", and "properties".
-
-    :return: True if the metadata of the two :py:class:`TensorBlock` objects are
-        equal, False otherwise.
-
-    Examples
-    --------
-    >>> import numpy as np
-    >>> import equistore
-    >>> from equistore import Labels, TensorBlock
-    >>> block_1 = TensorBlock(
-    ...     values=np.full((4, 3, 1), 4.0),
-    ...     samples=Labels(["samples"], np.array([[0], [1], [4], [5]])),
-    ...     components=[Labels.range("components", 3)],
-    ...     properties=Labels(["p_1", "p_2"], np.array([[0, 1]])),
-    ... )
-    >>> block_2 = TensorBlock(
-    ...     values=np.full((4, 3, 1), 4.0),
-    ...     samples=Labels(["samples"], np.array([[0], [1], [4], [5]])),
-    ...     components=[Labels.range("components", 3)],
-    ...     properties=Labels(["p_3", "p_4"], np.array([[0, 1]])),
-    ... )
-    >>> equal_metadata_block(block_1, block_2)
-    False
-    >>> equal_metadata_block(
-    ...     block_1,
-    ...     block_2,
-    ...     check=["samples", "components"],
-    ... )
-    True
-    """
-    try:
-        equal_metadata_block_raise(block_1, block_2, check)
-        return True
-    except NotEqualError:
-        return False
+    return not bool(_equal_metadata_impl(tensor_1, tensor_2, check))
 
 
 def equal_metadata_raise(
@@ -232,26 +233,61 @@ def equal_metadata_raise(
     ...     check=["samples", "components"],
     ... )
     """  # noqa: E501
-    if not isinstance(tensor_1, TensorMap):
-        raise TypeError(f"`tensor_1` must be a TensorMap, not {type(tensor_1)}")
-    if not isinstance(tensor_2, TensorMap):
-        raise TypeError(f"`tensor_2` must be a TensorMap, not {type(tensor_2)}")
-    if not isinstance(check, (list, type(None))):
-        raise TypeError(f"`check` must be a list, not {type(check)}")
-    if check is None:
-        check = ["samples", "components", "properties"]
-    for metadata in check:
-        if not isinstance(metadata, str):
-            raise TypeError(
-                f"`check` must be a list of strings, got list of {type(metadata)}"
-            )
-        if metadata not in ["samples", "components", "properties"]:
-            raise ValueError(f"Invalid metadata to check: {metadata}")
+    message = _equal_metadata_impl(tensor_1, tensor_2, check)
+    if message != "":
+        raise NotEqualError(message)
 
-    _check_same_keys(tensor_1, tensor_2, "equal_metadata_raise")
 
-    for key in tensor_1.keys:
-        equal_metadata_block_raise(tensor_1[key], tensor_2[key], check=check)
+def equal_metadata_block(
+    block_1: TensorBlock, block_2: TensorBlock, check: Optional[List] = None
+) -> bool:
+    """
+    Checks if two :py:class:`TensorBlock` objects have the same metadata,
+    returning a bool.
+
+    If ``check`` is none (the default), all metadata (i.e. the samples,
+    components, and properties of each block) is checked to contain the same
+    values in the same order.
+
+    Passing ``check`` as a list of strings will only check the metadata specified.
+    Allowed values to pass are "samples", "components", and "properties".
+
+    :param block_1: The first :py:class:`TensorBlock`.
+    :param block_2: The second :py:class:`TensorBlock` to compare to the first.
+    :param check: A list of strings specifying which metadata of each block to
+        check. If none, all metadata is checked. Allowed values are "samples",
+        "components", and "properties".
+
+    :return: True if the metadata of the two :py:class:`TensorBlock` objects are
+        equal, False otherwise.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> import equistore
+    >>> from equistore import Labels, TensorBlock
+    >>> block_1 = TensorBlock(
+    ...     values=np.full((4, 3, 1), 4.0),
+    ...     samples=Labels(["samples"], np.array([[0], [1], [4], [5]])),
+    ...     components=[Labels.range("components", 3)],
+    ...     properties=Labels(["p_1", "p_2"], np.array([[0, 1]])),
+    ... )
+    >>> block_2 = TensorBlock(
+    ...     values=np.full((4, 3, 1), 4.0),
+    ...     samples=Labels(["samples"], np.array([[0], [1], [4], [5]])),
+    ...     components=[Labels.range("components", 3)],
+    ...     properties=Labels(["p_3", "p_4"], np.array([[0, 1]])),
+    ... )
+    >>> equal_metadata_block(block_1, block_2)
+    False
+    >>> equal_metadata_block(
+    ...     block_1,
+    ...     block_2,
+    ...     check=["samples", "components"],
+    ... )
+    True
+    """
+    return not bool(_equal_metadata_block_impl(block_1, block_2, check))
 
 
 def equal_metadata_block_raise(
@@ -301,21 +337,6 @@ def equal_metadata_block_raise(
     ...     block_1, block_2, check=["samples", "components"]
     ... )
     """  # noqa: E501
-    if not isinstance(block_1, TensorBlock):
-        raise TypeError(f"`block_1` must be a TensorBlock, not {type(block_1)}")
-    if not isinstance(block_2, TensorBlock):
-        raise TypeError(f"`block_2` must be a TensorBlock, not {type(block_2)}")
-    if not isinstance(check, (list, type(None))):
-        raise TypeError(f"`check` must be a list, not {type(check)}")
-    if check is None:
-        check = ["samples", "components", "properties"]
-    for metadata in check:
-        if not isinstance(metadata, str):
-            raise TypeError(
-                f"`check` must be a list of strings, got list of {type(metadata)}"
-            )
-        if metadata not in ["samples", "components", "properties"]:
-            raise ValueError(f"Invalid metadata to check: {metadata}")
-
-    _check_blocks(block_1, block_2, check, "equal_metadata_block_raise")
-    _check_same_gradients(block_1, block_2, check, "equal_metadata_block_raise")
+    message = _equal_metadata_block_impl(block_1, block_2, check)
+    if message != "":
+        raise NotEqualError(message)

--- a/python/equistore-operations/tests/allclose.py
+++ b/python/equistore-operations/tests/allclose.py
@@ -42,7 +42,10 @@ def test_allclose_nograd():
     Y = TensorMap(keys, [block_3, block_4])
     assert not equistore.allclose(X, Y)
 
-    message = "blocks for \\(key_1=0, key_2=0\\) are different"
+    message = (
+        r"blocks for key \(key_1=0, key_2=0\) are different: values shapes are "
+        r"different"
+    )
     with pytest.raises(NotEqualError, match=message):
         equistore.allclose_raise(X, Y)
 
@@ -135,8 +138,8 @@ def test_self_allclose_grad():
     assert equistore.allclose(tensor1, tensor1_e6, rtol=1e-5, atol=1e-5)
 
     message = (
-        "blocks for \\(spherical_harmonics_l=0, species_center=1, "
-        "species_neighbor=1\\) are different"
+        r"blocks for key \(spherical_harmonics_l=0, species_center=1, "
+        r"species_neighbor=1\) are different: values are not allclose"
     )
     with pytest.raises(NotEqualError, match=message):
         equistore.allclose_raise(tensor1, tensor1_e6)

--- a/python/equistore-operations/tests/equal.py
+++ b/python/equistore-operations/tests/equal.py
@@ -43,7 +43,10 @@ def test_equal_no_gradient():
     Y = TensorMap(keys, [block_3, block_4])
     assert not equistore.equal(X, Y)
 
-    message = "blocks for \\(key_1=0, key_2=0\\) are different"
+    message = (
+        r"blocks for key \(key_1=0, key_2=0\) are different: values shapes are "
+        r"different"
+    )
     with pytest.raises(NotEqualError, match=message):
         equistore.equal_raise(X, Y)
 
@@ -133,8 +136,8 @@ def test_self_equal_grad():
     assert not equistore.equal(tensor_1, tensor_1_e6)
 
     message = (
-        "blocks for \\(spherical_harmonics_l=0, species_center=1, "
-        "species_neighbor=1\\) are different"
+        r"blocks for key \(spherical_harmonics_l=0, species_center=1, "
+        r"species_neighbor=1\) are different: values are not equal"
     )
     with pytest.raises(NotEqualError, match=message):
         equistore.equal_raise(tensor_1, tensor_1_e6)

--- a/python/equistore-operations/tests/equal_metadata.py
+++ b/python/equistore-operations/tests/equal_metadata.py
@@ -4,8 +4,7 @@ import numpy as np
 import pytest
 
 import equistore
-from equistore import Labels, TensorBlock, TensorMap
-from equistore.operations._utils import NotEqualError
+from equistore import Labels, NotEqualError, TensorBlock, TensorMap
 
 
 DATA_ROOT = os.path.join(os.path.dirname(__file__), "data")
@@ -197,28 +196,28 @@ def test_single_nonexisting_meta(test_tensor_map_1, test_tensor_map_2):
     # wrong metadata key alone
     wrong_meta = "species"
     error_message = f"Invalid metadata to check: {wrong_meta}"
-    with pytest.raises(ValueError, match=error_message):
-        equistore.equal_metadata(
+    with pytest.raises(NotEqualError, match=error_message):
+        equistore.equal_metadata_raise(
             tensor_1=test_tensor_map_1,
             tensor_2=test_tensor_map_1,
             check=[wrong_meta],
         )
-    with pytest.raises(ValueError, match=error_message):
-        equistore.equal_metadata(
+    with pytest.raises(NotEqualError, match=error_message):
+        equistore.equal_metadata_raise(
             tensor_1=test_tensor_map_1,
             tensor_2=test_tensor_map_2,
             check=[wrong_meta],
         )
     # wrong metadata key with another correct one
     correct_meta = "properties"
-    with pytest.raises(ValueError, match=error_message):
-        equistore.equal_metadata(
+    with pytest.raises(NotEqualError, match=error_message):
+        equistore.equal_metadata_raise(
             tensor_1=test_tensor_map_1,
             tensor_2=test_tensor_map_1,
             check=[correct_meta, wrong_meta],
         )
-    with pytest.raises(ValueError, match=error_message):
-        equistore.equal_metadata(
+    with pytest.raises(NotEqualError, match=error_message):
+        equistore.equal_metadata_raise(
             tensor_1=test_tensor_map_1,
             tensor_2=test_tensor_map_2,
             check=[correct_meta, wrong_meta],
@@ -230,28 +229,28 @@ def test_single_nonexisting_meta_block(test_tensor_block_1, test_tensor_block_2)
     # wrong metadata key alone
     wrong_meta = "species"
     error_message = f"Invalid metadata to check: {wrong_meta}"
-    with pytest.raises(ValueError, match=error_message):
-        equistore.equal_metadata_block(
+    with pytest.raises(NotEqualError, match=error_message):
+        equistore.equal_metadata_block_raise(
             block_1=test_tensor_block_1,
             block_2=test_tensor_block_1,
             check=[wrong_meta],
         )
-    with pytest.raises(ValueError, match=error_message):
-        equistore.equal_metadata_block(
+    with pytest.raises(NotEqualError, match=error_message):
+        equistore.equal_metadata_block_raise(
             block_1=test_tensor_block_1,
             block_2=test_tensor_block_2,
             check=[wrong_meta],
         )
     # wrong metadata key with another correct one
     correct_meta = "properties"
-    with pytest.raises(ValueError, match=error_message):
-        equistore.equal_metadata_block(
+    with pytest.raises(NotEqualError, match=error_message):
+        equistore.equal_metadata_block_raise(
             block_1=test_tensor_block_1,
             block_2=test_tensor_block_1,
             check=[correct_meta, wrong_meta],
         )
-    with pytest.raises(ValueError, match=error_message):
-        equistore.equal_metadata_block(
+    with pytest.raises(NotEqualError, match=error_message):
+        equistore.equal_metadata_block_raise(
             block_1=test_tensor_block_1,
             block_2=test_tensor_block_2,
             check=[correct_meta, wrong_meta],


### PR DESCRIPTION
To support TorchScript for the equistore-operations we need to remove all try-catch block. This includes these files
* equal.py
* equal_metadata.py
* allclose.py

We remove the try-catch block by implementing a `_impl_operation` function, that returns an error message, `operation_raise` will raise, `operation` will just check if the error message is empty and depending on this return True or False.

I started with equal.py. The test for this one should pass. **I will continue with the other operations, once I get feedback that the changes in `equal.py` are good**. There is just one small change here worth mentioning: We cannot return simply a backtrace of errors, so I just concatenate the error messages
```python
-        try:
-            equal_block_raise(block_1, tensor_2.block(key))
-        except NotEqualError as e:
-            raise NotEqualError(f"blocks for key '{key}' are different") from e
+        message = _equal_block_impl(block_1, tensor_2.block(key))
+        if message != "":
+            return f"blocks for key '{key}' are different: " + message 
```