### PR TITLE
Update the Python API to match TorchScript

### DIFF
--- a/equistore-torch/include/equistore/torch/labels.hpp
+++ b/equistore-torch/include/equistore/torch/labels.hpp
@@ -221,6 +221,9 @@ public:
     /// implementation of __getitem__, forwarding to one of the operator[]
     int64_t getitem(torch::IValue index) const;
 
+    /// Print this entry as a named tuple (i.e. `(key=value, key=value)`).
+    std::string print() const;
+
     /// Implementation of __repr__ for Python
     std::string __repr__() const;
 

--- a/equistore-torch/src/labels.cpp
+++ b/equistore-torch/src/labels.cpp
@@ -470,10 +470,10 @@ std::string LabelsHolder::__repr__() const {
 
 /******************************************************************************/
 
-std::string LabelsEntryHolder::__repr__() const {
+std::string LabelsEntryHolder::print() const {
     auto output = std::stringstream();
 
-    output << "LabelsEntry(";
+    output << "(";
     for (size_t i=0; i<this->size(); i++) {
         output << this->names()[i] << "=" << values_[i].item<int32_t>();
 
@@ -484,6 +484,10 @@ std::string LabelsEntryHolder::__repr__() const {
     output << ")";
 
     return output.str();
+}
+
+std::string LabelsEntryHolder::__repr__() const {
+    return "LabelsEntry" + this->print();
 }
 
 int32_t LabelsEntryHolder::operator[](const std::string& name) const {

--- a/equistore-torch/src/labels.cpp
+++ b/equistore-torch/src/labels.cpp
@@ -436,7 +436,12 @@ std::string LabelsHolder::print(int64_t max_entries, int64_t indent) const {
         }
     }
 
-    return output.str();
+    // remove the final \n
+    auto output_string = output.str();
+    assert(output_string[output_string.size() - 1] == '\n');
+    output_string.pop_back();
+
+    return output_string;
 }
 
 std::string LabelsHolder::__str__() const {
@@ -447,7 +452,7 @@ std::string LabelsHolder::__str__() const {
         output << "LabelsView(\n   ";
     }
 
-    output << this->print(4, 3) << ")";
+    output << this->print(4, 3) << "\n)";
     return output.str();
 }
 
@@ -459,7 +464,7 @@ std::string LabelsHolder::__repr__() const {
         output << "LabelsView(\n   ";
     }
 
-    output << this->print(-1, 3) << ")";
+    output << this->print(-1, 3) << "\n)";
     return output.str();
 }
 

--- a/equistore-torch/src/register.cpp
+++ b/equistore-torch/src/register.cpp
@@ -53,6 +53,7 @@ TORCH_LIBRARY(equistore, m) {
         )
         .def_property("names", &LabelsEntryHolder::names)
         .def_property("values", &LabelsEntryHolder::values)
+        .def("print", &LabelsEntryHolder::print)
         ;
 
     m.class_<LabelsHolder>("Labels")

--- a/equistore-torch/src/tensor.cpp
+++ b/equistore-torch/src/tensor.cpp
@@ -106,21 +106,13 @@ TorchTensorBlock TensorMapHolder::block(TorchLabelsEntry torch_selection) {
 
     auto matching = tensor_.blocks_matching(selection);
     if (matching.size() == 0) {
-        auto selection_str = torch_selection->__repr__();
-        // remove the starting 'LabelsEntry(' and final ')'
-        selection_str = selection_str.substr(12);
-        selection_str = selection_str.substr(0, selection_str.length() - 1);
         C10_THROW_ERROR(ValueError,
-            "could not find blocks matching the selection '" + selection_str + "'"
+            "could not find blocks matching the selection " + torch_selection->print()
         );
     } else if (matching.size() != 1) {
-        auto selection_str = torch_selection->__repr__();
-        // remove the starting 'LabelsEntry(' and final ')'
-        selection_str = selection_str.substr(12);
-        selection_str = selection_str.substr(0, selection_str.length() - 1);
         C10_THROW_ERROR(ValueError,
-            "got more than one matching block for '" + selection_str +
-            "', use the `blocks` function to select more than one block"
+            "got more than one matching block for " + torch_selection->print() +
+            ", use the `blocks` function to select more than one block"
         );
     }
 

--- a/equistore-torch/tests/labels.cpp
+++ b/equistore-torch/tests/labels.cpp
@@ -46,7 +46,7 @@ TEST_CASE("Labels") {
     SECTION("print") {
         auto labels = LabelsHolder::create({"aaa", "bbb"}, {{1, 2}, {3, 4}});
 
-        auto expected = " aaa  bbb\n     1    2\n     3    4\n";
+        auto expected = " aaa  bbb\n     1    2\n     3    4";
         CHECK(labels->print(-1, 3) == expected);
     }
 

--- a/python/equistore-core/equistore/core/block.py
+++ b/python/equistore-core/equistore/core/block.py
@@ -229,29 +229,29 @@ class TensorBlock:
         >>> block = TensorBlock(
         ...     values=np.full((3, 1, 5), 1.0),
         ...     samples=Labels(["structure"], np.array([[0], [2], [4]])),
-        ...     components=[Labels.arange("component", 1)],
-        ...     properties=Labels.arange("property", 5),
+        ...     components=[Labels.range("component", 1)],
+        ...     properties=Labels.range("property", 5),
         ... )
         >>> positions_gradient = TensorBlock(
         ...     values=np.full((2, 3, 1, 5), 11.0),
         ...     samples=Labels(["sample", "atom"], np.array([[0, 2], [2, 3]])),
         ...     components=[
-        ...         Labels.arange("direction", 3),
-        ...         Labels.arange("component", 1),
+        ...         Labels.range("direction", 3),
+        ...         Labels.range("component", 1),
         ...     ],
-        ...     properties=Labels.arange("property", 5),
+        ...     properties=Labels.range("property", 5),
         ... )
 
         >>> block.add_gradient("positions", positions_gradient)
         >>> cell_gradient = TensorBlock(
         ...     values=np.full((2, 3, 3, 1, 5), 15.0),
-        ...     samples=Labels.arange("sample", 2),
+        ...     samples=Labels.range("sample", 2),
         ...     components=[
-        ...         Labels.arange("direction_1", 3),
-        ...         Labels.arange("direction_2", 3),
-        ...         Labels.arange("component", 1),
+        ...         Labels.range("direction_1", 3),
+        ...         Labels.range("direction_2", 3),
+        ...         Labels.range("component", 1),
         ...     ],
-        ...     properties=Labels.arange("property", 5),
+        ...     properties=Labels.range("property", 5),
         ... )
         >>> block.add_gradient("cell", cell_gradient)
 
@@ -303,14 +303,14 @@ class TensorBlock:
         >>> block = TensorBlock(
         ...     values=np.full((3, 1, 1), 1.0),
         ...     samples=Labels(["structure"], np.array([[0], [2], [4]])),
-        ...     components=[Labels.arange("component", 1)],
-        ...     properties=Labels.arange("property", 1),
+        ...     components=[Labels.range("component", 1)],
+        ...     properties=Labels.range("property", 1),
         ... )
         >>> gradient = TensorBlock(
         ...     values=np.full((2, 1, 1), 11.0),
         ...     samples=Labels(["sample", "parameter"], np.array([[0, -2], [2, 3]])),
-        ...     components=[Labels.arange("component", 1)],
-        ...     properties=Labels.arange("property", 1),
+        ...     components=[Labels.range("component", 1)],
+        ...     properties=Labels.range("property", 1),
         ... )
         >>> block.add_gradient("parameter", gradient)
         >>> print(block)

--- a/python/equistore-core/equistore/core/io.py
+++ b/python/equistore-core/equistore/core/io.py
@@ -149,7 +149,7 @@ def _tensor_map_to_dict(tensor_map):
         "keys": _labels_to_npz(tensor_map.keys),
     }
 
-    for block_i, (_, block) in enumerate(tensor_map):
+    for block_i, block in enumerate(tensor_map.blocks()):
         prefix = f"blocks/{block_i}"
 
         result.update(_block_to_dict(block, prefix))

--- a/python/equistore-core/equistore/core/labels.py
+++ b/python/equistore-core/equistore/core/labels.py
@@ -51,9 +51,15 @@ class LabelsEntry:
         """
         return self._values
 
-    def __repr__(self) -> str:
+    def print(self) -> str:
+        """
+        print this entry as a named tuple (i.e. ``(key_1=value_1, key_2=value_2)``)
+        """
         values = [f"{n}={v}" for n, v in zip(self.names, self.values)]
-        return f"LabelsEntry({', '.join(values)})"
+        return f"({', '.join(values)})"
+
+    def __repr__(self) -> str:
+        return "LabelsEntry" + self.print()
 
     def __len__(self) -> int:
         """number of dimensions in this labels entry"""

--- a/python/equistore-core/equistore/core/labels.py
+++ b/python/equistore-core/equistore/core/labels.py
@@ -365,7 +365,7 @@ class Labels:
 
         When indexing with an integer, get the corresponding row/labels entry.
         """
-        if isinstance(index, int):
+        if isinstance(index, (int, np.int8, np.int16, np.int32, np.int64)):
             return self.entry(index)
         else:
             return self.view(index)
@@ -525,7 +525,13 @@ def _normalize_names_type(names: Union[str, Sequence[str]]) -> List[str]:
         else:
             names = [names]
     else:
-        names = list(names)
+        try:
+            names = list(names)
+        except TypeError:
+            raise TypeError(
+                f"Labels names must be a sequence of strings, got {type(names)} instead"
+            )
+
         for name in names:
             if not isinstance(name, str):
                 raise TypeError(

--- a/python/equistore-core/equistore/core/tensor.py
+++ b/python/equistore-core/equistore/core/tensor.py
@@ -44,6 +44,8 @@ class TensorMap:
         :param keys: keys associated with each block
         :param blocks: set of blocks containing the actual data
         """
+        assert isinstance(keys, Labels)
+
         self._lib = _get_library()
 
         blocks_array_t = ctypes.POINTER(eqs_block_t) * len(blocks)

--- a/python/equistore-core/equistore/core/tensor.py
+++ b/python/equistore-core/equistore/core/tensor.py
@@ -261,17 +261,13 @@ class TensorMap:
             if len(self.keys) == 0:
                 raise ValueError("there are no blocks in this TensorMap")
             else:
-                selection_string = (
-                    str(selection[0]).split("LabelsEntry(")[1].split(")")[0]
-                )
                 raise ValueError(
-                    f"Couldn't find any block matching '{selection_string}'"
+                    f"couldn't find any block matching {selection[0].print()}"
                 )
         elif len(matching) > 1:
-            selection_string = str(selection[0]).split("LabelsEntry(")[1].split(")")[0]
             raise ValueError(
-                f"more than one block matched '{selection_string}', "
-                "use `TensorMap.blocks` if you want to get all of them"
+                f"more than one block matched {selection[0].print()}, "
+                "use `TensorMap.blocks` to get all of them"
             )
         else:
             return self._get_block_by_id(matching[0])
@@ -318,9 +314,8 @@ class TensorMap:
             return []
 
         if len(matching) == 0:
-            selection_string = str(selection[0]).split("LabelsEntry(")[1].split(")")[0]
             raise ValueError(
-                f"Couldn't find any block matching the selection '{selection_string}'"
+                f"Couldn't find any block matching '{selection[0].print()}'"
             )
         else:
             return [self._get_block_by_id(i) for i in matching]

--- a/python/equistore-core/tests/blocks.py
+++ b/python/equistore-core/tests/blocks.py
@@ -133,7 +133,7 @@ def test_repr_zero_samples_gradient(block):
 def test_block_no_components(block):
     assert_equal(block.values, np.full((3, 2), -1.0))
 
-    assert block.samples.names == ("s",)
+    assert block.samples.names == ["s"]
     assert len(block.samples) == 3
     assert tuple(block.samples[0]) == (0,)
     assert tuple(block.samples[1]) == (2,)
@@ -141,7 +141,7 @@ def test_block_no_components(block):
 
     assert len(block.components) == 0
 
-    assert block.properties.names == ("p",)
+    assert block.properties.names == ["p"]
     assert len(block.properties) == 2
     assert tuple(block.properties[0]) == (5,)
     assert tuple(block.properties[1]) == (3,)
@@ -157,7 +157,7 @@ def test_block_with_components(block_components):
 
     assert_equal(block_components.values, np.full((3, 3, 2, 2), -1.0))
 
-    assert block_components.samples.names == ("s",)
+    assert block_components.samples.names == ["s"]
     assert len(block_components.samples) == 3
     assert tuple(block_components.samples[0]) == (0,)
     assert tuple(block_components.samples[1]) == (2,)
@@ -165,19 +165,19 @@ def test_block_with_components(block_components):
 
     assert len(block_components.components) == 2
     component_1 = block_components.components[0]
-    assert component_1.names == ("c_1",)
+    assert component_1.names == ["c_1"]
     assert len(component_1) == 3
     assert tuple(component_1[0]) == (-1,)
     assert tuple(component_1[1]) == (0,)
     assert tuple(component_1[2]) == (1,)
 
     component_2 = block_components.components[1]
-    assert component_2.names == ("c_2",)
+    assert component_2.names == ["c_2"]
     assert len(component_2) == 2
     assert tuple(component_2[0]) == (-4,)
     assert tuple(component_2[1]) == (1,)
 
-    assert block_components.properties.names, ("p",)
+    assert block_components.properties.names, ["p"]
     assert len(block_components.properties) == 2
     assert tuple(block_components.properties[0]) == (5,)
     assert tuple(block_components.properties[1]) == (3,)
@@ -216,7 +216,7 @@ def test_gradients(block_components):
     gradients: None"""
     assert gradient.__repr__() == expected_grad
 
-    assert gradient.samples.names == ("sample", "g")
+    assert gradient.samples.names == ["sample", "g"]
     assert len(gradient.samples) == 2
     assert tuple(gradient.samples[0]) == (0, -2)
     assert tuple(gradient.samples[1]) == (2, 3)
@@ -243,7 +243,7 @@ def test_copy():
     assert id(clone.values) != block_values_id
 
     assert_equal(clone.values, np.full((3, 3, 2), 2.0))
-    assert clone.samples.names == ("s",)
+    assert clone.samples.names == ["s"]
     assert len(clone.samples) == 3
     assert tuple(clone.samples[0]) == (0,)
     assert tuple(clone.samples[1]) == (2,)
@@ -272,14 +272,14 @@ def test_nested_gradients():
     """
     grad_grad = TensorBlock(
         values=np.array([[2.0]]),
-        samples=Labels.arange("sample", 1),
+        samples=Labels.range("sample", 1),
         components=[],
         properties=Labels.single(),
     )
 
     grad = TensorBlock(
         values=np.array([[1.0]]),
-        samples=Labels.arange("sample", 1),
+        samples=Labels.range("sample", 1),
         components=[],
         properties=Labels.single(),
     )

--- a/python/equistore-core/tests/blocks.py
+++ b/python/equistore-core/tests/blocks.py
@@ -120,7 +120,7 @@ def test_repr_zero_samples_gradient(block):
 
     assert block.__repr__() == expected_block
 
-    expected_grad = """Gradient TensorBlock
+    expected_grad = """Gradient TensorBlock ('g')
     samples (0): ['sample']
     components (): []
     properties (2): ['p']
@@ -209,7 +209,7 @@ def test_gradients(block_components):
 
     gradient = block_components.gradient("g")
 
-    expected_grad = """Gradient TensorBlock
+    expected_grad = """Gradient TensorBlock ('g')
     samples (2): ['sample', 'g']
     components (3, 2): ['c_1', 'c_2']
     properties (2): ['p']

--- a/python/equistore-core/tests/labels.py
+++ b/python/equistore-core/tests/labels.py
@@ -1,61 +1,52 @@
 import numpy as np
 import pytest
-from numpy.testing import assert_equal
 
 from equistore.core import EquistoreError, Labels
 
-from . import utils
 
+def test_constructor():
+    labels = Labels(names=("a", "b"), values=np.array([[0, 0]]))
 
-@pytest.fixture
-def labels():
-    return utils.tensor().keys
-
-
-def test_python_labels():
-    labels = Labels(names=["a", "b"], values=np.array([[0, 0]]))
-
-    assert labels.names == ("a", "b")
+    assert labels.names == ["a", "b"]
     assert len(labels) == 1
     assert tuple(labels[0]) == (0, 0)
 
-    assert_equal(labels.asarray(), np.array([[0, 0]]))
+    np.testing.assert_equal(labels.values, np.array([[0, 0]]))
 
-
-def test_single_str_name():
-    """check we can use single str for single name"""
+    # check we can use single str for a single name
     labels = Labels(
-        names=["abc"],
-        values=np.array([[1]]),
-    )
-    labels_str = Labels(
         names="abc",
         values=np.array([[1]]),
     )
 
-    assert labels.names == ("abc",)
-    assert labels.names == labels_str.names
+    assert labels.names == ["abc"]
     assert len(labels) == 1
-    assert len(labels_str) == 1
-    assert tuple(labels_str[0]) == (1,)
-    assert tuple(labels_str[0]) == tuple(labels[0])
+    assert tuple(labels[0]) == (1,)
 
-    assert_equal(labels.asarray(), np.array([[1]]))
-    assert_equal(labels.asarray(), labels_str.asarray())
+    np.testing.assert_equal(labels.values, np.array([[1]]))
 
 
-def test_empty_array():
+def test_empty_labels():
+    # labels without dimensions
     labels = Labels(names=[], values=np.array([[]], dtype=np.int32))
     labels_str = Labels(names="", values=np.array([[]], dtype=np.int32))
 
     assert labels.names == []
     assert labels.names == labels_str.names
-    assert len(labels) == 1
-    assert len(labels_str) == 1
-    assert tuple(labels_str[0]) == tuple(labels[0])
+    assert len(labels) == 0
+    assert len(labels_str) == 0
 
-    assert_equal(labels.asarray(), np.array([[]]))
-    assert_equal(labels.asarray(), labels_str.asarray())
+    assert labels.values.shape == (0, 0)
+    assert labels_str.values.shape == (0, 0)
+
+    # labels without entries
+    labels = Labels(names=["a", "b"], values=np.empty((0, 2)))
+    assert labels.names == ["a", "b"]
+    assert len(labels) == 0
+
+    labels = Labels.empty(["a", "b"])
+    assert labels.names == ["a", "b"]
+    assert len(labels) == 0
 
 
 def test_convert_types():
@@ -69,60 +60,29 @@ def test_wrong_types():
         Labels(names=["a", "b"], values=np.array([[0, 0]], dtype=np.float64))
 
 
-def test_native_labels(labels):
-    assert labels.names == ("key_1", "key_2")
-    assert len(labels) == 4
-    assert tuple(labels[0]) == (0, 0)
-    assert tuple(labels[1]) == (1, 0)
-    assert tuple(labels[2]) == (2, 2)
-    assert tuple(labels[3]) == (2, 3)
-
-    expected = np.array(
-        [
-            [0, 0],
-            [1, 0],
-            [2, 2],
-            [2, 3],
-        ]
+def test_position():
+    labels = Labels(
+        names=["a", "b"],
+        values=np.array([[0, 0], [1, 0], [2, 2], [2, 3]]),
     )
-    assert_equal(labels.asarray(), expected)
 
-
-def test_position(labels):
     assert labels.position((0, 0)) == 0
     assert labels.position((2, 3)) == 3
     assert labels.position((2, -1)) is None
 
-
-def test_contains(labels):
     assert (0, 0) in labels
     assert (2, 3) in labels
     assert (2, -1) not in labels
 
 
-def test_named_tuples(labels):
-    iterator = labels.as_namedtuples()
-    first = next(iterator)
+def test_not_writeable():
+    labels = Labels(
+        names=["a", "b"],
+        values=np.array([[0, 0]]),
+    )
 
-    assert isinstance(first, tuple)
-    assert hasattr(first, "_fields")
-
-    assert first.key_1 == 0
-    assert first.key_2 == 0
-    assert first.as_dict() == {"key_1": 0, "key_2": 0}
-
-    assert first == (0, 0)
-    assert next(iterator) == (1, 0)
-    assert next(iterator) == (2, 2)
-    assert next(iterator) == (2, 3)
-
-    with pytest.raises(StopIteration):
-        next(iterator)
-
-
-def test_not_writeable(labels):
     with pytest.raises(ValueError, match="assignment destination is read-only"):
-        labels[0][0] = 4
+        labels.values[0][0] = 4
 
 
 def test_invalid_names():
@@ -134,111 +94,211 @@ def test_invalid_names():
         )
 
 
-def test_zero_length_label():
-    label = Labels(["sample", "structure", "atom"], np.array([]))
-    assert len(label) == 0
-
-
-def test_labels_single():
+def test_custom_constructors():
+    # Labels.single
     label = Labels.single()
-    assert label.names == ("_",)
-    assert label.shape == (1,)
+    assert label.names == ["_"]
+    assert label.values.shape == (1, 1)
 
-
-def test_labels_empty():
-    names = (
-        "foo",
-        "bar",
-        "baz",
-    )
-    label = Labels.empty(names)
-    assert label.names == names
-    assert len(label) == 0
-
-
-def test_labels_contiguous():
-    labels = Labels(
-        names=["a", "b"],
-        values=np.arange(32).reshape(-1, 2),
-    )
-
-    labels = labels[::-1]
-    ptr = labels._as_eqs_labels_t().values
-
-    shape = (len(labels), len(labels.names))
-    array = np.ctypeslib.as_array(ptr, shape=shape)
-    array = array.view(dtype=labels.dtype).reshape(-1)
-
-    assert np.all(array == labels)
-
-
-def test_arange_one_argument():
-    labels_arange = Labels.arange("name", 10)
-    assert labels_arange.asarray().shape == (10, 1)
-    assert labels_arange.names == ("name",)
-    np.testing.assert_equal(labels_arange.asarray().reshape((-1,)), np.arange(10))
-
-    labels_arange = Labels.arange("name", stop=10)
-    assert labels_arange.asarray().shape == (10, 1)
-    assert labels_arange.names == ("name",)
-    np.testing.assert_equal(labels_arange.asarray().reshape((-1,)), np.arange(10))
-
-
-def test_arange_two_arguments():
-    labels_arange = Labels.arange("dummy", 10, 42)
-    assert labels_arange.names == ("dummy",)
-    np.testing.assert_equal(labels_arange.asarray().reshape((-1,)), np.arange(10, 42))
-
-    labels_arange = Labels.arange("dummy", start=10, stop=42)
-    assert labels_arange.names == ("dummy",)
-    np.testing.assert_equal(labels_arange.asarray().reshape((-1,)), np.arange(10, 42))
-
-
-def test_arange_three_arguments():
-    labels_arange = Labels.arange("samples", 0, 10, 2)
-    assert labels_arange.names == ("samples",)
-    np.testing.assert_equal(labels_arange.asarray().reshape((-1,)), np.arange(0, 10, 2))
-
-    labels_arange = Labels.arange("samples", start=0, stop=10, step=2)
-    assert labels_arange.names == ("samples",)
-    np.testing.assert_equal(labels_arange.asarray().reshape((-1,)), np.arange(0, 10, 2))
-
-
-def test_arange_incorrect_arguments():
-    message = (
-        "the maximum number of integer arguments accepted by "
-        r"`Labels.arange\(\)` is 3. 4 were provided"
-    )
-    with pytest.raises(ValueError, match=message):
-        Labels.arange("dummy", 0, 10, 2, 4)
-
-    message = r"please provide at least one integer for `Labels.arange\(\)`"
-    with pytest.raises(ValueError, match=message):
-        Labels.arange("dummy")
+    # Labels.range
+    labels = Labels.range("name", 10)
+    assert labels.values.shape == (10, 1)
+    assert labels.names == ["name"]
+    np.testing.assert_equal(labels.values.reshape((-1,)), np.arange(10))
 
     message = "Labels names must be strings, got <class 'int'> instead"
     with pytest.raises(TypeError, match=message):
-        Labels.arange(0, 1, 2)
+        Labels.range(0, 1)
 
-    message = r"all numbers provided to `Labels.arange\(\)` must be integers"
+
+def test_view():
+    labels = Labels(names=("aaa", "bbb"), values=np.array([[1, 2], [3, 4]]))
+
+    assert not labels.is_view()
+
+    view = labels["aaa"]
+    assert view.is_view()
+    assert view.names == ["aaa"]
+    np.testing.assert_equal(view.values, np.array([[1], [3]]))
+
+    view = labels["bbb"]
+    assert view.names == ["bbb"]
+    np.testing.assert_equal(view.values, np.array([[2], [4]]))
+
+    view = labels[["bbb"]]
+    assert view.is_view()
+    assert view.names == ["bbb"]
+    np.testing.assert_equal(view.values, np.array([[2], [4]]))
+
+    view = labels[["bbb", "aaa"]]
+    assert view.is_view()
+    assert view.names == ["bbb", "aaa"]
+    np.testing.assert_equal(view.values, np.array([[2, 1], [4, 3]]))
+
+    view = labels[["aaa", "aaa", "aaa"]]
+    assert view.names == ["aaa", "aaa", "aaa"]
+    np.testing.assert_equal(view.values, np.array([[1, 1, 1], [3, 3, 3]]))
+
+    message = "'ccc' not found in the dimensions of these Labels"
     with pytest.raises(ValueError, match=message):
-        Labels.arange(0.0, 1.0, 2)
+        labels["ccc"]
 
-    message = r"all numbers provided to `Labels.arange\(\)` must be integers"
+    message = "Labels names must be strings, got <class 'int'> instead"
+    with pytest.raises(TypeError, match=message):
+        labels[1, 2]
+
+    view = labels["aaa"]
+    message = "can not call `position` on a Labels view, call `to_owned` before"
     with pytest.raises(ValueError, match=message):
-        Labels.arange("dummy", 0, 5, 0.2)
+        view.position([1])
 
-    message = (
-        "the only valid names for integer arguments to "
-        + r"`Labels.arange\(\)` are start, stop and step"
+    owned = view.to_owned()
+    assert not owned.is_view()
+    assert owned.position([1]) == 0
+    assert owned.position([-1]) is None
+
+    view = labels[["aaa", "aaa"]]
+    message = "invalid parameter: labels names must be unique, got 'aaa' multiple times"
+    with pytest.raises(EquistoreError, match=message):
+        view.to_owned()
+
+
+def test_repr():
+    labels = Labels(names=("aaa", "bbb"), values=np.array([[1, 2], [3, 4]]))
+
+    expected = "Labels(\n    aaa  bbb\n     1    2\n     3    4\n)"
+    assert str(labels) == expected
+    assert repr(labels) == expected
+
+    expected = "LabelsEntry(aaa=1, bbb=2)"
+    assert str(labels[0]) == expected
+    assert repr(labels[0]) == expected
+
+    labels = Labels(
+        names=("aaa", "bbb"),
+        values=np.array([[0, 0], [1, 1], [2, 2], [3, 3], [4, 4], [5, 5], [6, 6]]),
     )
-    with pytest.raises(ValueError, match=message):
-        Labels.arange("dummy", random=10)
 
-    message = r"all numbers provided to `Labels.arange\(\)` must be integers"
-    with pytest.raises(ValueError, match=message):
-        Labels.arange(name="dummy", start=0.0, stop=1.0, step=2)
+    expected = """ aaa  bbb
+  0    0
+  1    1
+  2    2
+  3    3
+  4    4
+  5    5
+  6    6"""
+    assert labels.print(max_entries=-1) == expected
 
-    message = r"all numbers provided to `Labels.arange\(\)` must be integers"
-    with pytest.raises(ValueError, match=message):
-        Labels.arange("dummy", start=0, stop=0.2)
+    expected = """ aaa  bbb
+  0    0
+   ...
+  6    6"""
+    assert labels.print(max_entries=0) == expected
+    assert labels.print(max_entries=1) == expected
+    assert labels.print(max_entries=2) == expected
+
+    expected = """ aaa  bbb
+  0    0
+  1    1
+  2    2
+   ...
+  5    5
+  6    6"""
+    assert labels.print(max_entries=5) == expected
+
+    expected = """ aaa  bbb
+     0    0
+     1    1
+      ...
+     6    6"""
+    assert labels.print(max_entries=3, indent=3) == expected
+
+    labels = Labels(names=("aaa", "bbb"), values=np.array([[0, 0], [0, 1]]))
+    expected = "LabelsView(\n    bbb\n     0\n     1\n)"
+    assert str(labels["bbb"]) == expected
+
+    labels = Labels(
+        names=("aaa", "bbb"), values=np.array([[111111111, 2], [3, 444444444]])
+    )
+
+    expected = """Labels(
+       aaa        bbb
+    111111111      2
+        3      444444444
+)"""
+    assert str(labels) == expected
+
+
+def test_indexing():
+    labels = Labels(names=("a", "b"), values=np.array([[1, 2], [3, 4]]))
+
+    # indexing labels with integer
+    entry = labels[0]
+    assert entry.names == ["a", "b"]
+    np.testing.assert_equal(entry.values, np.array([1, 2]))
+
+    entry = labels[-1]
+    assert entry.names == ["a", "b"]
+    np.testing.assert_equal(entry.values, np.array([3, 4]))
+
+    # indexing labels errors
+    message = "index 3 is out of bounds for axis 0 with size 2"
+    with pytest.raises(IndexError, match=message):
+        labels[3]
+
+    message = "index -7 is out of bounds for axis 0 with size 2"
+    with pytest.raises(IndexError, match=message):
+        labels[-7]
+
+    # indexing entry with integer
+    entry = labels[0]
+    assert entry[0] == 1
+    assert entry[1] == 2
+    assert tuple(entry) == (1, 2)
+
+    # indexing entry with string
+    assert entry["a"] == 1
+    assert entry["b"] == 2
+
+    # indexing entry errors
+    message = "can only index LabelsEntry with str or int, got <class 'tuple'>"
+    with pytest.raises(TypeError, match=message):
+        entry[1, 2]
+
+    message = "can only index LabelsEntry with str or int, got <class 'list'>"
+    with pytest.raises(TypeError, match=message):
+        entry[["a", "b"]]
+
+
+def test_iter():
+    labels = Labels(names=("a", "b"), values=np.array([[0, 0], [0, 1]]))
+
+    for i, values in enumerate(labels[1]):
+        assert values == i
+
+    for i, entry in enumerate(labels):
+        assert tuple(entry) == (0, i)
+
+    # expand labels entry to tuples during iteration
+    for i, (a, b) in enumerate(labels):
+        assert a == 0
+        assert b == i
+
+
+def test_eq():
+    labels_1 = Labels(names=("a", "b"), values=np.array([[0, 0], [0, 1]]))
+    labels_2 = Labels(names=("a", "b"), values=np.array([[0, 0], [0, 1]]))
+    labels_3 = Labels(names=("a", "b"), values=np.array([[0, 2], [0, 1]]))
+    labels_4 = Labels(names=("a", "c"), values=np.array([[0, 0], [0, 1]]))
+
+    # Labels equality
+    assert labels_1 == labels_2
+    assert labels_1 != labels_3
+    assert labels_1 != labels_4
+
+    # LabelsEntry equality
+    assert labels_1[0] == labels_1[0]
+    assert labels_1[0] == labels_2[0]
+    assert labels_1[0] != labels_3[0]
+    assert labels_1[0] != labels_4[0]
+    assert labels_1[1] == labels_3[1]

--- a/python/equistore-core/tests/origin.py
+++ b/python/equistore-core/tests/origin.py
@@ -6,21 +6,26 @@ from equistore.core import EquistoreError, Labels, TensorBlock, TensorMap
 
 
 def test_different_origins():
-    """Test that an error is thrown when attempting
-    to initialize a TensorMap with TensorBlocks
-    with different origins"""
-    keys = Labels.arange("dummy", 2)
+    """
+    Test that an error is thrown when attempting to initialize a TensorMap with
+    TensorBlocks with different origins
+    """
+
+    keys = Labels.range("dummy", 2)
+
     block_numpy = TensorBlock(
         values=np.array([[0.0]]),
         samples=Labels.single(),
         components=[],
         properties=Labels.single(),
     )
+
     block_torch = TensorBlock(
         values=torch.tensor([[0.0]]),
         samples=Labels.single(),
         components=[],
         properties=Labels.single(),
     )
+
     with pytest.raises(EquistoreError, match="different origins"):
         TensorMap(keys=keys, blocks=[block_numpy, block_torch])

--- a/python/equistore-core/tests/serialization.py
+++ b/python/equistore-core/tests/serialization.py
@@ -4,7 +4,6 @@ import sys
 
 import numpy as np
 import pytest
-from numpy.testing import assert_equal
 
 import equistore.core
 from equistore.core import Labels, TensorBlock, TensorMap
@@ -33,19 +32,19 @@ def test_load(use_numpy):
     )
 
     assert isinstance(tensor, TensorMap)
-    assert tensor.keys.names == (
+    assert tensor.keys.names == [
         "spherical_harmonics_l",
         "center_species",
         "neighbor_species",
-    )
+    ]
     assert len(tensor.keys) == 27
 
     block = tensor.block(spherical_harmonics_l=2, center_species=6, neighbor_species=1)
-    assert block.samples.names == ("structure", "center")
+    assert block.samples.names == ["structure", "center"]
     assert block.values.shape == (9, 5, 3)
 
     gradient = block.gradient("positions")
-    assert gradient.samples.names == ("sample", "structure", "atom")
+    assert gradient.samples.names == ["sample", "structure", "atom"]
     assert gradient.values.shape == (59, 3, 5, 3)
 
 
@@ -62,20 +61,22 @@ def test_save(use_numpy, tmpdir, tensor):
 
     assert len(data.keys()) == 29
 
-    assert_equal(data["keys"], tensor.keys)
+    assert _npz_labels(data["keys"]) == tensor.keys
     for i, (_, block) in enumerate(tensor):
         prefix = f"blocks/{i}"
-        assert_equal(data[f"{prefix}/values"], block.values)
-        assert_equal(data[f"{prefix}/samples"], block.samples)
-        assert_equal(data[f"{prefix}/components/0"], block.components[0])
-        assert_equal(data[f"{prefix}/properties"], block.properties)
+
+        np.testing.assert_equal(data[f"{prefix}/values"], block.values)
+        assert _npz_labels(data[f"{prefix}/samples"]) == block.samples
+        assert _npz_labels(data[f"{prefix}/components/0"]) == block.components[0]
+        assert _npz_labels(data[f"{prefix}/properties"]) == block.properties
 
         for parameter in block.gradients_list():
             gradient = block.gradient(parameter)
             prefix = f"blocks/{i}/gradients/{parameter}"
-            assert_equal(data[f"{prefix}/values"], gradient.values)
-            assert_equal(data[f"{prefix}/samples"], gradient.samples)
-            assert_equal(data[f"{prefix}/components/0"], gradient.components[0])
+
+            np.testing.assert_equal(data[f"{prefix}/values"], gradient.values)
+            assert _npz_labels(data[f"{prefix}/samples"]) == gradient.samples
+            assert _npz_labels(data[f"{prefix}/components/0"]) == gradient.components[0]
 
 
 def test_save_warning_errors(tmpdir, tensor):
@@ -108,8 +109,7 @@ else:
 @pytest.mark.parametrize("protocol", protocols)
 def test_pickle(protocol, tmpdir, tensor):
     """
-    Checks that pickling and unpickling a tensor map
-    results in the same tensor map
+    Checks that pickling and unpickling a tensor map results in the same tensor map
     """
 
     tmpfile = "serialize-test.pickle"
@@ -121,44 +121,48 @@ def test_pickle(protocol, tmpdir, tensor):
         with open(tmpfile, "rb") as f:
             tensor_loaded = pickle.load(f)
 
-    assert_equal(tensor.keys, tensor_loaded.keys)
-    for key, block in tensor:
+    np.testing.assert_equal(tensor.keys, tensor_loaded.keys)
+    for key, block in tensor_loaded:
         ref_block = tensor.block(key)
-        assert_equal(type(block.values), type(ref_block.values))
-        assert_equal(block.values, ref_block.values)
-        assert_equal(block.samples, ref_block.samples)
-        assert_equal(block.components, ref_block.components)
-        assert_equal(block.properties, ref_block.properties)
+
+        assert isinstance(block.values, np.ndarray)
+        np.testing.assert_equal(block.values, ref_block.values)
+
+        assert block.samples == ref_block.samples
+        assert block.components == ref_block.components
+        assert block.properties == ref_block.properties
 
         for parameter in block.gradients_list():
             gradient = block.gradient(parameter)
             ref_gradient = ref_block.gradient(parameter)
-            assert_equal(gradient.values, ref_gradient.values)
-            assert_equal(gradient.samples, ref_gradient.samples)
-            assert_equal(gradient.components, ref_gradient.components)
+
+            np.testing.assert_equal(gradient.values, ref_gradient.values)
+
+            assert gradient.samples == ref_gradient.samples
+            assert gradient.components == ref_gradient.components
 
 
 @pytest.mark.parametrize("use_numpy", (True, False))
 def test_nested_gradients(tmpdir, use_numpy):
     block = TensorBlock(
         values=np.random.rand(3, 3),
-        samples=Labels.arange("s", 3),
+        samples=Labels.range("s", 3),
         components=[],
-        properties=Labels.arange("p", 3),
+        properties=Labels.range("p", 3),
     )
 
     grad = TensorBlock(
         values=np.random.rand(3, 3),
-        samples=Labels.arange("sample", 3),
+        samples=Labels.range("sample", 3),
         components=[],
-        properties=Labels.arange("p", 3),
+        properties=Labels.range("p", 3),
     )
 
     grad_grad = TensorBlock(
         values=np.random.rand(3, 5, 3),
-        samples=Labels.arange("sample", 3),
-        components=[Labels.arange("c", 5)],
-        properties=Labels.arange("p", 3),
+        samples=Labels.range("sample", 3),
+        components=[Labels.range("c", 5)],
+        properties=Labels.range("p", 3),
     )
 
     grad.add_gradient("grad-of-grad", grad_grad)
@@ -176,58 +180,62 @@ def test_nested_gradients(tmpdir, use_numpy):
         # load back with equistore
         loaded = equistore.core.load(tmpfile)
 
-    assert_equal(data["keys"], tensor.keys)
-    assert_equal(data["keys"], loaded.keys)
+    assert _npz_labels(data["keys"]) == tensor.keys
+    assert _npz_labels(data["keys"]) == loaded.keys
 
     for i, (key, block) in enumerate(tensor):
         loaded_block = loaded.block(key)
 
         prefix = f"blocks/{i}"
-        assert_equal(data[f"{prefix}/values"], block.values)
-        assert_equal(data[f"{prefix}/values"], loaded_block.values)
+        np.testing.assert_equal(data[f"{prefix}/values"], block.values)
+        np.testing.assert_equal(block.values, loaded_block.values)
 
-        assert_equal(data[f"{prefix}/samples"], block.samples)
-        assert_equal(data[f"{prefix}/samples"], loaded_block.samples)
+        assert _npz_labels(data[f"{prefix}/samples"]) == block.samples
+        assert block.samples == loaded_block.samples
 
-        assert_equal(data[f"{prefix}/properties"], block.properties)
-        assert_equal(data[f"{prefix}/properties"], loaded_block.properties)
+        assert _npz_labels(data[f"{prefix}/properties"]) == block.properties
+        assert block.properties == loaded_block.properties
 
-        assert_equal(block.gradients_list(), loaded_block.gradients_list())
+        assert block.gradients_list() == loaded_block.gradients_list()
 
         for parameter, gradient in block.gradients():
             loaded_gradient = loaded_block.gradient(parameter)
             grad_prefix = f"{prefix}/gradients/{parameter}"
 
-            assert_equal(data[f"{grad_prefix}/values"], gradient.values)
-            assert_equal(data[f"{grad_prefix}/values"], loaded_gradient.values)
+            np.testing.assert_equal(data[f"{grad_prefix}/values"], gradient.values)
+            np.testing.assert_equal(gradient.values, loaded_gradient.values)
 
-            assert_equal(data[f"{grad_prefix}/samples"], gradient.samples)
-            assert_equal(data[f"{grad_prefix}/samples"], loaded_gradient.samples)
+            assert _npz_labels(data[f"{grad_prefix}/samples"]) == gradient.samples
+            assert gradient.samples == loaded_gradient.samples
 
-            assert len(gradient.components) == len(loaded_gradient.components)
-            for a, b in zip(gradient.components, loaded_gradient.components):
-                assert_equal(a, b)
+            assert gradient.components == loaded_gradient.components
+            assert gradient.properties == loaded_gradient.properties
 
-            assert_equal(gradient.properties, loaded_gradient.properties)
-
-            assert_equal(gradient.gradients_list(), loaded_gradient.gradients_list())
+            assert gradient.gradients_list() == loaded_gradient.gradients_list()
 
             for parameter, grad_grad in gradient.gradients():
                 loaded_grad_grad = loaded_gradient.gradient(parameter)
                 grad_grad_prefix = f"{grad_prefix}/gradients/{parameter}"
 
-                assert_equal(data[f"{grad_grad_prefix}/values"], grad_grad.values)
-                assert_equal(
-                    data[f"{grad_grad_prefix}/values"], loaded_grad_grad.values
+                np.testing.assert_equal(
+                    data[f"{grad_grad_prefix}/values"], grad_grad.values
+                )
+                np.testing.assert_equal(grad_grad.values, loaded_grad_grad.values)
+
+                assert (
+                    _npz_labels(data[f"{grad_grad_prefix}/samples"])
+                    == grad_grad.samples
                 )
 
-                assert_equal(data[f"{grad_grad_prefix}/samples"], grad_grad.samples)
-                assert_equal(
-                    data[f"{grad_grad_prefix}/samples"], loaded_grad_grad.samples
-                )
+                assert grad_grad.samples == loaded_grad_grad.samples
 
                 assert len(grad_grad.components) == len(loaded_grad_grad.components)
                 for a, b in zip(grad_grad.components, loaded_grad_grad.components):
-                    assert_equal(a, b)
+                    assert a == b
 
-                assert_equal(grad_grad.properties, loaded_grad_grad.properties)
+                assert grad_grad.properties == loaded_grad_grad.properties
+
+
+def _npz_labels(data):
+    names = data.dtype.names
+    return Labels(names=names, values=data.view(dtype=np.int32).reshape(-1, len(names)))

--- a/python/equistore-core/tests/serialization.py
+++ b/python/equistore-core/tests/serialization.py
@@ -62,7 +62,7 @@ def test_save(use_numpy, tmpdir, tensor):
     assert len(data.keys()) == 29
 
     assert _npz_labels(data["keys"]) == tensor.keys
-    for i, (_, block) in enumerate(tensor):
+    for i, block in enumerate(tensor.blocks()):
         prefix = f"blocks/{i}"
 
         np.testing.assert_equal(data[f"{prefix}/values"], block.values)
@@ -122,7 +122,7 @@ def test_pickle(protocol, tmpdir, tensor):
             tensor_loaded = pickle.load(f)
 
     np.testing.assert_equal(tensor.keys, tensor_loaded.keys)
-    for key, block in tensor_loaded:
+    for key, block in tensor_loaded.items():
         ref_block = tensor.block(key)
 
         assert isinstance(block.values, np.ndarray)
@@ -183,7 +183,7 @@ def test_nested_gradients(tmpdir, use_numpy):
     assert _npz_labels(data["keys"]) == tensor.keys
     assert _npz_labels(data["keys"]) == loaded.keys
 
-    for i, (key, block) in enumerate(tensor):
+    for i, (key, block) in enumerate(tensor.items()):
         loaded_block = loaded.block(key)
 
         prefix = f"blocks/{i}"

--- a/python/equistore-core/tests/tensor.py
+++ b/python/equistore-core/tests/tensor.py
@@ -138,14 +138,14 @@ def test_block(tensor):
         tensor[tensor.keys[1], 4]
 
     # 0 blocks matching criteria
-    msg = "Couldn't find any block matching 'key_1=3'"
+    msg = "couldn't find any block matching \\(key_1=3\\)"
     with pytest.raises(ValueError, match=msg):
         tensor.block(key_1=3)
 
     # more than one block matching criteria
     msg = (
-        "more than one block matched 'key_2=0', use `TensorMap.blocks` "
-        "if you want to get all of them"
+        "more than one block matched \\(key_2=0\\), use `TensorMap.blocks` "
+        "to get all of them"
     )
     with pytest.raises(ValueError, match=msg):
         tensor.block(key_2=0)

--- a/python/equistore-core/tests/tensor.py
+++ b/python/equistore-core/tests/tensor.py
@@ -53,7 +53,7 @@ def test_shallow_copy_error(tensor):
 
 
 def test_keys(tensor):
-    assert tensor.keys.names == ("key_1", "key_2")
+    assert tensor.keys.names == ["key_1", "key_2"]
     assert len(tensor.keys) == 4
     assert len(tensor) == 4
     assert tuple(tensor.keys[0]) == (0, 0)
@@ -69,32 +69,30 @@ def test_print(tensor):
     """
     repr = tensor.__repr__()
     expected = """TensorMap with 4 blocks
-keys: ['key_1' 'key_2']
-          0       0
-          1       0
-          2       2
-          2       3"""
+keys: key_1  key_2
+        0      0
+        1      0
+        2      2
+        2      3"""
     assert expected == repr
 
 
 def test_print_large(large_tensor):
     _print = large_tensor.__repr__()
     expected = """TensorMap with 12 blocks
-keys: ['key_1' 'key_2']
-          0       0
-          1       0
-          2       2
-       ...
-          1       5
-          2       5
-          3       5"""
+keys: key_1  key_2
+        0      0
+        1      0
+          ...
+        2      5
+        3      5"""
     assert expected == _print
 
 
 def test_labels_names(tensor):
-    assert tensor.sample_names == ("s",)
-    assert tensor.components_names == [("c",)]
-    assert tensor.property_names == ("p",)
+    assert tensor.sample_names == ["s"]
+    assert tensor.components_names == [["c"]]
+    assert tensor.property_names == ["p"]
 
 
 def test_block(tensor):
@@ -140,13 +138,13 @@ def test_block(tensor):
         tensor[tensor.keys[1], 4]
 
     # 0 blocks matching criteria
-    msg = "Couldn't find any block matching the selection 'key_1 = 3'"
+    msg = "Couldn't find any block matching 'key_1=3'"
     with pytest.raises(ValueError, match=msg):
         tensor.block(key_1=3)
 
     # more than one block matching criteria
     msg = (
-        "more than one block matched 'key_2 = 0', use `TensorMap.blocks` "
+        "more than one block matched 'key_2=0', use `TensorMap.blocks` "
         "if you want to get all of them"
     )
     with pytest.raises(ValueError, match=msg):
@@ -189,7 +187,7 @@ def test_iter(tensor):
 def test_keys_to_properties(tensor):
     tensor = tensor.keys_to_properties("key_1")
 
-    assert tensor.keys.names == ("key_2",)
+    assert tensor.keys.names == ["key_2"]
     assert tuple(tensor.keys[0]) == (0,)
     assert tuple(tensor.keys[1]) == (2,)
     assert tuple(tensor.keys[2]) == (3,)
@@ -205,7 +203,7 @@ def test_keys_to_properties(tensor):
     assert len(block.components), 1
     assert tuple(block.components[0][0]), (0,)
 
-    assert block.properties.names == ("key_1", "p")
+    assert block.properties.names == ["key_1", "p"]
     assert tuple(block.properties[0]) == (0, 0)
     assert tuple(block.properties[1]) == (1, 3)
     assert tuple(block.properties[2]) == (1, 4)
@@ -240,14 +238,14 @@ def test_keys_to_properties(tensor):
 
     # The new second block contains the old third block
     block = tensor.block(1)
-    assert block.properties.names == ("key_1", "p")
+    assert block.properties.names == ["key_1", "p"]
     assert tuple(block.properties[0]) == (2, 0)
 
     assert_equal(block.values, np.full((4, 3, 1), 3.0))
 
     # The new third block contains the old fourth block
     block = tensor.block(2)
-    assert block.properties.names == ("key_1", "p")
+    assert block.properties.names == ["key_1", "p"]
     assert tuple(block.properties[0]) == (2, 0)
 
     assert_equal(block.values, np.full((4, 3, 1), 4.0))
@@ -256,7 +254,7 @@ def test_keys_to_properties(tensor):
 def test_keys_to_samples(tensor):
     tensor = tensor.keys_to_samples("key_2", sort_samples=True)
 
-    assert tensor.keys.names == ("key_1",)
+    assert tensor.keys.names == ["key_1"]
     assert tuple(tensor.keys[0]) == (0,)
     assert tuple(tensor.keys[1]) == (1,)
     assert tuple(tensor.keys[2]) == (2,)
@@ -271,7 +269,7 @@ def test_keys_to_samples(tensor):
     assert_equal(block.values, np.full((3, 1, 1), 1.0))
 
     block = tensor.block(1)
-    assert block.samples.names == ("s", "key_2")
+    assert block.samples.names == ["s", "key_2"]
     assert tuple(block.samples[0]) == (0, 0)
     assert tuple(block.samples[1]) == (1, 0)
     assert tuple(block.samples[2]) == (3, 0)
@@ -281,7 +279,7 @@ def test_keys_to_samples(tensor):
     # The new third block contains the old third and fourth blocks merged
     block = tensor.block(2)
 
-    assert block.samples.names == ("s", "key_2")
+    assert block.samples.names == ["s", "key_2"]
     assert tuple(block.samples[0]) == (0, 2)
     assert tuple(block.samples[1]) == (0, 3)
     assert tuple(block.samples[2]) == (1, 3)
@@ -306,7 +304,7 @@ def test_keys_to_samples(tensor):
     assert_equal(block.values, expected)
 
     gradient = block.gradient("g")
-    assert gradient.samples.names == ("sample", "g")
+    assert gradient.samples.names == ["sample", "g"]
     assert tuple(gradient.samples[0]) == (1, 1)
     assert tuple(gradient.samples[1]) == (4, -2)
     assert tuple(gradient.samples[2]) == (5, 3)
@@ -340,14 +338,14 @@ def test_components_to_properties(tensor):
     tensor = tensor.components_to_properties("c")
 
     block = tensor.block(0)
-    assert block.samples.names == ("s",)
+    assert block.samples.names == ["s"]
     assert tuple(block.samples[0]) == (0,)
     assert tuple(block.samples[1]) == (2,)
     assert tuple(block.samples[2]) == (4,)
 
     assert block.components == []
 
-    assert block.properties.names == ("c", "p")
+    assert block.properties.names == ["c", "p"]
     assert tuple(block.properties[0]) == (0, 0)
 
     block = tensor.block(3)
@@ -359,7 +357,7 @@ def test_components_to_properties(tensor):
 
     assert block.components == []
 
-    assert block.properties.names == ("c", "p")
+    assert block.properties.names == ["c", "p"]
     assert tuple(block.properties[0]) == (0, 0)
     assert tuple(block.properties[1]) == (1, 0)
     assert tuple(block.properties[2]) == (2, 0)
@@ -368,7 +366,7 @@ def test_components_to_properties(tensor):
 def test_empty_tensor():
     empty_tensor = TensorMap(keys=Labels.empty(["key"]), blocks=[])
 
-    assert empty_tensor.keys.names == ("key",)
+    assert empty_tensor.keys.names == ["key"]
 
     assert empty_tensor.sample_names == tuple()
     assert empty_tensor.components_names == []

--- a/python/equistore-core/tests/utils.py
+++ b/python/equistore-core/tests/utils.py
@@ -87,7 +87,7 @@ def large_tensor():
     Create a dummy tensor map of 16 blocks to be used in tests. This is the same
     tensor map used in `tensor.rs` tests.
     """
-    blocks = [block.copy() for _, block in tensor()]
+    blocks = [block.copy() for block in tensor().blocks()]
 
     for i in range(8):
         block = TensorBlock(

--- a/python/equistore-core/tests/utils.py
+++ b/python/equistore-core/tests/utils.py
@@ -45,7 +45,7 @@ def tensor():
     block_3 = TensorBlock(
         values=np.full((4, 3, 1), 3.0),
         samples=Labels(["s"], np.array([[0], [3], [6], [8]])),
-        components=[Labels.arange("c", 3)],
+        components=[Labels.range("c", 3)],
         properties=Labels(["p"], np.array([[0]])),
     )
     block_3.add_gradient(
@@ -61,7 +61,7 @@ def tensor():
     block_4 = TensorBlock(
         values=np.full((4, 3, 1), 4.0),
         samples=Labels(["s"], np.array([[0], [1], [2], [5]])),
-        components=[Labels.arange("c", 3)],
+        components=[Labels.range("c", 3)],
         properties=Labels(["p"], np.array([[0]])),
     )
     block_4.add_gradient(
@@ -93,7 +93,7 @@ def large_tensor():
         block = TensorBlock(
             values=np.full((4, 3, 1), 4.0),
             samples=Labels(["s"], np.array([[0], [1], [4], [5]])),
-            components=[Labels.arange("c", 3)],
+            components=[Labels.range("c", 3)],
             properties=Labels(["p"], np.array([[i]])),
         )
         block.add_gradient(

--- a/python/equistore-operations/equistore/operations/_utils.py
+++ b/python/equistore-operations/equistore/operations/_utils.py
@@ -2,7 +2,7 @@ from typing import List
 
 import numpy as np
 
-from equistore.core import Labels, TensorBlock, TensorMap
+from equistore.core import TensorBlock, TensorMap
 
 
 class NotEqualError(Exception):
@@ -193,21 +193,3 @@ def _check_gradient_presence(block: TensorBlock, parameters: List[str], fname: s
                 f"requested gradient '{parameter}' in {fname} is not defined "
                 "in this tensor"
             )
-
-
-def _labels_equal(a: Labels, b: Labels, exact_order: bool):
-    """
-    For 2 :py:class:`Labels` objects ``a`` and ``b``, returns true if they are
-    exactly equivalent in names, values, and elemental positions. Assumes that
-    the Labels are already searchable, i.e. they belong to a parent TensorBlock
-    or TensorMap.
-    """
-    # They can only be equivalent if the same length
-    if len(a) != len(b):
-        return False
-    # Check the names
-    if not np.all(a.names == b.names):
-        return False
-    if exact_order:
-        return np.all(np.array(a == b))
-    return np.all([a_i in b for a_i in a])

--- a/python/equistore-operations/equistore/operations/_utils.py
+++ b/python/equistore-operations/equistore/operations/_utils.py
@@ -130,8 +130,7 @@ def _check_same_gradients(a: TensorBlock, b: TensorBlock, props: List[str], fnam
     for parameter, grad_a in a.gradients():
         grad_b = b.gradient(parameter)
 
-        if len(grad_a.gradients_list()) != 0 or len(grad_b.gradients_list()) != 0:
-            raise NotImplementedError("gradients of gradients are not supported")
+        _check_same_gradients(grad_a, grad_b, props=props, fname=fname)
 
         if props is not None:
             for prop in props:

--- a/python/equistore-operations/equistore/operations/abs.py
+++ b/python/equistore-operations/equistore/operations/abs.py
@@ -62,7 +62,8 @@ def _abs_block(block: TensorBlock) -> TensorBlock:
         diff_components = len(gradient.components) - len(block.components)
         # The sign_values have the same dimensions as that of the block.values.
         # Reshape the sign_values to allow multiplication with gradient.values
-        new_grad = gradient.values[:] * sign_values[gradient.samples["sample"]].reshape(
+        gradient_samples_sample = gradient.samples["sample"].values[:, 0]
+        new_grad = gradient.values[:] * sign_values[gradient_samples_sample].reshape(
             (-1,) + (1,) * diff_components + _shape
         )
 

--- a/python/equistore-operations/equistore/operations/allclose.py
+++ b/python/equistore-operations/equistore/operations/allclose.py
@@ -217,7 +217,7 @@ def allclose_raise(
     ... except equistore.NotEqualError as e:
     ...     print(f"got an exception: {e}")
     ...
-    got an exception: blocks for key '(0,)' are different
+    got an exception: blocks for (key=0) are different
     >>> # call allclose_raise again, but use equal_nan=True and rtol=1e-5
     >>> # This passes, as the two NaNs are now considered equal, and the
     >>> # difference between the first values of the blocks of the two tensors
@@ -239,7 +239,7 @@ def allclose_raise(
                 equal_nan=equal_nan,
             )
         except NotEqualError as e:
-            raise NotEqualError(f"blocks for key '{key}' are different") from e
+            raise NotEqualError(f"blocks for {key.print()} are different") from e
 
 
 def allclose_block(

--- a/python/equistore-operations/equistore/operations/allclose.py
+++ b/python/equistore-operations/equistore/operations/allclose.py
@@ -229,7 +229,7 @@ def allclose_raise(
     except NotEqualError as e:
         raise NotEqualError("the tensor maps have different keys") from e
 
-    for key, block_1 in tensor_1:
+    for key, block_1 in tensor_1.items():
         try:
             allclose_block_raise(
                 block_1,

--- a/python/equistore-operations/equistore/operations/block_from_array.py
+++ b/python/equistore-operations/equistore/operations/block_from_array.py
@@ -50,13 +50,13 @@ def block_from_array(array: equistore.core.data.Array) -> TensorBlock:
         )
 
     components = [
-        Labels.arange(f"component_{component_index+1}", axis_size)
+        Labels.range(f"component_{component_index+1}", axis_size)
         for component_index, axis_size in enumerate(shape[1:-1])
     ]
 
     return TensorBlock(
         values=array,
-        samples=Labels.arange("sample", shape[0]),
+        samples=Labels.range("sample", shape[0]),
         components=components,
-        properties=Labels.arange("property", shape[-1]),
+        properties=Labels.range("property", shape[-1]),
     )

--- a/python/equistore-operations/equistore/operations/divide.py
+++ b/python/equistore-operations/equistore/operations/divide.py
@@ -113,14 +113,20 @@ def _divide_block_block(block_1: TensorBlock, block_2: TensorBlock) -> TensorBlo
 
         values_grad = []
         for i_sample in range(len(block_1.samples)):
-            i_sample_grad_1 = np.where(gradient_1.samples["sample"] == i_sample)[0]
-            i_sample_grad_2 = np.where(gradient_2.samples["sample"] == i_sample)[0]
-            values_grad.append(
+            samples_1 = gradient_1.samples["sample"].values
+            i_sample_grad_1 = np.where(samples_1 == i_sample)[0]
+
+            samples_2 = gradient_2.samples["sample"].values
+            i_sample_grad_2 = np.where(samples_2 == i_sample)[0]
+
+            value_grad = (
                 -block_1.values[i_sample]
                 * gradient_2.values[i_sample_grad_2]
                 / block_2.values[i_sample] ** 2
-                + gradient_1.values[i_sample_grad_1] / block_2.values[i_sample]
             )
+            value_grad += gradient_1.values[i_sample_grad_1] / block_2.values[i_sample]
+            values_grad.append(value_grad)
+
         values_grad = _dispatch.concatenate(values_grad, axis=0)
 
         result_block.add_gradient(

--- a/python/equistore-operations/equistore/operations/divide.py
+++ b/python/equistore-operations/equistore/operations/divide.py
@@ -38,29 +38,29 @@ def divide(A: TensorMap, B: Union[float, TensorMap]) -> TensorMap:
     blocks = []
     if isinstance(B, TensorMap):
         _check_same_keys(A, B, "divide")
-        for key, blockA in A:
-            blockB = B.block(key)
+        for key, block_A in A.items():
+            block_B = B.block(key)
             _check_blocks(
-                blockA,
-                blockB,
+                block_A,
+                block_B,
                 props=["samples", "components", "properties"],
                 fname="divide",
             )
             _check_same_gradients(
-                blockA,
-                blockB,
+                block_A,
+                block_B,
                 props=["samples", "components", "properties"],
                 fname="divide",
             )
-            blocks.append(_divide_block_block(block_1=blockA, block_2=blockB))
+            blocks.append(_divide_block_block(block_1=block_A, block_2=block_B))
     else:
         # check if can be converted in float (so if it is a constant value)
         try:
             float(B)
         except TypeError as e:
             raise TypeError("B should be a TensorMap or a scalar value. ") from e
-        for blockA in A.blocks():
-            blocks.append(_divide_block_constant(block=blockA, constant=B))
+        for block_A in A:
+            blocks.append(_divide_block_constant(block=block_A, constant=B))
 
     return TensorMap(A.keys, blocks)
 

--- a/python/equistore-operations/equistore/operations/dot.py
+++ b/python/equistore-operations/equistore/operations/dot.py
@@ -53,7 +53,11 @@ def dot(tensor_1: TensorMap, tensor_2: TensorMap) -> TensorMap:
         properties (2): ['structure']
         gradients: None
     >>> print(tensor_dot.block(0).samples)
-    [(0,) (1,)]
+    Labels(
+        structure
+            0
+            1
+    )
     >>> print(tensor_dot.block(0).values)
     [[14 32]
      [32 77]]

--- a/python/equistore-operations/equistore/operations/dot.py
+++ b/python/equistore-operations/equistore/operations/dot.py
@@ -74,7 +74,7 @@ def dot(tensor_1: TensorMap, tensor_2: TensorMap) -> TensorMap:
     _check_same_keys(tensor_1, tensor_2, "dot")
 
     blocks = []
-    for key, block_1 in tensor_1:
+    for key, block_1 in tensor_1.items():
         block_2 = tensor_2.block(key)
         blocks.append(_dot_block(block_1=block_1, block_2=block_2))
 

--- a/python/equistore-operations/equistore/operations/empty_like.py
+++ b/python/equistore-operations/equistore/operations/empty_like.py
@@ -88,7 +88,7 @@ def empty_like(
     """
 
     blocks = []
-    for _k, block in tensor:
+    for block in tensor:
         blocks.append(
             empty_like_block(
                 block=block, gradients=gradients, requires_grad=requires_grad

--- a/python/equistore-operations/equistore/operations/empty_like.py
+++ b/python/equistore-operations/equistore/operations/empty_like.py
@@ -37,16 +37,16 @@ def empty_like(
 
     >>> block = TensorBlock(
     ...     values=np.random.rand(4, 3),
-    ...     samples=Labels.arange("sample", 4),
+    ...     samples=Labels.range("sample", 4),
     ...     components=[],
-    ...     properties=Labels.arange("property", 3),
+    ...     properties=Labels.range("property", 3),
     ... )
     >>> block.add_gradient(
     ...     parameter="alpha",
     ...     gradient=TensorBlock(
     ...         values=np.random.rand(2, 3, 3),
     ...         samples=Labels(["sample", "atom"], np.array([[0, 0], [0, 2]])),
-    ...         components=[Labels.arange("component", 3)],
+    ...         components=[Labels.range("component", 3)],
     ...         properties=block.properties,
     ...     ),
     ... )

--- a/python/equistore-operations/equistore/operations/equal.py
+++ b/python/equistore-operations/equistore/operations/equal.py
@@ -56,7 +56,7 @@ def equal_raise(tensor_1: TensorMap, tensor_2: TensorMap):
     except ValueError as e:
         raise NotEqualError("the tensor maps have different keys") from e
 
-    for key, block_1 in tensor_1:
+    for key, block_1 in tensor_1.items():
         try:
             equal_block_raise(block_1, tensor_2.block(key))
         except NotEqualError as e:

--- a/python/equistore-operations/equistore/operations/equal.py
+++ b/python/equistore-operations/equistore/operations/equal.py
@@ -60,7 +60,7 @@ def equal_raise(tensor_1: TensorMap, tensor_2: TensorMap):
         try:
             equal_block_raise(block_1, tensor_2.block(key))
         except NotEqualError as e:
-            raise NotEqualError(f"blocks for key '{key}' are different") from e
+            raise NotEqualError(f"blocks for {key.print()} are different") from e
 
 
 def equal_block(block_1: TensorBlock, block_2: TensorBlock) -> bool:

--- a/python/equistore-operations/equistore/operations/equal_metadata.py
+++ b/python/equistore-operations/equistore/operations/equal_metadata.py
@@ -51,13 +51,13 @@ def equal_metadata(
     ...         TensorBlock(
     ...             values=np.full((4, 3, 1), 4.0),
     ...             samples=Labels(["samples"], np.array([[0], [1], [4], [5]])),
-    ...             components=[Labels.arange("components", 3)],
+    ...             components=[Labels.range("components", 3)],
     ...             properties=Labels(["p_1", "p_2"], np.array([[0, 1]])),
     ...         ),
     ...         TensorBlock(
     ...             values=np.full((4, 3, 1), 4.0),
     ...             samples=Labels(["samples"], np.array([[0], [1], [4], [5]])),
-    ...             components=[Labels.arange("components", 3)],
+    ...             components=[Labels.range("components", 3)],
     ...             properties=Labels(["p_1", "p_2"], np.array([[0, 1]])),
     ...         ),
     ...     ],
@@ -71,13 +71,13 @@ def equal_metadata(
     ...         TensorBlock(
     ...             values=np.full((4, 3, 1), 4.0),
     ...             samples=Labels(["samples"], np.array([[0], [1], [4], [5]])),
-    ...             components=[Labels.arange("components", 3)],
+    ...             components=[Labels.range("components", 3)],
     ...             properties=Labels(["p_3", "p_4"], np.array([[0, 1]])),
     ...         ),
     ...         TensorBlock(
     ...             values=np.full((4, 3, 1), 4.0),
     ...             samples=Labels(["samples"], np.array([[0], [1], [4], [5]])),
-    ...             components=[Labels.arange("components", 3)],
+    ...             components=[Labels.range("components", 3)],
     ...             properties=Labels(["p_3", "p_4"], np.array([[0, 1]])),
     ...         ),
     ...     ],
@@ -129,13 +129,13 @@ def equal_metadata_block(
     >>> block_1 = TensorBlock(
     ...     values=np.full((4, 3, 1), 4.0),
     ...     samples=Labels(["samples"], np.array([[0], [1], [4], [5]])),
-    ...     components=[Labels.arange("components", 3)],
+    ...     components=[Labels.range("components", 3)],
     ...     properties=Labels(["p_1", "p_2"], np.array([[0, 1]])),
     ... )
     >>> block_2 = TensorBlock(
     ...     values=np.full((4, 3, 1), 4.0),
     ...     samples=Labels(["samples"], np.array([[0], [1], [4], [5]])),
-    ...     components=[Labels.arange("components", 3)],
+    ...     components=[Labels.range("components", 3)],
     ...     properties=Labels(["p_3", "p_4"], np.array([[0, 1]])),
     ... )
     >>> equal_metadata_block(block_1, block_2)
@@ -190,13 +190,13 @@ def equal_metadata_raise(
     ...         TensorBlock(
     ...             values=np.full((4, 3, 1), 4.0),
     ...             samples=Labels(["samples"], np.array([[0], [1], [4], [5]])),
-    ...             components=[Labels.arange("components", 3)],
+    ...             components=[Labels.range("components", 3)],
     ...             properties=Labels(["p_1", "p_2"], np.array([[0, 1]])),
     ...         ),
     ...         TensorBlock(
     ...             values=np.full((4, 3, 1), 4.0),
     ...             samples=Labels(["samples"], np.array([[0], [1], [4], [5]])),
-    ...             components=[Labels.arange("components", 3)],
+    ...             components=[Labels.range("components", 3)],
     ...             properties=Labels(["p_1", "p_2"], np.array([[0, 1]])),
     ...         ),
     ...     ],
@@ -210,13 +210,13 @@ def equal_metadata_raise(
     ...         TensorBlock(
     ...             values=np.full((4, 3, 1), 4.0),
     ...             samples=Labels(["samples"], np.array([[0], [1], [4], [5]])),
-    ...             components=[Labels.arange("components", 3)],
+    ...             components=[Labels.range("components", 3)],
     ...             properties=Labels(["p_3", "p_4"], np.array([[0, 1]])),
     ...         ),
     ...         TensorBlock(
     ...             values=np.full((4, 3, 1), 4.0),
     ...             samples=Labels(["samples"], np.array([[0], [1], [4], [5]])),
-    ...             components=[Labels.arange("components", 3)],
+    ...             components=[Labels.range("components", 3)],
     ...             properties=Labels(["p_3", "p_4"], np.array([[0, 1]])),
     ...         ),
     ...     ],
@@ -283,13 +283,13 @@ def equal_metadata_block_raise(
     >>> block_1 = TensorBlock(
     ...     values=np.full((4, 3, 1), 4.0),
     ...     samples=Labels(["samples"], np.array([[0], [1], [4], [5]])),
-    ...     components=[Labels.arange("components", 3)],
+    ...     components=[Labels.range("components", 3)],
     ...     properties=Labels(["p_1", "p_2"], np.array([[0, 1]])),
     ... )
     >>> block_2 = TensorBlock(
     ...     values=np.full((4, 3, 1), 4.0),
     ...     samples=Labels(["samples"], np.array([[0], [1], [4], [5]])),
-    ...     components=[Labels.arange("components", 3)],
+    ...     components=[Labels.range("components", 3)],
     ...     properties=Labels(["p_3", "p_4"], np.array([[0, 1]])),
     ... )
     >>> equistore.equal_metadata_block_raise(block_1, block_2)

--- a/python/equistore-operations/equistore/operations/join.py
+++ b/python/equistore-operations/equistore/operations/join.py
@@ -78,12 +78,12 @@ def join(tensors: List[TensorMap], axis: str):
             "sample names will loose information and is not supported."
         )
 
-    keys_names = ("tensor",) + tensors[0].keys.names
+    keys_names = ["tensor"] + tensors[0].keys.names
     keys_values = []
     blocks = []
 
     for i, tensor in enumerate(tensors):
-        keys_values += [(i,) + value for value in tensor.keys.tolist()]
+        keys_values += [[i] + value.tolist() for value in tensor.keys.values]
 
         for _, block in tensor:
             # We would already raised an error if `axis == "samples"`. Therefore, we can
@@ -91,7 +91,7 @@ def join(tensors: List[TensorMap], axis: str):
             if names_are_same:
                 properties = block.properties
             else:
-                properties = Labels.arange("property", len(block.properties))
+                properties = Labels.range("property", len(block.properties))
 
             new_block = TensorBlock(
                 values=block.values,

--- a/python/equistore-operations/equistore/operations/join.py
+++ b/python/equistore-operations/equistore/operations/join.py
@@ -85,7 +85,7 @@ def join(tensors: List[TensorMap], axis: str):
     for i, tensor in enumerate(tensors):
         keys_values += [[i] + value.tolist() for value in tensor.keys.values]
 
-        for _, block in tensor:
+        for block in tensor:
             # We would already raised an error if `axis == "samples"`. Therefore, we can
             # neglect the check for `axis == "properties"`.
             if names_are_same:

--- a/python/equistore-operations/equistore/operations/lstsq.py
+++ b/python/equistore-operations/equistore/operations/lstsq.py
@@ -112,7 +112,7 @@ def lstsq(X: TensorMap, Y: TensorMap, rcond, driver=None) -> TensorMap:
     _check_same_keys(X, Y, "lstsq")
 
     blocks = []
-    for key, X_block in X:
+    for key, X_block in X.items():
         Y_block = Y.block(key)
         blocks.append(_lstsq_block(X_block, Y_block, rcond=rcond, driver=driver))
 

--- a/python/equistore-operations/equistore/operations/multiply.py
+++ b/python/equistore-operations/equistore/operations/multiply.py
@@ -113,8 +113,12 @@ def _multiply_block_block(block_1: TensorBlock, block_2: TensorBlock) -> TensorB
 
         gradient_values = []
         for i_sample in range(len(block_1.samples)):
-            i_sample_grad_1 = np.where(gradient_1.samples["sample"] == i_sample)[0]
-            i_sample_grad_2 = np.where(gradient_2.samples["sample"] == i_sample)[0]
+            gradient_samples_1 = gradient_1.samples["sample"].values
+            i_sample_grad_1 = np.where(gradient_samples_1 == i_sample)[0]
+
+            gradient_samples_2 = gradient_2.samples["sample"].values
+            i_sample_grad_2 = np.where(gradient_samples_2 == i_sample)[0]
+
             gradient_values.append(
                 block_1.values[i_sample] * gradient_2.values[i_sample_grad_2]
                 + gradient_1.values[i_sample_grad_1] * block_2.values[i_sample]

--- a/python/equistore-operations/equistore/operations/one_hot.py
+++ b/python/equistore-operations/equistore/operations/one_hot.py
@@ -15,7 +15,7 @@ def one_hot(labels: Labels, dimension: Labels) -> np.ndarray:
         A ``Labels`` object from which one label will be extracted and
         transformed into a one-hot-encoded array.
     :param dimension:
-        A ``Labels`` object that contains a single label. The name of
+        A ``Labels`` object that contains a single dimension. The name of
         this label is the same that will be selected from ``labels``,
         and its values correspond to all possible values that the label
         can take.
@@ -59,19 +59,16 @@ def one_hot(labels: Labels, dimension: Labels) -> np.ndarray:
         )
 
     name = dimension.names[0]
-    possible_labels = dimension[name]
-    try:
-        original_labels = labels[name]
-    except ValueError:
-        raise ValueError("the dimension provided was not found among the labels")
 
-    indices = np.where(
-        original_labels.reshape(original_labels.size, 1) == possible_labels
-    )[1]
-    if indices.shape[0] != labels.asarray().shape[0]:
-        raise ValueError(
-            "some values not present in the dimension were found in the labels"
-        )
-    one_hot_array = np.eye(possible_labels.shape[0])[indices]
+    indices = np.zeros(len(labels), dtype=np.int64)
+    for i, entry in enumerate(labels[name].values):
+        position = dimension.position(entry)
+        if position is None:
+            raise ValueError(
+                f"{name}={entry[0]} is present in the labels, but was not found in "
+                "the dimension"
+            )
+        indices[i] = position
 
+    one_hot_array = np.eye(len(dimension))[indices]
     return one_hot_array

--- a/python/equistore-operations/equistore/operations/ones_like.py
+++ b/python/equistore-operations/equistore/operations/ones_like.py
@@ -37,16 +37,16 @@ def ones_like(
 
     >>> block = TensorBlock(
     ...     values=np.random.rand(4, 3),
-    ...     samples=Labels.arange("sample", 4),
+    ...     samples=Labels.range("sample", 4),
     ...     components=[],
-    ...     properties=Labels.arange("property", 3),
+    ...     properties=Labels.range("property", 3),
     ... )
     >>> block.add_gradient(
     ...     parameter="alpha",
     ...     gradient=TensorBlock(
     ...         values=np.random.rand(2, 3, 3),
     ...         samples=Labels(["sample", "atom"], np.array([[0, 0], [0, 2]])),
-    ...         components=[Labels.arange("component", 3)],
+    ...         components=[Labels.range("component", 3)],
     ...         properties=block.properties,
     ...     ),
     ... )

--- a/python/equistore-operations/equistore/operations/ones_like.py
+++ b/python/equistore-operations/equistore/operations/ones_like.py
@@ -101,7 +101,7 @@ def ones_like(
     """
 
     blocks = []
-    for block in tensor.blocks():
+    for block in tensor:
         blocks.append(
             ones_like_block(
                 block=block, gradients=gradients, requires_grad=requires_grad

--- a/python/equistore-operations/equistore/operations/pow.py
+++ b/python/equistore-operations/equistore/operations/pow.py
@@ -59,10 +59,11 @@ def _pow_block_constant(block: TensorBlock, constant: float) -> TensorBlock:
         # I want the difference between the number of components of the gradients and
         # the values
         diff_components = len(gradient_values.shape) - len(block.values.shape)
+        gradient_samples_sample = gradient.samples["sample"].values[:, 0]
         values_grad.append(
             constant
             * gradient_values
-            * block.values[gradient.samples["sample"]].reshape(
+            * block.values[gradient_samples_sample].reshape(
                 (-1,) + (1,) * diff_components + _shape
             )
             ** (constant - 1)

--- a/python/equistore-operations/equistore/operations/random_like.py
+++ b/python/equistore-operations/equistore/operations/random_like.py
@@ -38,16 +38,16 @@ def random_uniform_like(
 
     >>> block = TensorBlock(
     ...     values=np.random.rand(4, 3),
-    ...     samples=Labels.arange("sample", 4),
+    ...     samples=Labels.range("sample", 4),
     ...     components=[],
-    ...     properties=Labels.arange("property", 3),
+    ...     properties=Labels.range("property", 3),
     ... )
     >>> block.add_gradient(
     ...     parameter="alpha",
     ...     gradient=TensorBlock(
     ...         values=np.random.rand(2, 3, 3),
     ...         samples=Labels(["sample", "atom"], np.array([[0, 0], [0, 2]])),
-    ...         components=[Labels.arange("component", 3)],
+    ...         components=[Labels.range("component", 3)],
     ...         properties=block.properties,
     ...     ),
     ... )

--- a/python/equistore-operations/equistore/operations/random_like.py
+++ b/python/equistore-operations/equistore/operations/random_like.py
@@ -102,7 +102,7 @@ def random_uniform_like(
     ['alpha']
     """
     blocks = []
-    for block in tensor.blocks():
+    for block in tensor:
         blocks.append(
             random_uniform_like_block(
                 block=block,

--- a/python/equistore-operations/equistore/operations/reduce_over_samples.py
+++ b/python/equistore-operations/equistore/operations/reduce_over_samples.py
@@ -91,7 +91,7 @@ def _reduce_over_samples_block(
     ]
 
     # checks if it is a zero sample TensorBlock
-    if block.samples.shape[0] == 0:
+    if len(block.samples) == 0:
         # Here is different from the general case where we use Labels.single() if
         # if len(remaining_samples) == 0
         # Labels.single() cannot be used because Labels.single() has not
@@ -130,11 +130,9 @@ def _reduce_over_samples_block(
 
         return result_block
 
-    # reshaping the samples in a 2D array
-    samples = block_samples.view(dtype=np.int32).reshape(block_samples.shape[0], -1)
     # get which samples will still be there after reduction
     new_samples, index = np.unique(
-        samples[:, sample_selected], return_inverse=True, axis=0
+        block_samples.values[:, sample_selected], return_inverse=True, axis=0
     )
 
     block_values = block.values
@@ -195,7 +193,7 @@ def _reduce_over_samples_block(
             raise NotImplementedError("gradients of gradients are not supported")
 
         # check if all gradients are zeros
-        if gradient.samples.shape[0] == 0:
+        if len(gradient.samples) == 0:
             # The gradients does not change because, if they are all zeros, the
             # gradients after reducing operation is still zero.
 
@@ -215,11 +213,7 @@ def _reduce_over_samples_block(
 
         gradient_samples = gradient.samples
         # here we need to copy because we want to modify the samples array
-        samples = (
-            gradient_samples.view(dtype=np.int32)
-            .reshape(gradient_samples.shape[0], -1)
-            .copy()
-        )
+        samples = gradient_samples.values.copy()
 
         # change the first columns of the samples array with the mapping
         # between samples and gradient.samples
@@ -391,11 +385,15 @@ def sum_over_samples_block(
     ...         ),
     ...     ),
     ...     components=[],
-    ...     properties=Labels.arange("properties", 3),
+    ...     properties=Labels.range("properties", 3),
     ... )
     >>> block_sum = sum_over_samples_block(block, sample_names="center")
     >>> print(block_sum.samples)
-    [(0,) (1,)]
+    Labels(
+        structure
+            0
+            1
+    )
     >>> print(block_sum.values)
     [[ 4  7 10]
      [17 19 21]]
@@ -453,7 +451,7 @@ def sum_over_samples(
     ...         ),
     ...     ),
     ...     components=[],
-    ...     properties=Labels.arange("properties", 3),
+    ...     properties=Labels.range("properties", 3),
     ... )
     >>> keys = Labels(names=["key"], values=np.array([[0]]))
     >>> tensor = TensorMap(keys, [block])
@@ -466,7 +464,11 @@ def sum_over_samples(
         properties (3): ['properties']
         gradients: None
     >>> print(tensor_sum.block(0).samples)
-    [(0,) (1,)]
+    Labels(
+        structure
+            0
+            1
+    )
     >>> print(tensor_sum.block(0).values)
     [[ 4  7 10]
      [17 19 21]]

--- a/python/equistore-operations/equistore/operations/reduce_over_samples.py
+++ b/python/equistore-operations/equistore/operations/reduce_over_samples.py
@@ -328,7 +328,7 @@ def _reduce_over_samples(
     ]
 
     blocks = []
-    for _, block in tensor:
+    for block in tensor:
         blocks.append(
             _reduce_over_samples_block(
                 block=block,

--- a/python/equistore-operations/equistore/operations/remove_gradients.py
+++ b/python/equistore-operations/equistore/operations/remove_gradients.py
@@ -25,7 +25,7 @@ def remove_gradients(
         remove = tensor.block(0).gradients_list()
 
     blocks = []
-    for _, block in tensor:
+    for block in tensor:
         new_block = TensorBlock(
             values=block.values,
             samples=block.samples,

--- a/python/equistore-operations/equistore/operations/solve.py
+++ b/python/equistore-operations/equistore/operations/solve.py
@@ -71,7 +71,7 @@ def solve(X: TensorMap, Y: TensorMap) -> TensorMap:
     """
     _check_same_keys(X, Y, "solve")
 
-    for _, X_block in X:
+    for X_block in X:
         shape = X_block.values.shape
         if len(shape) != 2 or (not (shape[0] == shape[1])):
             raise ValueError(
@@ -79,7 +79,7 @@ def solve(X: TensorMap, Y: TensorMap) -> TensorMap:
             )
 
     blocks = []
-    for key, X_block in X:
+    for key, X_block in X.items():
         Y_block = Y.block(key)
         blocks.append(_solve_block(X_block, Y_block))
 

--- a/python/equistore-operations/equistore/operations/solve.py
+++ b/python/equistore-operations/equistore/operations/solve.py
@@ -40,9 +40,9 @@ def solve(X: TensorMap, Y: TensorMap) -> TensorMap:
     ...     keys=Labels(names=["dummy"], values=np.array([[0]])),
     ...     blocks=[
     ...         TensorBlock(
-    ...             samples=Labels.arange("sample", 2),
+    ...             samples=Labels.range("sample", 2),
     ...             components=[],
-    ...             properties=Labels.arange("properties_for_regression", 2),
+    ...             properties=Labels.range("properties_for_regression", 2),
     ...             values=covariance,
     ...         )
     ...     ],
@@ -51,9 +51,9 @@ def solve(X: TensorMap, Y: TensorMap) -> TensorMap:
     ...     keys=Labels(names=["dummy"], values=np.array([[0]])),
     ...     blocks=[
     ...         TensorBlock(
-    ...             samples=Labels.arange("sample", 2),
+    ...             samples=Labels.range("sample", 2),
     ...             components=[],
-    ...             properties=Labels.arange("property_to_regress", 1),
+    ...             properties=Labels.range("property_to_regress", 1),
     ...             values=y_regression,
     ...         )
     ...     ],

--- a/python/equistore-operations/equistore/operations/to.py
+++ b/python/equistore-operations/equistore/operations/to.py
@@ -106,10 +106,10 @@ def block_to(
         )
     if backend is not None:
         if not isinstance(backend, str):
-            raise TypeError("`backend` should be passed as a `str`")
+            raise TypeError("'backend' should be given as a string")
         else:
             if backend not in ["numpy", "torch"]:
-                raise ValueError(f"backend ``{backend}`` not supported")
+                raise ValueError(f"backend '{backend}' is not supported")
             if backend == "numpy":
                 if requires_grad is not None:
                     raise ValueError(

--- a/python/equistore-operations/equistore/operations/unique_metadata.py
+++ b/python/equistore-operations/equistore/operations/unique_metadata.py
@@ -111,7 +111,7 @@ def unique_metadata(
     if gradient is None:
         blocks = tensor.blocks()
     else:
-        blocks = [block.gradient(gradient) for block in tensor.blocks()]
+        blocks = [block.gradient(gradient) for block in tensor]
 
     return _unique_from_blocks(blocks, axis, names)
 

--- a/python/equistore-operations/equistore/operations/zeros_like.py
+++ b/python/equistore-operations/equistore/operations/zeros_like.py
@@ -37,16 +37,16 @@ def zeros_like(
 
     >>> block = TensorBlock(
     ...     values=np.random.rand(4, 3),
-    ...     samples=Labels.arange("sample", 4),
+    ...     samples=Labels.range("sample", 4),
     ...     components=[],
-    ...     properties=Labels.arange("property", 3),
+    ...     properties=Labels.range("property", 3),
     ... )
     >>> block.add_gradient(
     ...     parameter="alpha",
     ...     gradient=TensorBlock(
     ...         values=np.random.rand(2, 3, 3),
     ...         samples=Labels(["sample", "atom"], np.array([[0, 0], [0, 2]])),
-    ...         components=[Labels.arange("component", 3)],
+    ...         components=[Labels.range("component", 3)],
     ...         properties=block.properties,
     ...     ),
     ... )

--- a/python/equistore-operations/equistore/operations/zeros_like.py
+++ b/python/equistore-operations/equistore/operations/zeros_like.py
@@ -101,7 +101,7 @@ def zeros_like(
     """
 
     blocks = []
-    for block in tensor.blocks():
+    for block in tensor:
         blocks.append(
             zeros_like_block(
                 block=block, gradients=gradients, requires_grad=requires_grad

--- a/python/equistore-operations/tests/abs.py
+++ b/python/equistore-operations/tests/abs.py
@@ -18,7 +18,7 @@ def tensor():
 def tensor_map_complex(tensor):
     """Manipulate tensor to be a suitable test for the `abs` function."""
     blocks = []
-    for _, block in tensor:
+    for block in tensor:
         new_block = TensorBlock(
             values=-block.values + 3j,
             samples=block.samples,
@@ -45,7 +45,7 @@ def tensor_map_complex(tensor):
 @pytest.fixture
 def tensor_map_result(tensor_map_complex):
     blocks = []
-    for _, block in tensor_map_complex:
+    for block in tensor_map_complex:
         new_block = TensorBlock(
             values=np.abs(block.values),
             samples=block.samples,

--- a/python/equistore-operations/tests/allclose.py
+++ b/python/equistore-operations/tests/allclose.py
@@ -15,13 +15,13 @@ def test_allclose_nograd():
         values=np.array([[1, 2], [3, 5]], dtype=np.float64),
         samples=Labels(["s"], np.array([[0], [2]])),
         components=[],
-        properties=Labels.arange("p", 2),
+        properties=Labels.range("p", 2),
     )
     block_2 = TensorBlock(
         values=np.array([[1, 2], [3, 4], [5, 6], [1, 2], [3, 4], [5, 6]]),
-        samples=Labels.arange("s", 6),
+        samples=Labels.range("s", 6),
         components=[],
-        properties=Labels.arange("p", 2),
+        properties=Labels.range("p", 2),
     )
 
     block_3 = TensorBlock(
@@ -42,7 +42,7 @@ def test_allclose_nograd():
     Y = TensorMap(keys, [block_3, block_4])
     assert not equistore.allclose(X, Y)
 
-    message = r"blocks for key '\(0, 0\)' are different"
+    message = "blocks for \\(key_1=0, key_2=0\\) are different"
     with pytest.raises(NotEqualError, match=message):
         equistore.allclose_raise(X, Y)
 
@@ -64,19 +64,19 @@ def test_allclose_nograd():
         ),
         samples=Labels(["s"], np.array([[0], [2]])),
         components=[
-            Labels.arange("c_1", 3),
-            Labels.arange("c_2", 3),
+            Labels.range("c_1", 3),
+            Labels.range("c_2", 3),
         ],
-        properties=Labels.arange("p", 2),
+        properties=Labels.range("p", 2),
     )
     block_1_c_copy = TensorBlock(
         values=block_1_c.values + 0.1e-6,
         samples=Labels(["s"], np.array([[0], [2]])),
         components=[
-            Labels.arange("c_1", 3),
-            Labels.arange("c_2", 3),
+            Labels.range("c_1", 3),
+            Labels.range("c_2", 3),
         ],
-        properties=Labels.arange("p", 2),
+        properties=Labels.range("p", 2),
     )
 
     block_2_c = TensorBlock(
@@ -89,21 +89,21 @@ def test_allclose_nograd():
                 [[[1, 2], [17.7, 27.7]], [[77.1, 22.2], [1.11, 3.42]]],
             ]
         ),
-        samples=Labels.arange("s", 5),
+        samples=Labels.range("s", 5),
         components=[
             Labels(["c_1"], np.array([[3], [5]])),
             Labels(["c_2"], np.array([[6], [8]])),
         ],
-        properties=Labels.arange("p", 2),
+        properties=Labels.range("p", 2),
     )
     block_2_c_copy = TensorBlock(
         values=block_2_c.values + 0.1e-6,
-        samples=Labels.arange("s", 5),
+        samples=Labels.range("s", 5),
         components=[
             Labels(["c_1"], np.array([[3], [5]])),
             Labels(["c_2"], np.array([[6], [8]])),
         ],
-        properties=Labels.arange("p", 2),
+        properties=Labels.range("p", 2),
     )
     X_c = TensorMap(keys, [block_1_c, block_2_c])
     X_c_copy = TensorMap(keys, [block_1_c_copy, block_2_c_copy])
@@ -134,7 +134,10 @@ def test_self_allclose_grad():
     assert not equistore.allclose(tensor1, tensor1_e6)
     assert equistore.allclose(tensor1, tensor1_e6, rtol=1e-5, atol=1e-5)
 
-    message = r"blocks for key '\(0, 1, 1\)' are different"
+    message = (
+        "blocks for \\(spherical_harmonics_l=0, species_center=1, "
+        "species_neighbor=1\\) are different"
+    )
     with pytest.raises(NotEqualError, match=message):
         equistore.allclose_raise(tensor1, tensor1_e6)
 
@@ -299,7 +302,7 @@ def test_self_allclose_exceptions_gradient():
         gradient=TensorBlock(
             values=np.full((2, 3, 1), 1.0),
             samples=Labels(["sample", "g"], np.array([[0, -2], [1, 3]])),
-            components=[Labels.arange("c_1", -1, 2)],
+            components=[Labels(["c_1"], np.array([[-1], [0], [1]]))],
             properties=block_4.properties,
         ),
     )

--- a/python/equistore-operations/tests/allclose.py
+++ b/python/equistore-operations/tests/allclose.py
@@ -122,7 +122,7 @@ def test_self_allclose_grad():
     )
     blocks = []
     blocks_e6 = []
-    for _, block in tensor1:
+    for block in tensor1:
         blocks.append(block.copy())
         be6 = block.copy()
         be6.values[:] += 1e-6

--- a/python/equistore-operations/tests/block_from_array.py
+++ b/python/equistore-operations/tests/block_from_array.py
@@ -17,14 +17,14 @@ def test_without_components():
     block = equistore.block_from_array(array)
     assert block.values is array
 
-    assert block.samples.names == ("sample",)
+    assert block.samples.names == ["sample"]
     np.testing.assert_equal(
-        block.samples.asarray(), np.arange(array.shape[0]).reshape((-1, 1))
+        block.samples.values, np.arange(array.shape[0]).reshape((-1, 1))
     )
 
-    assert block.properties.names == ("property",)
+    assert block.properties.names == ["property"]
     np.testing.assert_equal(
-        block.properties.asarray(), np.arange(array.shape[1]).reshape((-1, 1))
+        block.properties.values, np.arange(array.shape[1]).reshape((-1, 1))
     )
 
 
@@ -34,19 +34,19 @@ def test_with_components():
     block = equistore.block_from_array(array)
     assert block.values is array
 
-    assert block.samples.names == ("sample",)
+    assert block.samples.names == ["sample"]
     np.testing.assert_equal(
-        block.samples.asarray(), np.arange(array.shape[0]).reshape((-1, 1))
+        block.samples.values, np.arange(array.shape[0]).reshape((-1, 1))
     )
 
     assert len(block.components) == 1
     component = block.components[0]
-    assert component.names == ("component_1",)
+    assert component.names == ["component_1"]
     np.testing.assert_equal(
-        component.asarray(), np.arange(array.shape[1]).reshape((-1, 1))
+        component.values, np.arange(array.shape[1]).reshape((-1, 1))
     )
 
-    assert block.properties.names == ("property",)
+    assert block.properties.names == ["property"]
     np.testing.assert_equal(
-        block.properties.asarray(), np.arange(array.shape[2]).reshape((-1, 1))
+        block.properties.values, np.arange(array.shape[2]).reshape((-1, 1))
     )

--- a/python/equistore-operations/tests/divide.py
+++ b/python/equistore-operations/tests/divide.py
@@ -12,38 +12,38 @@ class TestDivide(unittest.TestCase):
             values=np.array([[1, 2], [3, 5]]),
             samples=Labels(["s"], np.array([[0], [2]])),
             components=[],
-            properties=Labels.arange("p", 2),
+            properties=Labels.range("p", 2),
         )
         block_2 = TensorBlock(
             values=np.array([[1, 2], [3, 4], [5, 6]]),
             samples=Labels(["s"], np.array([[0], [2], [7]])),
             components=[],
-            properties=Labels.arange("p", 2),
+            properties=Labels.range("p", 2),
         )
         block_3 = TensorBlock(
             values=np.array([[1.5, 2.1], [6.7, 10.2]]),
             samples=Labels(["s"], np.array([[0], [2]])),
             components=[],
-            properties=Labels.arange("p", 2),
+            properties=Labels.range("p", 2),
         )
         block_4 = TensorBlock(
             values=np.array([[10, 200.8], [3.76, 4.432], [545, 26]]),
             samples=Labels(["s"], np.array([[0], [2], [7]])),
             components=[],
-            properties=Labels.arange("p", 2),
+            properties=Labels.range("p", 2),
         )
 
         block_res1 = TensorBlock(
             values=block_1.values[:] / block_3.values[:],
             samples=Labels(["s"], np.array([[0], [2]])),
             components=[],
-            properties=Labels.arange("p", 2),
+            properties=Labels.range("p", 2),
         )
         block_res2 = TensorBlock(
             values=block_2.values[:] / block_4.values[:],
             samples=Labels(["s"], np.array([[0], [2], [7]])),
             components=[],
-            properties=Labels.arange("p", 2),
+            properties=Labels.range("p", 2),
         )
         keys = Labels(names=["key_1", "key_2"], values=np.array([[0, 0], [1, 0]]))
         A = TensorMap(keys, [block_1, block_2])
@@ -62,14 +62,14 @@ class TestDivide(unittest.TestCase):
             values=np.array([[14, 24], [43, 45]]),
             samples=Labels(["s"], np.array([[0], [2]])),
             components=[],
-            properties=Labels.arange("p", 2),
+            properties=Labels.range("p", 2),
         )
         block_1.add_gradient(
             parameter="g",
             gradient=TensorBlock(
                 values=np.array([[[6, 1], [7, 2]], [[8, 3], [9, 4]]]),
                 samples=Labels(["sample", "g"], np.array([[0, 1], [1, 1]])),
-                components=[Labels.arange("c", 2)],
+                components=[Labels.range("c", 2)],
                 properties=block_1.properties,
             ),
         )
@@ -78,7 +78,7 @@ class TestDivide(unittest.TestCase):
             values=np.array([[15, 25], [53, 54], [55, 65]]),
             samples=Labels(["s"], np.array([[0], [2], [7]])),
             components=[],
-            properties=Labels.arange("p", 2),
+            properties=Labels.range("p", 2),
         )
         block_2.add_gradient(
             parameter="g",
@@ -87,7 +87,7 @@ class TestDivide(unittest.TestCase):
                     [[[10, 11], [12, 13]], [[14, 15], [10, 11]], [[12, 13], [14, 15]]]
                 ),
                 samples=Labels(["sample", "g"], np.array([[0, 1], [1, 1], [2, 1]])),
-                components=[Labels.arange("c", 2)],
+                components=[Labels.range("c", 2)],
                 properties=block_2.properties,
             ),
         )
@@ -96,14 +96,14 @@ class TestDivide(unittest.TestCase):
             values=np.array([[1.45, 2.41], [6.47, 10.42]]),
             samples=Labels(["s"], np.array([[0], [2]])),
             components=[],
-            properties=Labels.arange("p", 2),
+            properties=Labels.range("p", 2),
         )
         block_3.add_gradient(
             parameter="g",
             gradient=TensorBlock(
                 values=np.array([[[1, 0.1], [2, 0.2]], [[3, 0.3], [4.5, 0.4]]]),
                 samples=Labels(["sample", "g"], np.array([[0, 1], [1, 1]])),
-                components=[Labels.arange("c", 2)],
+                components=[Labels.range("c", 2)],
                 properties=block_3.properties,
             ),
         )
@@ -111,7 +111,7 @@ class TestDivide(unittest.TestCase):
             values=np.array([[105, 200.58], [3.756, 4.4325], [545.5, 26.05]]),
             samples=Labels(["s"], np.array([[0], [2], [7]])),
             components=[],
-            properties=Labels.arange("p", 2),
+            properties=Labels.range("p", 2),
         )
         block_4.add_gradient(
             parameter="g",
@@ -124,7 +124,7 @@ class TestDivide(unittest.TestCase):
                     ]
                 ),
                 samples=Labels(["sample", "g"], np.array([[0, 1], [1, 1], [2, 1]])),
-                components=[Labels.arange("c", 2)],
+                components=[Labels.range("c", 2)],
                 properties=block_4.properties,
             ),
         )
@@ -133,7 +133,7 @@ class TestDivide(unittest.TestCase):
             values=np.array([[9.65517241, 9.95850622], [6.64605873, 4.31861804]]),
             samples=Labels(["s"], np.array([[0], [2]])),
             components=[],
-            properties=Labels.arange("p", 2),
+            properties=Labels.range("p", 2),
         )
         block_res1.add_gradient(
             parameter="g",
@@ -145,7 +145,7 @@ class TestDivide(unittest.TestCase):
                     ]
                 ),
                 samples=Labels(["sample", "g"], np.array([[0, 1], [1, 1]])),
-                components=[Labels.arange("c", 2)],
+                components=[Labels.range("c", 2)],
                 properties=block_res1.properties,
             ),
         )
@@ -159,7 +159,7 @@ class TestDivide(unittest.TestCase):
             ),
             samples=Labels(["s"], np.array([[0], [2], [7]])),
             components=[],
-            properties=Labels.arange("p", 2),
+            properties=Labels.range("p", 2),
         )
         block_res2.add_gradient(
             parameter="g",
@@ -172,7 +172,7 @@ class TestDivide(unittest.TestCase):
                     ]
                 ),
                 samples=Labels(["sample", "g"], np.array([[0, 1], [1, 1], [2, 1]])),
-                components=[Labels.arange("c", 2)],
+                components=[Labels.range("c", 2)],
                 properties=block_res2.properties,
             ),
         )
@@ -199,14 +199,14 @@ class TestDivide(unittest.TestCase):
             values=np.array([[1, 2], [3, 5]]),
             samples=Labels(["s"], np.array([[0], [2]])),
             components=[],
-            properties=Labels.arange("p", 2),
+            properties=Labels.range("p", 2),
         )
         block_1.add_gradient(
             parameter="g",
             gradient=TensorBlock(
                 values=np.array([[[6, 1], [7, 2]], [[8, 3], [9, 4]]]),
                 samples=Labels(["sample", "g"], np.array([[0, 1], [1, 1]])),
-                components=[Labels.arange("c", 2)],
+                components=[Labels.range("c", 2)],
                 properties=block_1.properties,
             ),
         )
@@ -214,7 +214,7 @@ class TestDivide(unittest.TestCase):
             values=np.array([[11, 12], [13, 14], [15, 16]]),
             samples=Labels(["s"], np.array([[0], [2], [7]])),
             components=[],
-            properties=Labels.arange("p", 2),
+            properties=Labels.range("p", 2),
         )
         block_2.add_gradient(
             parameter="g",
@@ -223,7 +223,7 @@ class TestDivide(unittest.TestCase):
                     [[[10, 11], [12, 13]], [[14, 15], [10, 11]], [[12, 13], [14, 15]]]
                 ),
                 samples=Labels(["sample", "g"], np.array([[0, 1], [1, 1], [2, 1]])),
-                components=[Labels.arange("c", 2)],
+                components=[Labels.range("c", 2)],
                 properties=block_2.properties,
             ),
         )
@@ -232,7 +232,7 @@ class TestDivide(unittest.TestCase):
             values=np.array([[0.19607843, 0.39215686], [0.58823529, 0.98039216]]),
             samples=Labels(["s"], np.array([[0], [2]])),
             components=[],
-            properties=Labels.arange("p", 2),
+            properties=Labels.range("p", 2),
         )
         block_res1.add_gradient(
             parameter="g",
@@ -244,7 +244,7 @@ class TestDivide(unittest.TestCase):
                     ]
                 ),
                 samples=Labels(["sample", "g"], np.array([[0, 1], [1, 1]])),
-                components=[Labels.arange("c", 2)],
+                components=[Labels.range("c", 2)],
                 properties=block_res1.properties,
             ),
         )
@@ -258,7 +258,7 @@ class TestDivide(unittest.TestCase):
             ),
             samples=Labels(["s"], np.array([[0], [2], [7]])),
             components=[],
-            properties=Labels.arange("p", 2),
+            properties=Labels.range("p", 2),
         )
         block_res2.add_gradient(
             parameter="g",
@@ -271,7 +271,7 @@ class TestDivide(unittest.TestCase):
                     ]
                 ),
                 samples=Labels(["sample", "g"], np.array([[0, 1], [1, 1], [2, 1]])),
-                components=[Labels.arange("c", 2)],
+                components=[Labels.range("c", 2)],
                 properties=block_res2.properties,
             ),
         )
@@ -293,7 +293,7 @@ class TestDivide(unittest.TestCase):
             values=np.array([[1, 2], [3, 5]]),
             samples=Labels(["s"], np.array([[0], [2]])),
             components=[],
-            properties=Labels.arange("p", 2),
+            properties=Labels.range("p", 2),
         )
         keys = Labels(names=["key_1", "key_2"], values=np.array([[0, 0]]))
         A = TensorMap(keys, [block_1])

--- a/python/equistore-operations/tests/dot.py
+++ b/python/equistore-operations/tests/dot.py
@@ -22,7 +22,7 @@ class TestDot(unittest.TestCase):
         dot_tensor = equistore.dot(tensor_1=tensor_1, tensor_2=tensor_2)
         self.assertTrue(np.all(tensor_1.keys == dot_tensor.keys))
 
-        for key, block_1 in tensor_1:
+        for key, block_1 in tensor_1.items():
             dot_block = dot_tensor.block(key)
 
             block_2 = tensor_2.block(key)
@@ -65,7 +65,7 @@ class TestDot(unittest.TestCase):
 
         tensor_2 = []
         n_samples = 42
-        for _, block_1 in tensor_1:
+        for block_1 in tensor_1:
             value2 = np.arange(n_samples * len(block_1.properties)).reshape(
                 n_samples, len(block_1.properties)
             )
@@ -86,7 +86,7 @@ class TestDot(unittest.TestCase):
         dot_tensor = equistore.dot(tensor_1=tensor_1, tensor_2=tensor_2)
         self.assertTrue(np.all(tensor_1.keys == dot_tensor.keys))
 
-        for key, block_1 in tensor_1:
+        for key, block_1 in tensor_1.items():
             block_2 = tensor_2.block(key)
             dot_block = dot_tensor.block(key)
 

--- a/python/equistore-operations/tests/drop_blocks.py
+++ b/python/equistore-operations/tests/drop_blocks.py
@@ -1,5 +1,4 @@
 import os
-import re
 
 import numpy as np
 import pytest
@@ -11,9 +10,6 @@ from equistore import Labels, TensorMap
 DATA_ROOT = os.path.join(os.path.dirname(__file__), "data")
 
 
-# ===== Fixtures and helper functions =====
-
-
 @pytest.fixture
 def test_tensor_map() -> TensorMap:
     return equistore.load(
@@ -21,20 +17,6 @@ def test_tensor_map() -> TensorMap:
         # the npz is using DEFLATE compression, equistore only supports STORED
         use_numpy=True,
     )
-
-
-def check_consistency(tensor1: TensorMap, tensor2: TensorMap):
-    # check if two TensorMaps contain the same information
-    if tensor1.keys.names != tensor2.keys.names:
-        raise ValueError("the two tensors have different key names")
-
-    keys = tensor2.keys
-    for key in keys:
-        if tensor2[key] != tensor1[key]:
-            raise ValueError(f"the blocks indexed by key {key} are not equivalent")
-
-
-# ===== Tests =====
 
 
 def test_drop_all(test_tensor_map):
@@ -46,72 +28,36 @@ def test_drop_all(test_tensor_map):
     assert equistore.equal(tensor, empty_tensor)
 
 
-def test_drop_first(test_tensor_map):
-    # test the behavior when the first key is dropped
-    ref_keys = test_tensor_map.keys[1:]
-    ref_blocks = [test_tensor_map[key].copy() for key in ref_keys]
-    ref_tensor = TensorMap(ref_keys, ref_blocks)
-
-    key_to_drop = test_tensor_map.keys[:1]
-    new_tensor = equistore.drop_blocks(test_tensor_map, key_to_drop)
-    assert equistore.equal(new_tensor, ref_tensor)
-    check_consistency(test_tensor_map, new_tensor)
-
-
-def test_drop_last(test_tensor_map):
-    # test the behavior when the last key is dropped
-    ref_keys = test_tensor_map.keys[:-1]
-    ref_blocks = [test_tensor_map[key].copy() for key in ref_keys]
-    ref_tensor = TensorMap(ref_keys, ref_blocks)
-
-    key_to_drop = test_tensor_map.keys[-1:]
-    new_tensor = equistore.drop_blocks(test_tensor_map, key_to_drop)
-    assert equistore.equal(new_tensor, ref_tensor)
-    check_consistency(test_tensor_map, new_tensor)
-
-
-def test_drop_random(test_tensor_map):
-    # test the behavior when an existing  random key is dropped
-    number_blocks = len(test_tensor_map.blocks())
-    index_to_remove = np.random.randint(1, number_blocks - 1)
-
-    names = test_tensor_map.keys.names
-    values = []
-    for i in range(index_to_remove):
-        values += [tuple(test_tensor_map.keys[i])]
-    for i in range(index_to_remove + 1, number_blocks):
-        values += [tuple(test_tensor_map.keys[i])]
-    values = np.array(values)
-    ref_keys = Labels(names, values)
-    ref_blocks = [test_tensor_map[key].copy() for key in ref_keys]
-    ref_tensor = TensorMap(ref_keys, ref_blocks)
-
-    key_to_drop = Labels(
-        test_tensor_map.keys[index_to_remove].dtype.names,
-        np.array([tuple(test_tensor_map.keys[index_to_remove])]),
-    )
-    new_tensor = equistore.drop_blocks(test_tensor_map, key_to_drop)
-    assert equistore.equal(new_tensor, ref_tensor)
-    check_consistency(test_tensor_map, new_tensor)
-
-
 def test_drop_two_random_keys(test_tensor_map):
     # test the behavior when two random keys are dropped
-    number_blocks = len(test_tensor_map.blocks())
-    indices_to_drop = np.random.randint(0, number_blocks, 2)
-    keys_to_drop = test_tensor_map.keys[indices_to_drop]
+    n_blocks = len(test_tensor_map.keys)
+    indices_to_drop = np.random.randint(0, n_blocks, 2)
 
-    ref_keys = np.setdiff1d(test_tensor_map.keys, keys_to_drop)
-    ref_blocks = [test_tensor_map[key].copy() for key in ref_keys]
-    ref_tensor = TensorMap(ref_keys, ref_blocks)
+    values_to_drop = [test_tensor_map.keys[i].values for i in indices_to_drop]
+    keys_to_drop = Labels(
+        test_tensor_map.keys.names,
+        np.vstack(values_to_drop),
+    )
+
+    values_to_keep = [
+        test_tensor_map.keys[i].values
+        for i in range(n_blocks)
+        if i not in indices_to_drop
+    ]
+    keys_to_keep = Labels(
+        test_tensor_map.keys.names,
+        np.vstack(values_to_keep),
+    )
+
+    ref_blocks = [test_tensor_map[key].copy() for key in keys_to_keep]
+    ref_tensor = TensorMap(keys_to_keep, ref_blocks)
 
     new_tensor = equistore.drop_blocks(test_tensor_map, keys_to_drop)
     assert equistore.equal(new_tensor, ref_tensor)
-    check_consistency(test_tensor_map, new_tensor)
 
 
 def test_drop_nothing(test_tensor_map):
-    # test when an emty key is dropped
+    # test when an empty set of keys are dropped
     empty_key = Labels.empty(test_tensor_map.keys.names)
     new_tensor = equistore.drop_blocks(test_tensor_map, empty_key)
     assert new_tensor == test_tensor_map
@@ -122,11 +68,11 @@ def test_not_existent(test_tensor_map):
     non_existent_key = Labels(
         test_tensor_map.keys.names, np.array([[-1, -1, -1], [0, 0, 0]])
     )
-    error_msg = (
-        "some keys in `keys` are not present in `tensor`."
-        f" Non-existent keys: {non_existent_key}"
+    message = (
+        "\\(species_center=-1, species_neighbor_1=-1, species_neighbor_2=-1\\) "
+        "is not present in this tensor"
     )
-    with pytest.raises(ValueError, match=re.escape(error_msg)):
+    with pytest.raises(ValueError, match=message):
         equistore.drop_blocks(test_tensor_map, non_existent_key)
 
 
@@ -134,10 +80,14 @@ def test_copy_flag(test_tensor_map):
     """
     Checks that settings the copy flag to true or false gives the same result.
     Also checks that inplace modifications of the underlying data doesn't affect
-    the copied returned tensor, but it does for the uncopied version.
+    the copied returned tensor, but it does for the un-copied version.
     """
     # Define some keys to drop
-    keys_to_drop = test_tensor_map.keys[:5]
+    values_to_drop = [test_tensor_map.keys[i].values for i in range(5)]
+    keys_to_drop = Labels(
+        test_tensor_map.keys.names,
+        np.vstack(values_to_drop),
+    )
 
     # Drop blocks with copy=True flag
     new_tensor_copied = equistore.drop_blocks(test_tensor_map, keys_to_drop, copy=True)
@@ -147,10 +97,8 @@ def test_copy_flag(test_tensor_map):
         test_tensor_map, keys_to_drop, copy=False
     )
 
-    # Check that the resulting tensormaps are equal whether or not they are
-    # copied
+    # Check that the resulting tensor are equal whether or not they are copied
     assert equistore.equal(new_tensor_copied, new_tensor_not_copied)
-    # check_consistency(new_tensor_copied, new_tensor_not_copied)
 
     # Now modify the original tensor's block values in place
     for block in test_tensor_map.blocks():
@@ -160,7 +108,7 @@ def test_copy_flag(test_tensor_map):
     for key in new_tensor_copied.keys:
         assert np.all(new_tensor_copied[key].values != test_tensor_map[key].values)
 
-    # But the uncopied tensor's values should have been
+    # But the un-copied tensor's values should have been
     for key in new_tensor_not_copied.keys:
         assert np.all(new_tensor_not_copied[key].values == test_tensor_map[key].values)
         assert np.all(

--- a/python/equistore-operations/tests/drop_blocks.py
+++ b/python/equistore-operations/tests/drop_blocks.py
@@ -31,6 +31,7 @@ def test_drop_all(test_tensor_map):
 def test_drop_two_random_keys(test_tensor_map):
     # test the behavior when two random keys are dropped
     n_blocks = len(test_tensor_map.keys)
+    np.random.seed(0xFEA123)
     indices_to_drop = np.random.randint(0, n_blocks, 2)
 
     values_to_drop = [test_tensor_map.keys[i].values for i in indices_to_drop]

--- a/python/equistore-operations/tests/equal.py
+++ b/python/equistore-operations/tests/equal.py
@@ -15,13 +15,13 @@ def test_equal_no_gradient():
         values=np.array([[1, 2], [3, 5]], dtype=np.float64),
         samples=Labels(["s"], np.array([[0], [2]])),
         components=[],
-        properties=Labels.arange("p", 2),
+        properties=Labels.range("p", 2),
     )
     block_2 = TensorBlock(
         values=np.array([[1, 2], [3, 4], [5, 6], [1, 2], [3, 4], [5, 6]]),
-        samples=Labels.arange("s", 6),
+        samples=Labels.range("s", 6),
         components=[],
-        properties=Labels.arange("p", 2),
+        properties=Labels.range("p", 2),
     )
 
     block_3 = TensorBlock(
@@ -43,7 +43,7 @@ def test_equal_no_gradient():
     Y = TensorMap(keys, [block_3, block_4])
     assert not equistore.equal(X, Y)
 
-    message = r"blocks for key '\(0, 0\)' are different"
+    message = "blocks for \\(key_1=0, key_2=0\\) are different"
     with pytest.raises(NotEqualError, match=message):
         equistore.equal_raise(X, Y)
 
@@ -65,19 +65,19 @@ def test_equal_no_gradient():
         ),
         samples=Labels(["s"], np.array([[0], [2]])),
         components=[
-            Labels.arange("c1", 3),
-            Labels.arange("c2", 3),
+            Labels.range("c1", 3),
+            Labels.range("c2", 3),
         ],
-        properties=Labels.arange("p", 2),
+        properties=Labels.range("p", 2),
     )
     block_1_c_copy = TensorBlock(
         values=block_1_c.values + 0.1e-6,
         samples=Labels(["s"], np.array([[0], [2]])),
         components=[
-            Labels.arange("c1", 3),
-            Labels.arange("c2", 3),
+            Labels.range("c1", 3),
+            Labels.range("c2", 3),
         ],
-        properties=Labels.arange("p", 2),
+        properties=Labels.range("p", 2),
     )
 
     block_2_c = TensorBlock(
@@ -90,21 +90,21 @@ def test_equal_no_gradient():
                 [[[1, 2], [17.7, 27.7]], [[77.1, 22.2], [1.11, 3.42]]],
             ]
         ),
-        samples=Labels.arange("s", 5),
+        samples=Labels.range("s", 5),
         components=[
             Labels(["c1"], np.array([[3], [5]])),
             Labels(["c2"], np.array([[6], [8]])),
         ],
-        properties=Labels.arange("p", 2),
+        properties=Labels.range("p", 2),
     )
     block_2_c_copy = TensorBlock(
         values=block_2_c.values + 0.1e-6,
-        samples=Labels.arange("s", 5),
+        samples=Labels.range("s", 5),
         components=[
             Labels(["c1"], np.array([[3], [5]])),
             Labels(["c2"], np.array([[6], [8]])),
         ],
-        properties=Labels.arange("p", 2),
+        properties=Labels.range("p", 2),
     )
     X_c = TensorMap(keys, [block_1_c, block_2_c])
     X_c_copy = TensorMap(keys, [block_1_c_copy, block_2_c_copy])
@@ -132,7 +132,10 @@ def test_self_equal_grad():
     assert equistore.equal(tensor1, tensor1_copy)
     assert not equistore.equal(tensor1, tensor1_e6)
 
-    message = r"blocks for key '\(0, 1, 1\)' are different"
+    message = (
+        "blocks for \\(spherical_harmonics_l=0, species_center=1, "
+        "species_neighbor=1\\) are different"
+    )
     with pytest.raises(NotEqualError, match=message):
         equistore.equal_raise(tensor1, tensor1_e6)
 
@@ -336,7 +339,7 @@ def test_self_equal_exceptions_gradient():
         gradient=TensorBlock(
             values=np.full((2, 3, 1), 1.0),
             samples=Labels(["sample", "g"], np.array([[0, -2], [1, 3]])),
-            components=[Labels.arange("c_1", -1, 2)],
+            components=[Labels.range("c_1", 3)],
             properties=block_4.properties,
         ),
     )

--- a/python/equistore-operations/tests/equal.py
+++ b/python/equistore-operations/tests/equal.py
@@ -115,32 +115,32 @@ def test_equal_no_gradient():
 
 
 def test_self_equal_grad():
-    tensor1 = equistore.load(
+    tensor_1 = equistore.load(
         os.path.join(DATA_ROOT, "qm7-spherical-expansion.npz"),
         use_numpy=True,
     )
     blocks = []
     blocks_e6 = []
-    for _, block in tensor1:
+    for block in tensor_1:
         blocks.append(block.copy())
         be6 = block.copy()
         be6.values[:] += 1e-6
         blocks_e6.append(be6)
 
-    tensor1_copy = TensorMap(tensor1.keys, blocks)
-    tensor1_e6 = TensorMap(tensor1.keys, blocks_e6)
-    assert equistore.equal(tensor1, tensor1_copy)
-    assert not equistore.equal(tensor1, tensor1_e6)
+    tensor1_copy = TensorMap(tensor_1.keys, blocks)
+    tensor_1_e6 = TensorMap(tensor_1.keys, blocks_e6)
+    assert equistore.equal(tensor_1, tensor1_copy)
+    assert not equistore.equal(tensor_1, tensor_1_e6)
 
     message = (
         "blocks for \\(spherical_harmonics_l=0, species_center=1, "
         "species_neighbor=1\\) are different"
     )
     with pytest.raises(NotEqualError, match=message):
-        equistore.equal_raise(tensor1, tensor1_e6)
+        equistore.equal_raise(tensor_1, tensor_1_e6)
 
     with pytest.raises(NotEqualError, match="values are not equal"):
-        equistore.equal_block_raise(tensor1.block(0), tensor1_e6.block(0))
+        equistore.equal_block_raise(tensor_1.block(0), tensor_1_e6.block(0))
 
 
 def test_self_equal_exceptions():

--- a/python/equistore-operations/tests/join.py
+++ b/python/equistore-operations/tests/join.py
@@ -108,7 +108,7 @@ def test_join_properties_values(tensor):
 
     # We can not use `equistore.equal_raise` for the checks because the meta data
     # differs by the tensor entry.
-    for key, block in tensor:
+    for key, block in tensor.items():
         joined_block = joined_tensor[key]
 
         assert_equal(joined_block.values, block.values)
@@ -210,7 +210,7 @@ def test_join_samples_values(tensor):
 
     # We can not use #equistore.equal_raise for the checks because the meta data
     # differs by the tensor entry.
-    for key, block in tensor:
+    for key, block in tensor.items():
         joined_block = joined_tensor[key]
 
         assert_equal(joined_block.values, block.values)

--- a/python/equistore-operations/tests/lstsq.py
+++ b/python/equistore-operations/tests/lstsq.py
@@ -16,13 +16,13 @@ class TestLstsq(unittest.TestCase):
             values=np.array([[1, 2], [3, 5]]),
             samples=Labels(["s"], np.array([[0], [2]])),
             components=[],
-            properties=Labels.arange("p", 2),
+            properties=Labels.range("p", 2),
         )
         block_2 = TensorBlock(
             values=np.array([[1, 2], [3, 4], [5, 6]]),
             samples=Labels(["s"], np.array([[0], [2], [7]])),
             components=[],
-            properties=Labels.arange("p", 2),
+            properties=Labels.range("p", 2),
         )
 
         block_3 = TensorBlock(
@@ -70,23 +70,23 @@ class TestLstsq(unittest.TestCase):
         x, x_grad, y, y_grad = get_value_linear_solve()
         block_X = TensorBlock(
             values=x,
-            samples=Labels.arange("s", 5),
+            samples=Labels.range("s", 5),
             components=[],
-            properties=Labels.arange("p", 2),
+            properties=Labels.range("p", 2),
         )
         block_X.add_gradient(
             parameter="z",
             gradient=TensorBlock(
                 values=x_grad,
-                samples=Labels.arange("sample", 5),
-                components=[Labels.arange("c", 3)],
+                samples=Labels.range("sample", 5),
+                components=[Labels.range("c", 3)],
                 properties=block_X.properties,
             ),
         )
 
         block_Y = TensorBlock(
             values=y,
-            samples=Labels.arange("s", 5),
+            samples=Labels.range("s", 5),
             components=[],
             properties=Labels(["p"], np.array([[2]])),
         )
@@ -94,8 +94,8 @@ class TestLstsq(unittest.TestCase):
             parameter="z",
             gradient=TensorBlock(
                 values=y_grad,
-                samples=Labels.arange("sample", 5),
-                components=[Labels.arange("c", 3)],
+                samples=Labels.range("sample", 5),
+                components=[Labels.range("c", 3)],
                 properties=block_Y.properties,
             ),
         )
@@ -124,17 +124,17 @@ class TestLstsq(unittest.TestCase):
         block_X = TensorBlock(
             values=x.reshape((1, x.shape[0], x.shape[1])),
             samples=Labels(["s"], np.array([[0]])),
-            components=[Labels.arange("c", 5)],
-            properties=Labels.arange("p", 2),
+            components=[Labels.range("c", 5)],
+            properties=Labels.range("p", 2),
         )
         block_X.add_gradient(
             parameter="z",
             gradient=TensorBlock(
                 values=x_grad.reshape(1, 3, len(x), x.shape[-1]),
-                samples=Labels.arange("sample", 1),
+                samples=Labels.range("sample", 1),
                 components=[
-                    Labels.arange("der_components", 3),
-                    Labels.arange("c", 5),
+                    Labels.range("der_components", 3),
+                    Labels.range("c", 5),
                 ],
                 properties=block_X.properties,
             ),
@@ -143,17 +143,17 @@ class TestLstsq(unittest.TestCase):
         block_Y = TensorBlock(
             values=y.reshape((1, len(y), y.shape[-1])),
             samples=Labels(["s"], np.array([[0]])),
-            components=[Labels.arange("c", 5)],
+            components=[Labels.range("c", 5)],
             properties=Labels(["p"], np.array([[2]])),
         )
         block_Y.add_gradient(
             parameter="z",
             gradient=TensorBlock(
                 values=y_grad.reshape((1, 3, len(y), y.shape[-1])),
-                samples=Labels.arange("sample", 1),
+                samples=Labels.range("sample", 1),
                 components=[
-                    Labels.arange("der_components", 3),
-                    Labels.arange("c", 5),
+                    Labels.range("der_components", 3),
+                    Labels.range("c", 5),
                 ],
                 properties=block_Y.properties,
             ),

--- a/python/equistore-operations/tests/lstsq.py
+++ b/python/equistore-operations/tests/lstsq.py
@@ -59,9 +59,9 @@ class TestLstsq(unittest.TestCase):
             np.allclose(w.block(0).values, np.array([-1.0, 1.0]), rtol=1e-13)
         )
         self.assertTrue(np.allclose(w.block(1).values, np.array([7, 8]), rtol=1e-7))
-        for key, blockw in w:
-            self.assertTrue(np.all(blockw.samples == Y.block(key).properties))
-            self.assertTrue(np.all(blockw.properties == X.block(key).properties))
+        for key, block_w in w.items():
+            self.assertTrue(np.all(block_w.samples == Y.block(key).properties))
+            self.assertTrue(np.all(block_w.properties == X.block(key).properties))
 
         Ydot = equistore.dot(X, w)
         self.assertTrue(equistore.allclose(Ydot, Y))
@@ -112,7 +112,7 @@ class TestLstsq(unittest.TestCase):
             np.allclose(w.block(0).values, np.array([1.0, 3.0]), rtol=1e-13)
         )
 
-        for key, block_w in w:
+        for key, block_w in w.items():
             self.assertTrue(np.all(block_w.samples == Y.block(key).properties))
             self.assertTrue(np.all(block_w.properties == X.block(key).properties))
 
@@ -171,9 +171,9 @@ class TestLstsq(unittest.TestCase):
             np.allclose(w.block(0).values, np.array([1.0, 3.0]), rtol=1e-13)
         )
 
-        for key, blockw in w:
-            self.assertTrue(np.all(blockw.samples == Y.block(key).properties))
-            self.assertTrue(np.all(blockw.properties == X.block(key).properties))
+        for key, block_w in w.items():
+            self.assertTrue(np.all(block_w.samples == Y.block(key).properties))
+            self.assertTrue(np.all(block_w.properties == X.block(key).properties))
 
         Ydot = equistore.dot(X, w)
         self.assertTrue(equistore.allclose(Ydot, Y))

--- a/python/equistore-operations/tests/multiply.py
+++ b/python/equistore-operations/tests/multiply.py
@@ -16,38 +16,38 @@ class TestMultiply(unittest.TestCase):
             values=np.array([[1, 2], [3, 5]]),
             samples=Labels(["s"], np.array([[0], [2]])),
             components=[],
-            properties=Labels.arange("p", 2),
+            properties=Labels.range("p", 2),
         )
         block_2 = TensorBlock(
             values=np.array([[1, 2], [3, 4], [5, 6]]),
             samples=Labels(["s"], np.array([[0], [2], [7]])),
             components=[],
-            properties=Labels.arange("p", 2),
+            properties=Labels.range("p", 2),
         )
         block_3 = TensorBlock(
             values=np.array([[1.5, 2.1], [6.7, 10.2]]),
             samples=Labels(["s"], np.array([[0], [2]])),
             components=[],
-            properties=Labels.arange("p", 2),
+            properties=Labels.range("p", 2),
         )
         block_4 = TensorBlock(
             values=np.array([[10, 200.8], [3.76, 4.432], [545, 26]]),
             samples=Labels(["s"], np.array([[0], [2], [7]])),
             components=[],
-            properties=Labels.arange("p", 2),
+            properties=Labels.range("p", 2),
         )
 
         block_res_1 = TensorBlock(
             values=np.array([[1.5, 4.2], [20.1, 51.0]]),
             samples=Labels(["s"], np.array([[0], [2]])),
             components=[],
-            properties=Labels.arange("p", 2),
+            properties=Labels.range("p", 2),
         )
         block_res_2 = TensorBlock(
             values=np.array([[10.0, 401.6], [11.28, 17.728], [2725.0, 156.0]]),
             samples=Labels(["s"], np.array([[0], [2], [7]])),
             components=[],
-            properties=Labels.arange("p", 2),
+            properties=Labels.range("p", 2),
         )
         keys = Labels(names=["key_1", "key_2"], values=np.array([[0, 0], [1, 0]]))
         A = TensorMap(keys, [block_1, block_2])
@@ -67,14 +67,14 @@ class TestMultiply(unittest.TestCase):
             values=np.array([[14, 24], [43, 45]]),
             samples=Labels(["s"], np.array([[0], [2]])),
             components=[],
-            properties=Labels.arange("p", 2),
+            properties=Labels.range("p", 2),
         )
         block_1.add_gradient(
             parameter="g",
             gradient=TensorBlock(
                 values=np.array([[[6, 1], [7, 2]], [[8, 3], [9, 4]]]),
-                samples=Labels.arange("sample", 2),
-                components=[Labels.arange("c", 2)],
+                samples=Labels.range("sample", 2),
+                components=[Labels.range("c", 2)],
                 properties=block_1.properties,
             ),
         )
@@ -83,7 +83,7 @@ class TestMultiply(unittest.TestCase):
             values=np.array([[15, 25], [53, 54], [55, 65]]),
             samples=Labels(["s"], np.array([[0], [2], [7]])),
             components=[],
-            properties=Labels.arange("p", 2),
+            properties=Labels.range("p", 2),
         )
         block_2.add_gradient(
             parameter="g",
@@ -91,8 +91,8 @@ class TestMultiply(unittest.TestCase):
                 values=np.array(
                     [[[10, 11], [12, 13]], [[14, 15], [10, 11]], [[12, 13], [14, 15]]]
                 ),
-                samples=Labels.arange("sample", 3),
-                components=[Labels.arange("c", 2)],
+                samples=Labels.range("sample", 3),
+                components=[Labels.range("c", 2)],
                 properties=block_2.properties,
             ),
         )
@@ -101,14 +101,14 @@ class TestMultiply(unittest.TestCase):
             values=np.array([[1.45, 2.41], [6.47, 10.42]]),
             samples=Labels(["s"], np.array([[0], [2]])),
             components=[],
-            properties=Labels.arange("p", 2),
+            properties=Labels.range("p", 2),
         )
         block_3.add_gradient(
             parameter="g",
             gradient=TensorBlock(
                 values=np.array([[[1, 0.1], [2, 0.2]], [[3, 0.3], [4.5, 0.4]]]),
-                samples=Labels.arange("sample", 2),
-                components=[Labels.arange("c", 2)],
+                samples=Labels.range("sample", 2),
+                components=[Labels.range("c", 2)],
                 properties=block_3.properties,
             ),
         )
@@ -117,7 +117,7 @@ class TestMultiply(unittest.TestCase):
             values=np.array([[105, 200.58], [3.756, 4.4325], [545.5, 26.05]]),
             samples=Labels(["s"], np.array([[0], [2], [7]])),
             components=[],
-            properties=Labels.arange("p", 2),
+            properties=Labels.range("p", 2),
         )
         block_4.add_gradient(
             parameter="g",
@@ -129,8 +129,8 @@ class TestMultiply(unittest.TestCase):
                         [[1.2, 1.3], [1.4, 1.5]],
                     ]
                 ),
-                samples=Labels.arange("sample", 3),
-                components=[Labels.arange("c", 2)],
+                samples=Labels.range("sample", 3),
+                components=[Labels.range("c", 2)],
                 properties=block_4.properties,
             ),
         )
@@ -139,7 +139,7 @@ class TestMultiply(unittest.TestCase):
             values=np.array([[20.3, 57.84], [278.21, 468.9]]),
             samples=Labels(["s"], np.array([[0], [2]])),
             components=[],
-            properties=Labels.arange("p", 2),
+            properties=Labels.range("p", 2),
         )
         block_res_1.add_gradient(
             parameter="g",
@@ -147,8 +147,8 @@ class TestMultiply(unittest.TestCase):
                 values=np.array(
                     [[[22.7, 4.81], [38.15, 9.62]], [[180.76, 44.76], [251.73, 59.68]]]
                 ),
-                samples=Labels.arange("sample", 2),
-                components=[Labels.arange("c", 2)],
+                samples=Labels.range("sample", 2),
+                components=[Labels.range("c", 2)],
                 properties=block_res_1.properties,
             ),
         )
@@ -157,7 +157,7 @@ class TestMultiply(unittest.TestCase):
             values=np.array([[1575.0, 5014.5], [199.068, 239.355], [30002.5, 1693.25]]),
             samples=Labels(["s"], np.array([[0], [2], [7]])),
             components=[],
-            properties=Labels.arange("p", 2),
+            properties=Labels.range("p", 2),
         )
         block_res_2.add_gradient(
             parameter="g",
@@ -169,8 +169,8 @@ class TestMultiply(unittest.TestCase):
                         [[6612.0, 423.15], [7714.0, 488.25]],
                     ]
                 ),
-                samples=Labels.arange("sample", 3),
-                components=[Labels.arange("c", 2)],
+                samples=Labels.range("sample", 3),
+                components=[Labels.range("c", 2)],
                 properties=block_res_2.properties,
             ),
         )
@@ -193,14 +193,14 @@ class TestMultiply(unittest.TestCase):
             values=np.array([[1, 2], [3, 5]]),
             samples=Labels(["s"], np.array([[0], [2]])),
             components=[],
-            properties=Labels.arange("p", 2),
+            properties=Labels.range("p", 2),
         )
         block_1.add_gradient(
             parameter="g",
             gradient=TensorBlock(
                 values=np.array([[[6, 1], [7, 2]], [[8, 3], [9, 4]]]),
-                samples=Labels.arange("sample", 2),
-                components=[Labels.arange("c", 2)],
+                samples=Labels.range("sample", 2),
+                components=[Labels.range("c", 2)],
                 properties=block_1.properties,
             ),
         )
@@ -209,7 +209,7 @@ class TestMultiply(unittest.TestCase):
             values=np.array([[11, 12], [13, 14], [15, 16]]),
             samples=Labels(["s"], np.array([[0], [2], [7]])),
             components=[],
-            properties=Labels.arange("p", 2),
+            properties=Labels.range("p", 2),
         )
         block_2.add_gradient(
             parameter="g",
@@ -217,8 +217,8 @@ class TestMultiply(unittest.TestCase):
                 values=np.array(
                     [[[10, 11], [12, 13]], [[14, 15], [10, 11]], [[12, 13], [14, 15]]]
                 ),
-                samples=Labels.arange("sample", 3),
-                components=[Labels.arange("c", 2)],
+                samples=Labels.range("sample", 3),
+                components=[Labels.range("c", 2)],
                 properties=block_2.properties,
             ),
         )
@@ -227,7 +227,7 @@ class TestMultiply(unittest.TestCase):
             values=np.array([[5.1, 10.2], [15.3, 25.5]]),
             samples=Labels(["s"], np.array([[0], [2]])),
             components=[],
-            properties=Labels.arange("p", 2),
+            properties=Labels.range("p", 2),
         )
         block_res_1.add_gradient(
             parameter="g",
@@ -235,8 +235,8 @@ class TestMultiply(unittest.TestCase):
                 values=np.array(
                     [[[30.6, 5.1], [35.7, 10.2]], [[40.8, 15.3], [45.9, 20.4]]]
                 ),
-                samples=Labels.arange("sample", 2),
-                components=[Labels.arange("c", 2)],
+                samples=Labels.range("sample", 2),
+                components=[Labels.range("c", 2)],
                 properties=block_res_1.properties,
             ),
         )
@@ -245,7 +245,7 @@ class TestMultiply(unittest.TestCase):
             values=np.array([[56.1, 61.2], [66.3, 71.4], [76.5, 81.6]]),
             samples=Labels(["s"], np.array([[0], [2], [7]])),
             components=[],
-            properties=Labels.arange("p", 2),
+            properties=Labels.range("p", 2),
         )
         block_res_2.add_gradient(
             parameter="g",
@@ -257,8 +257,8 @@ class TestMultiply(unittest.TestCase):
                         [[61.2, 66.3], [71.4, 76.5]],
                     ]
                 ),
-                samples=Labels.arange("sample", 3),
-                components=[Labels.arange("c", 2)],
+                samples=Labels.range("sample", 3),
+                components=[Labels.range("c", 2)],
                 properties=block_res_2.properties,
             ),
         )
@@ -280,7 +280,7 @@ class TestMultiply(unittest.TestCase):
             values=np.array([[1, 2], [3, 5]]),
             samples=Labels(["s"], np.array([[0], [2]])),
             components=[],
-            properties=Labels.arange("p", 2),
+            properties=Labels.range("p", 2),
         )
         keys = Labels(names=["key_1", "key_2"], values=np.array([[0, 0]]))
         A = TensorMap(keys, [block_1])

--- a/python/equistore-operations/tests/one_hot.py
+++ b/python/equistore-operations/tests/one_hot.py
@@ -70,7 +70,9 @@ def test_wrong_name():
         values=np.array([[0, 6], [1, 1], [2, 1], [3, 1], [4, 6], [5, 1]]),
     )
     possible_labels = Labels(names=["not_present"], values=np.array([[1], [6], [8]]))
-    with pytest.raises(ValueError, match="dimension provided was not found"):
+
+    message = "'not_present' not found in the dimensions of these Labels"
+    with pytest.raises(ValueError, match=message):
         equistore.one_hot(original_labels, possible_labels)
 
 
@@ -82,8 +84,7 @@ def test_missing_value():
         values=np.array([[0, 6], [1, 1], [2, 1], [3, 1], [4, 6], [5, 1]]),
     )
     possible_labels = Labels(names=["species"], values=np.array([[1], [8]]))
-    with pytest.raises(
-        ValueError,
-        match="some values not present in the dimension were found in the labels",
-    ):
+
+    message = "species=6 is present in the labels, but was not found in the dimension"
+    with pytest.raises(ValueError, match=message):
         equistore.one_hot(original_labels, possible_labels)

--- a/python/equistore-operations/tests/ones_like.py
+++ b/python/equistore-operations/tests/ones_like.py
@@ -24,7 +24,7 @@ def test_ones_like():
     assert equistore.equal_metadata(ones_tensor_positions, tensor_no_cell)
 
     # check the values
-    for key, block in tensor:
+    for key, block in tensor.items():
         one_block = ones_tensor[key]
 
         assert np.all(one_block.values == np.ones_like(block.values))

--- a/python/equistore-operations/tests/pow.py
+++ b/python/equistore-operations/tests/pow.py
@@ -30,14 +30,14 @@ class TestPow:
             values=np.vstack([b1_s0, b1_s2]),
             samples=Labels(["s"], np.array([[0], [2]])),
             components=[],
-            properties=Labels.arange("p", 2),
+            properties=Labels.range("p", 2),
         )
         block_1.add_gradient(
             parameter="g",
             gradient=TensorBlock(
                 values=np.vstack([[b1grad_s01], [b1grad_s11]]),
-                samples=Labels.arange("sample", 2),
-                components=[Labels.arange("c", 2)],
+                samples=Labels.range("sample", 2),
+                components=[Labels.range("c", 2)],
                 properties=block_1.properties,
             ),
         )
@@ -46,14 +46,14 @@ class TestPow:
             values=np.vstack([b2_s0, b2_s2, b2_s7]),
             samples=Labels(["s"], np.array([[0], [2], [7]])),
             components=[],
-            properties=Labels.arange("p", 2),
+            properties=Labels.range("p", 2),
         )
         block_2.add_gradient(
             parameter="g",
             gradient=TensorBlock(
                 values=np.vstack([[b2grad_s01], [b2grad_s11], [b2grad_s21]]),
-                samples=Labels.arange("sample", 3),
-                components=[Labels.arange("c", 2)],
+                samples=Labels.range("sample", 3),
+                components=[Labels.range("c", 2)],
                 properties=block_2.properties,
             ),
         )
@@ -70,7 +70,7 @@ class TestPow:
             values=res_values_1,
             samples=Labels(["s"], np.array([[0], [2]])),
             components=[],
-            properties=Labels.arange("p", 2),
+            properties=Labels.range("p", 2),
         )
         block_res_1.add_gradient(
             parameter="g",
@@ -81,8 +81,8 @@ class TestPow:
                         [B * b1grad_s11 * (b1_s2 ** (B - 1))],
                     ]
                 ),
-                samples=Labels.arange("sample", 2),
-                components=[Labels.arange("c", 2)],
+                samples=Labels.range("sample", 2),
+                components=[Labels.range("c", 2)],
                 properties=block_res_1.properties,
             ),
         )
@@ -91,7 +91,7 @@ class TestPow:
             values=res_values_2,
             samples=Labels(["s"], np.array([[0], [2], [7]])),
             components=[],
-            properties=Labels.arange("p", 2),
+            properties=Labels.range("p", 2),
         )
         block_res_2.add_gradient(
             parameter="g",
@@ -103,8 +103,8 @@ class TestPow:
                         [B * b2grad_s21 * (b2_s7 ** (B - 1))],
                     ]
                 ),
-                samples=Labels.arange("sample", 3),
-                components=[Labels.arange("c", 2)],
+                samples=Labels.range("sample", 3),
+                components=[Labels.range("c", 2)],
                 properties=block_res_2.properties,
             ),
         )
@@ -141,10 +141,10 @@ class TestPow:
             ),
             samples=Labels(["s"], np.array([[0], [2]])),
             components=[
-                Labels.arange("components_1", 2),
+                Labels.range("components_1", 2),
                 Labels(["component2"], np.array([[0]])),
             ],
-            properties=Labels.arange("p", 2),
+            properties=Labels.range("p", 2),
         )
 
         block_1.add_gradient(
@@ -164,10 +164,10 @@ class TestPow:
                         ],
                     ]
                 ),
-                samples=Labels.arange("sample", 2),
+                samples=Labels.range("sample", 2),
                 components=[
-                    Labels.arange("grad_components", 2),
-                    Labels.arange("components_1", 2),
+                    Labels.range("grad_components", 2),
+                    Labels.range("components_1", 2),
                     Labels(["component2"], np.array([[0]])),
                 ],
                 properties=block_1.properties,
@@ -213,19 +213,19 @@ class TestPow:
             values=res_values_1,
             samples=Labels(["s"], np.array([[0], [2]])),
             components=[
-                Labels.arange("components_1", 2),
+                Labels.range("components_1", 2),
                 Labels(["component2"], np.array([[0]])),
             ],
-            properties=Labels.arange("p", 2),
+            properties=Labels.range("p", 2),
         )
         block_res_1.add_gradient(
             parameter="g",
             gradient=TensorBlock(
                 values=res_grad_1,
-                samples=Labels.arange("sample", 2),
+                samples=Labels.range("sample", 2),
                 components=[
-                    Labels.arange("grad_components", 2),
-                    Labels.arange("components_1", 2),
+                    Labels.range("grad_components", 2),
+                    Labels.range("components_1", 2),
                     Labels(["component2"], np.array([[0]])),
                 ],
                 properties=block_res_1.properties,
@@ -261,14 +261,14 @@ class TestPow:
             values=np.vstack([b1_s0, b1_s2]),
             samples=Labels(["s"], np.array([[0], [2]])),
             components=[],
-            properties=Labels.arange("p", 2),
+            properties=Labels.range("p", 2),
         )
         block_1.add_gradient(
             parameter="g",
             gradient=TensorBlock(
                 values=np.vstack([[b1grad_s01], [b1grad_s11]]),
-                samples=Labels.arange("sample", 2),
-                components=[Labels.arange("c", 2)],
+                samples=Labels.range("sample", 2),
+                components=[Labels.range("c", 2)],
                 properties=block_1.properties,
             ),
         )
@@ -277,14 +277,14 @@ class TestPow:
             values=np.vstack([b2_s0, b2_s2, b2_s7]),
             samples=Labels(["s"], np.array([[0], [2], [7]])),
             components=[],
-            properties=Labels.arange("p", 2),
+            properties=Labels.range("p", 2),
         )
         block_2.add_gradient(
             parameter="g",
             gradient=TensorBlock(
                 values=np.vstack([[b2grad_s01], [b2grad_s11], [b2grad_s21]]),
-                samples=Labels.arange("sample", 3),
-                components=[Labels.arange("c", 2)],
+                samples=Labels.range("sample", 3),
+                components=[Labels.range("c", 2)],
                 properties=block_2.properties,
             ),
         )
@@ -300,7 +300,7 @@ class TestPow:
             values=res_values_1,
             samples=Labels(["s"], np.array([[0], [2]])),
             components=[],
-            properties=Labels.arange("p", 2),
+            properties=Labels.range("p", 2),
         )
 
         block_res_1.add_gradient(
@@ -312,8 +312,8 @@ class TestPow:
                         [B * b1grad_s11 * (b1_s2 ** (B - 1))],
                     ]
                 ),
-                samples=Labels.arange("sample", 2),
-                components=[Labels.arange("c", 2)],
+                samples=Labels.range("sample", 2),
+                components=[Labels.range("c", 2)],
                 properties=block_res_1.properties,
             ),
         )
@@ -322,7 +322,7 @@ class TestPow:
             values=res_values_2,
             samples=Labels(["s"], np.array([[0], [2], [7]])),
             components=[],
-            properties=Labels.arange("p", 2),
+            properties=Labels.range("p", 2),
         )
         block_res_2.add_gradient(
             parameter="g",
@@ -334,8 +334,8 @@ class TestPow:
                         [B * b2grad_s21 * (b2_s7 ** (B - 1))],
                     ]
                 ),
-                samples=Labels.arange("sample", 3),
-                components=[Labels.arange("c", 2)],
+                samples=Labels.range("sample", 3),
+                components=[Labels.range("c", 2)],
                 properties=block_res_2.properties,
             ),
         )
@@ -356,7 +356,7 @@ class TestPow:
             values=np.array([[1, 2], [3, 5]]),
             samples=Labels(["s"], np.array([[0], [2]])),
             components=[],
-            properties=Labels.arange("p", 2),
+            properties=Labels.range("p", 2),
         )
         keys = Labels(names=["key_1", "key_2"], values=np.array([[0, 0]]))
         A = TensorMap(keys, [block_1])

--- a/python/equistore-operations/tests/random_like.py
+++ b/python/equistore-operations/tests/random_like.py
@@ -26,7 +26,7 @@ def test_random_uniform_like():
     assert equistore.equal_metadata(random_tensor_positions, tensor_no_cell)
 
     # check the values
-    for _, random_block in random_tensor:
+    for random_block in random_tensor:
         assert np.all(random_block.values >= 0)
         assert np.all(random_block.values < 1)
 

--- a/python/equistore-operations/tests/reduce_over_samples.py
+++ b/python/equistore-operations/tests/reduce_over_samples.py
@@ -527,7 +527,7 @@ class TestReductionAllSamples(unittest.TestCase):
                     [-1.3, 26.7, 4.54],
                 ]
             ),
-            samples=Labels.arange("s", 3),
+            samples=Labels.range("s", 3),
             components=[],
             properties=Labels(["p"], np.array([[0], [1], [5]])),
         )
@@ -980,7 +980,7 @@ class TestZeroSamples(unittest.TestCase):
 
         sum_block = TensorBlock(
             values=np.array([[-0.3, 28.7, 8.54], [6.5, 10.3, 12.87]]),
-            samples=Labels.arange("s_2", 2),
+            samples=Labels.range("s_2", 2),
             components=[],
             properties=Labels(["p"], np.array([[0], [1], [5]])),
         )

--- a/python/equistore-operations/tests/slice.py
+++ b/python/equistore-operations/tests/slice.py
@@ -224,7 +224,7 @@ def test_slice_samples(tensor):
         labels=samples,
     )
 
-    for key, block in tensor:
+    for key, block in tensor.items():
         sliced_block = sliced_tensor.block(key)
         _check_sliced_block_samples(block, sliced_block, structures_to_keep)
 
@@ -244,7 +244,7 @@ def test_slice_samples(tensor):
         labels=samples,
     )
 
-    for _, block in sliced_tensor:
+    for block in sliced_tensor:
         # all blocks are empty
         _check_empty_block(block, sliced_tensor.block(key), "s")
 
@@ -298,7 +298,7 @@ def test_slice_properties(tensor):
         labels=properties,
     )
 
-    for key, block in tensor:
+    for key, block in tensor.items():
         sliced_block = sliced_tensor.block(key)
         _check_sliced_block_properties(block, sliced_block, radial_to_keep)
 
@@ -318,7 +318,7 @@ def test_slice_properties(tensor):
         labels=properties,
     )
 
-    for key, block in tensor:
+    for key, block in tensor.items():
         sliced_block = sliced_tensor.block(key)
         _check_empty_block(block, sliced_block, "p")
 
@@ -431,7 +431,7 @@ def test_slicing_by_empty(tensor):
     # Empty tensor returned if no samples to slice by are passed
     block_list = [
         _construct_empty_slice_block(block, "samples", empty_labels_samples)
-        for block in tensor.blocks()
+        for block in tensor
     ]
     reference_tensor = TensorMap(tensor.keys, block_list)
     assert equistore.equal(
@@ -454,7 +454,7 @@ def test_slicing_by_empty(tensor):
     # Empty tensor returned if no properties to slice by are passed
     block_list = [
         _construct_empty_slice_block(block, "properties", empty_labels_properties)
-        for block in tensor.blocks()
+        for block in tensor
     ]
     reference_tensor = TensorMap(tensor.keys, block_list)
     assert equistore.equal(

--- a/python/equistore-operations/tests/slice.py
+++ b/python/equistore-operations/tests/slice.py
@@ -93,10 +93,10 @@ def _check_sliced_block_samples(block, sliced_block, structures_to_keep):
         assert np.max(sliced_gradient.samples["sample"]) < sliced_block.values.shape[0]
 
         # other columns in the gradient samples have been sliced correctly
-        gradient_sample_filter = samples_filter[gradient.samples["sample"]]
-        if len(gradient.samples.names) > 0:
-            expected = gradient.samples.asarray()[gradient_sample_filter, 1:]
-            sliced_gradient_samples = sliced_gradient.samples.asarray()[:, 1:]
+        gradient_sample_filter = samples_filter[gradient.samples["sample"].values[:, 0]]
+        if len(gradient.samples.names) > 1:
+            expected = gradient.samples.values[gradient_sample_filter, 1:]
+            sliced_gradient_samples = sliced_gradient.samples.values[:, 1:]
             assert np.all(sliced_gradient_samples == expected)
 
         # same components as the original

--- a/python/equistore-operations/tests/solve.py
+++ b/python/equistore-operations/tests/solve.py
@@ -49,9 +49,9 @@ class TestSolve(unittest.TestCase):
         self.assertTrue(
             np.allclose(w.block(1).values, np.array([-2.0, 2.0]), rtol=1e-7)
         )
-        for key, blockw in w:
-            self.assertTrue(np.all(blockw.samples == Y.block(key).properties))
-            self.assertTrue(np.all(blockw.properties == X.block(key).properties))
+        for key, block_w in w.items():
+            self.assertTrue(np.all(block_w.samples == Y.block(key).properties))
+            self.assertTrue(np.all(block_w.properties == X.block(key).properties))
 
         Ydot = equistore.dot(X, w)
         self.assertTrue(equistore.allclose(Ydot, Y))

--- a/python/equistore-operations/tests/solve.py
+++ b/python/equistore-operations/tests/solve.py
@@ -16,13 +16,13 @@ class TestSolve(unittest.TestCase):
             values=np.array([[1, 2], [3, 5]]),
             samples=Labels(["s"], np.array([[0], [2]])),
             components=[],
-            properties=Labels.arange("p", 2),
+            properties=Labels.range("p", 2),
         )
         block_2 = TensorBlock(
             values=np.array([[1, 2], [3, 5]]),
             samples=Labels(["s"], np.array([[0], [2]])),
             components=[],
-            properties=Labels.arange("p", 2),
+            properties=Labels.range("p", 2),
         )
         block_3 = TensorBlock(
             values=np.array([[1], [2]]),

--- a/python/equistore-operations/tests/subtract.py
+++ b/python/equistore-operations/tests/subtract.py
@@ -16,38 +16,38 @@ class TestSubtract(unittest.TestCase):
             values=np.array([[1, 2], [3, 5]]),
             samples=Labels(["s"], np.array([[0], [2]])),
             components=[],
-            properties=Labels.arange("p", 2),
+            properties=Labels.range("p", 2),
         )
         block_2 = TensorBlock(
             values=np.array([[1, 2], [3, 4], [5, 6]]),
             samples=Labels(["s"], np.array([[0], [2], [7]])),
             components=[],
-            properties=Labels.arange("p", 2),
+            properties=Labels.range("p", 2),
         )
         block_3 = TensorBlock(
             values=np.array([[1.5, 2.1], [6.7, 10.2]]),
             samples=Labels(["s"], np.array([[0], [2]])),
             components=[],
-            properties=Labels.arange("p", 2),
+            properties=Labels.range("p", 2),
         )
         block_4 = TensorBlock(
             values=np.array([[10, 200.8], [3.76, 4.432], [545, 26]]),
             samples=Labels(["s"], np.array([[0], [2], [7]])),
             components=[],
-            properties=Labels.arange("p", 2),
+            properties=Labels.range("p", 2),
         )
 
         block_res_1 = TensorBlock(
             values=np.array([[-0.5, -0.1], [-3.7, -5.2]]),
             samples=Labels(["s"], np.array([[0], [2]])),
             components=[],
-            properties=Labels.arange("p", 2),
+            properties=Labels.range("p", 2),
         )
         block_res_2 = TensorBlock(
             values=np.array([[-9, -198.8], [-0.76, -0.432], [-540, -20]]),
             samples=Labels(["s"], np.array([[0], [2], [7]])),
             components=[],
-            properties=Labels.arange("p", 2),
+            properties=Labels.range("p", 2),
         )
         keys = Labels(names=["key_1", "key_2"], values=np.array([[0, 0], [1, 0]]))
         A = TensorMap(keys, [block_1, block_2])
@@ -67,14 +67,14 @@ class TestSubtract(unittest.TestCase):
             values=np.array([[1, 2], [3, 5]]),
             samples=Labels(["s"], np.array([[0], [2]])),
             components=[],
-            properties=Labels.arange("p", 2),
+            properties=Labels.range("p", 2),
         )
         block_1.add_gradient(
             parameter="g",
             gradient=TensorBlock(
                 values=np.array([[[6, 1], [7, 2]], [[8, 3], [9, 4]]]),
-                samples=Labels.arange("sample", 2),
-                components=[Labels.arange("c", 2)],
+                samples=Labels.range("sample", 2),
+                components=[Labels.range("c", 2)],
                 properties=block_1.properties,
             ),
         )
@@ -83,7 +83,7 @@ class TestSubtract(unittest.TestCase):
             values=np.array([[-1, -2], [-3, -4], [5, 6]]),
             samples=Labels(["s"], np.array([[0], [2], [7]])),
             components=[],
-            properties=Labels.arange("p", 2),
+            properties=Labels.range("p", 2),
         )
         block_2.add_gradient(
             parameter="g",
@@ -95,8 +95,8 @@ class TestSubtract(unittest.TestCase):
                         [[12, 13], [14, 15]],
                     ]
                 ),
-                samples=Labels.arange("sample", 3),
-                components=[Labels.arange("c", 2)],
+                samples=Labels.range("sample", 3),
+                components=[Labels.range("c", 2)],
                 properties=block_2.properties,
             ),
         )
@@ -105,14 +105,14 @@ class TestSubtract(unittest.TestCase):
             values=np.array([[1.5, 2.1], [6.7, 10.2]]),
             samples=Labels(["s"], np.array([[0], [2]])),
             components=[],
-            properties=Labels.arange("p", 2),
+            properties=Labels.range("p", 2),
         )
         block_3.add_gradient(
             parameter="g",
             gradient=TensorBlock(
                 values=np.array([[[-1, -0.1], [-2, -0.2]], [[-3, -0.3], [-4.5, -0.4]]]),
-                samples=Labels.arange("sample", 2),
-                components=[Labels.arange("c", 2)],
+                samples=Labels.range("sample", 2),
+                components=[Labels.range("c", 2)],
                 properties=block_3.properties,
             ),
         )
@@ -121,7 +121,7 @@ class TestSubtract(unittest.TestCase):
             values=np.array([[10, 200.8], [3.76, 4.432], [-545, -26]]),
             samples=Labels(["s"], np.array([[0], [2], [7]])),
             components=[],
-            properties=Labels.arange("p", 2),
+            properties=Labels.range("p", 2),
         )
         block_4.add_gradient(
             parameter="g",
@@ -133,8 +133,8 @@ class TestSubtract(unittest.TestCase):
                         [[1.2, 1.3], [1.4, 1.5]],
                     ]
                 ),
-                samples=Labels.arange("sample", 3),
-                components=[Labels.arange("c", 2)],
+                samples=Labels.range("sample", 3),
+                components=[Labels.range("c", 2)],
                 properties=block_4.properties,
             ),
         )
@@ -143,7 +143,7 @@ class TestSubtract(unittest.TestCase):
             values=np.array([[-0.5, -0.1], [-3.7, -5.2]]),
             samples=Labels(["s"], np.array([[0], [2]])),
             components=[],
-            properties=Labels.arange("p", 2),
+            properties=Labels.range("p", 2),
         )
         block_res_1.add_gradient(
             parameter="g",
@@ -151,8 +151,8 @@ class TestSubtract(unittest.TestCase):
                 values=np.array(
                     np.array([[[7, 1.1], [9, 2.2]], [[11, 3.3], [13.5, 4.4]]])
                 ),
-                samples=Labels.arange("sample", 2),
-                components=[Labels.arange("c", 2)],
+                samples=Labels.range("sample", 2),
+                components=[Labels.range("c", 2)],
                 properties=block_res_1.properties,
             ),
         )
@@ -161,7 +161,7 @@ class TestSubtract(unittest.TestCase):
             values=np.array([[-11, -202.8], [-6.76, -8.432], [550, 32]]),
             samples=Labels(["s"], np.array([[0], [2], [7]])),
             components=[],
-            properties=Labels.arange("p", 2),
+            properties=Labels.range("p", 2),
         )
         block_res_2.add_gradient(
             parameter="g",
@@ -173,8 +173,8 @@ class TestSubtract(unittest.TestCase):
                         [[10.8, 11.7], [12.6, 13.5]],
                     ]
                 ),
-                samples=Labels.arange("sample", 3),
-                components=[Labels.arange("c", 2)],
+                samples=Labels.range("sample", 3),
+                components=[Labels.range("c", 2)],
                 properties=block_res_2.properties,
             ),
         )
@@ -197,14 +197,14 @@ class TestSubtract(unittest.TestCase):
             values=np.array([[1, 2], [3, 5]]),
             samples=Labels(["s"], np.array([[0], [2]])),
             components=[],
-            properties=Labels.arange("p", 2),
+            properties=Labels.range("p", 2),
         )
         block_1.add_gradient(
             parameter="g",
             gradient=TensorBlock(
                 values=np.array([[[6, 1], [7, 2]], [[8, 3], [9, 4]]]),
-                samples=Labels.arange("sample", 2),
-                components=[Labels.arange("c", 2)],
+                samples=Labels.range("sample", 2),
+                components=[Labels.range("c", 2)],
                 properties=block_1.properties,
             ),
         )
@@ -213,7 +213,7 @@ class TestSubtract(unittest.TestCase):
             values=np.array([[11, 12], [13, 14], [15, 16]]),
             samples=Labels(["s"], np.array([[0], [2], [7]])),
             components=[],
-            properties=Labels.arange("p", 2),
+            properties=Labels.range("p", 2),
         )
         block_2.add_gradient(
             parameter="g",
@@ -221,8 +221,8 @@ class TestSubtract(unittest.TestCase):
                 values=np.array(
                     [[[10, 11], [12, 13]], [[14, 15], [10, 11]], [[12, 13], [14, 15]]]
                 ),
-                samples=Labels.arange("sample", 3),
-                components=[Labels.arange("c", 2)],
+                samples=Labels.range("sample", 3),
+                components=[Labels.range("c", 2)],
                 properties=block_2.properties,
             ),
         )
@@ -231,14 +231,14 @@ class TestSubtract(unittest.TestCase):
             values=np.array([[6.1, 7.1], [8.1, 10.1]]),
             samples=Labels(["s"], np.array([[0], [2]])),
             components=[],
-            properties=Labels.arange("p", 2),
+            properties=Labels.range("p", 2),
         )
         block_res_1.add_gradient(
             parameter="g",
             gradient=TensorBlock(
                 values=np.array([[[6, 1], [7, 2]], [[8, 3], [9, 4]]]),
-                samples=Labels.arange("sample", 2),
-                components=[Labels.arange("c", 2)],
+                samples=Labels.range("sample", 2),
+                components=[Labels.range("c", 2)],
                 properties=block_res_1.properties,
             ),
         )
@@ -247,7 +247,7 @@ class TestSubtract(unittest.TestCase):
             values=np.array([[16.1, 17.1], [18.1, 19.1], [20.1, 21.1]]),
             samples=Labels(["s"], np.array([[0], [2], [7]])),
             components=[],
-            properties=Labels.arange("p", 2),
+            properties=Labels.range("p", 2),
         )
         block_res_2.add_gradient(
             parameter="g",
@@ -255,8 +255,8 @@ class TestSubtract(unittest.TestCase):
                 values=np.array(
                     [[[10, 11], [12, 13]], [[14, 15], [10, 11]], [[12, 13], [14, 15]]]
                 ),
-                samples=Labels.arange("sample", 3),
-                components=[Labels.arange("c", 2)],
+                samples=Labels.range("sample", 3),
+                components=[Labels.range("c", 2)],
                 properties=block_res_2.properties,
             ),
         )
@@ -278,7 +278,7 @@ class TestSubtract(unittest.TestCase):
             values=np.array([[1, 2], [3, 5]]),
             samples=Labels(["s"], np.array([[0], [2]])),
             components=[],
-            properties=Labels.arange("p", 2),
+            properties=Labels.range("p", 2),
         )
         keys = Labels(names=["key_1", "key_2"], values=np.array([[0, 0]]))
         A = TensorMap(keys, [block_1])

--- a/python/equistore-operations/tests/to.py
+++ b/python/equistore-operations/tests/to.py
@@ -28,7 +28,7 @@ def tensor():
     block1 = equistore.block_from_array(values1)
     values2 = np.arange(100, dtype=np.float64).reshape(10, 5, 2)
     block2 = equistore.block_from_array(values2)
-    tensor = TensorMap(keys=Labels.arange("dummy", 2), blocks=[block1, block2])
+    tensor = TensorMap(keys=Labels.range("dummy", 2), blocks=[block1, block2])
     return tensor
 
 

--- a/python/equistore-operations/tests/unique_metadata.py
+++ b/python/equistore-operations/tests/unique_metadata.py
@@ -5,7 +5,6 @@ import pytest
 
 import equistore
 from equistore import Labels
-from equistore.operations._utils import _labels_equal
 
 from . import utils
 
@@ -37,7 +36,7 @@ def test_unique_metadata_block(large_tensor):
         axis="samples",
         names="s",
     )
-    assert _labels_equal(target_samples, actual_samples, exact_order=True)
+    assert target_samples == actual_samples
 
     # unique metadata of gradient along sample axis
     names = ["sample", "g"]
@@ -48,7 +47,7 @@ def test_unique_metadata_block(large_tensor):
         names=names,
         gradient="g",
     )
-    assert _labels_equal(target_samples, actual_samples, exact_order=True)
+    assert target_samples == actual_samples
 
     # unique metadata along properties axis
     properties = [3, 4, 5]
@@ -56,7 +55,7 @@ def test_unique_metadata_block(large_tensor):
     actual_properties = equistore.unique_metadata_block(
         large_tensor.block(1), axis="properties", names="p"
     )
-    assert _labels_equal(target_properties, actual_properties, exact_order=True)
+    assert target_properties == actual_properties
 
     # unique metadata of gradient along properties axis
     names = ["p"]
@@ -67,7 +66,7 @@ def test_unique_metadata_block(large_tensor):
         names=names,
         gradient="g",
     )
-    assert _labels_equal(target_properties, actual_properties, exact_order=True)
+    assert target_properties == actual_properties
 
 
 def test_empty_block(real_tensor):
@@ -83,7 +82,7 @@ def test_empty_block(real_tensor):
         axis="samples",
         names="structure",
     )
-    assert _labels_equal(target_samples, actual_samples, exact_order=True)
+    assert target_samples == actual_samples
     assert len(actual_samples) == 0
 
     target_properties = Labels(names=["n"], values=np.empty((0, 1)))
@@ -97,7 +96,7 @@ def test_empty_block(real_tensor):
         axis="properties",
         names="n",
     )
-    assert _labels_equal(target_properties, actual_properties, exact_order=True)
+    assert target_properties == actual_properties
     assert len(actual_properties) == 0
 
 
@@ -108,10 +107,10 @@ def test_unique_metadata(tensor, large_tensor):
         values=np.array([0, 1, 2, 3, 4, 5, 6, 8]).reshape(-1, 1),
     )
     actual_samples = equistore.unique_metadata(tensor, "samples", "s")
-    assert _labels_equal(target_samples, actual_samples, exact_order=True)
+    assert target_samples == actual_samples
 
     actual_samples = equistore.unique_metadata(large_tensor, "samples", "s")
-    assert _labels_equal(actual_samples, target_samples, exact_order=True)
+    assert actual_samples == target_samples
 
     # unique metadata along samples for gradients
     names = ["sample", "g"]
@@ -125,7 +124,7 @@ def test_unique_metadata(tensor, large_tensor):
         names=names,
         gradient="g",
     )
-    assert _labels_equal(actual_samples, target_samples, exact_order=True)
+    assert actual_samples == target_samples
 
     # unique metadata along properties
     target_properties = Labels(
@@ -136,7 +135,7 @@ def test_unique_metadata(tensor, large_tensor):
         axis="properties",
         names=["p"],  # names passed as list
     )
-    assert _labels_equal(target_properties, actual_properties, exact_order=True)
+    assert target_properties == actual_properties
 
     target_properties = Labels(
         names=["p"], values=np.array([0, 1, 2, 3, 4, 5, 6, 7]).reshape(-1, 1)
@@ -146,7 +145,7 @@ def test_unique_metadata(tensor, large_tensor):
         axis="properties",
         names=("p",),  # names passed as tuple
     )
-    assert _labels_equal(target_properties, actual_properties, exact_order=True)
+    assert target_properties == actual_properties
 
     names = ["p"]
     target_properties = Labels(
@@ -156,33 +155,7 @@ def test_unique_metadata(tensor, large_tensor):
     actual_properties = equistore.unique_metadata(
         tensor, axis="properties", names=names, gradient="g"
     )
-    assert _labels_equal(target_properties, actual_properties, exact_order=True)
-
-
-def test_unique_metadata_different_names(tensor):
-    # these names are not in the samples/properties
-    names = ["ciao", "bonjour", "hello"]
-    target_labels = Labels(names=names, values=np.arange(len(names)).reshape(1, -1))[:0]
-
-    # block/samples
-    actual_labels = equistore.unique_metadata_block(
-        tensor.block(0), axis="samples", names=names
-    )
-    assert _labels_equal(target_labels, actual_labels, exact_order=True)
-
-    # tensor/samples
-    actual_labels = equistore.unique_metadata(tensor, axis="samples", names=names)
-    assert _labels_equal(target_labels, actual_labels, exact_order=True)
-
-    # block/properties
-    actual_labels = equistore.unique_metadata_block(
-        tensor.block(0), axis="properties", names=names
-    )
-    assert _labels_equal(target_labels, actual_labels, exact_order=True)
-
-    # tensor/properties
-    actual_labels = equistore.unique_metadata(tensor, axis="properties", names=names)
-    assert _labels_equal(target_labels, actual_labels, exact_order=True)
+    assert target_properties == actual_properties
 
 
 def test_unique_metadata_block_errors(real_tensor):
@@ -249,3 +222,7 @@ def test_unique_metadata_block_errors(real_tensor):
             names=["structure"],
             gradient=3.14,
         )
+
+    message = "'ciao' not found in the dimensions of these Labels"
+    with pytest.raises(ValueError, match=message):
+        equistore.unique_metadata(real_tensor, axis="samples", names=["ciao"])

--- a/python/equistore-operations/tests/utils.py
+++ b/python/equistore-operations/tests/utils.py
@@ -45,7 +45,7 @@ def tensor():
     block_3 = TensorBlock(
         values=np.full((4, 3, 1), 3.0),
         samples=Labels(["s"], np.array([[0], [3], [6], [8]])),
-        components=[Labels.arange("c", 3)],
+        components=[Labels.range("c", 3)],
         properties=Labels(["p"], np.array([[0]])),
     )
     block_3.add_gradient(
@@ -61,7 +61,7 @@ def tensor():
     block_4 = TensorBlock(
         values=np.full((4, 3, 1), 4.0),
         samples=Labels(["s"], np.array([[0], [1], [2], [5]])),
-        components=[Labels.arange("c", 3)],
+        components=[Labels.range("c", 3)],
         properties=Labels(["p"], np.array([[0]])),
     )
     block_4.add_gradient(
@@ -93,7 +93,7 @@ def large_tensor():
         block = TensorBlock(
             values=np.full((4, 3, 1), 4.0),
             samples=Labels(["s"], np.array([[0], [1], [4], [5]])),
-            components=[Labels.arange("c", 3)],
+            components=[Labels.range("c", 3)],
             properties=Labels(["p"], np.array([[i]])),
         )
         block.add_gradient(

--- a/python/equistore-operations/tests/utils.py
+++ b/python/equistore-operations/tests/utils.py
@@ -87,7 +87,7 @@ def large_tensor():
     Create a dummy tensor map of 16 blocks to be used in tests. This is the same
     tensor map used in `tensor.rs` tests.
     """
-    blocks = [block.copy() for _, block in tensor()]
+    blocks = [block.copy() for block in tensor()]
 
     for i in range(8):
         block = TensorBlock(

--- a/python/equistore-operations/tests/zeros_like.py
+++ b/python/equistore-operations/tests/zeros_like.py
@@ -24,7 +24,7 @@ def test_zeros_like():
     assert equistore.equal_metadata(zeros_tensor_positions, tensor_no_cell)
 
     # check the values
-    for key, block in tensor:
+    for key, block in tensor.items():
         zeros_block = zeros_tensor[key]
 
         assert np.all(zeros_block.values == np.zeros_like(block.values))

--- a/python/equistore-torch/equistore/torch/documentation.py
+++ b/python/equistore-torch/equistore/torch/documentation.py
@@ -406,18 +406,21 @@ class TensorBlock:
             :py:class:`TensorBlock` containing values.
 
         >>> import numpy as np
-        >>> from equistore import TensorBlock, Labels
+        >>> from equistore.torch import TensorBlock, Labels
         >>> block = TensorBlock(
-        ...     values=np.full((3, 1, 1), 1.0),
-        ...     samples=Labels(["structure"], np.array([[0], [2], [4]])),
-        ...     components=[Labels.arange("component", 1)],
-        ...     properties=Labels.arange("property", 1),
+        ...     values=torch.full((3, 1, 1), 1.0),
+        ...     samples=Labels(["structure"], torch.IntTensor([[0], [2], [4]])),
+        ...     components=[Labels.range("component", 1)],
+        ...     properties=Labels.range("property", 1),
         ... )
         >>> gradient = TensorBlock(
-        ...     values=np.full((2, 1, 1), 11.0),
-        ...     samples=Labels(["sample", "parameter"], np.array([[0, -2], [2, 3]])),
-        ...     components=[Labels.arange("component", 1)],
-        ...     properties=Labels.arange("property", 1),
+        ...     values=torch.full((2, 1, 1), 11.0),
+        ...     samples=Labels(
+        ...         names=["sample", "parameter"],
+        ...         values=torch.IntTensor([[0, -2], [2, 3]]),
+        ...     ),
+        ...     components=[Labels.range("component", 1)],
+        ...     properties=Labels.range("property", 1),
         ... )
         >>> block.add_gradient("parameter", gradient)
         >>> print(block)
@@ -426,6 +429,7 @@ class TensorBlock:
             components (1): ['component']
             properties (1): ['property']
             gradients: ['parameter']
+        <BLANKLINE>
         """
 
     def gradient(self, parameter: str) -> "TensorBlock":

--- a/python/equistore-torch/equistore/torch/documentation.py
+++ b/python/equistore-torch/equistore/torch/documentation.py
@@ -548,8 +548,8 @@ class TensorMap:
         selection: Union[int, Labels, LabelsEntry, Dict[str, int]],
     ) -> TensorBlock:
         """
-        Get a single block with indexing syntax. This calls
-        :py:func:`TensorMap.block` directly.
+        Get a single block with indexing syntax. This calls :py:func:`TensorMap.block`
+        directly.
         """
 
     def copy(self) -> "TensorMap":
@@ -682,24 +682,23 @@ class TensorMap:
         selection: Union[int, Labels, LabelsEntry, Dict[str, int]],
     ) -> TensorBlock:
         """
-        Get the single block in this :py:class:`TensorMap` matching the
-        ``selection``.
+        Get the single block in this :py:class:`TensorMap` matching the ``selection``.
 
         When ``selection`` is an ``int``, this is equivalent to
         :py:func:`TensorMap.block_by_id`.
 
-        When ``selection`` is an :py:class:`Labels`, it should only contain a
-        single entry, which will be used for the selection.
+        When ``selection`` is an :py:class:`Labels`, it should only contain a single
+        entry, which will be used for the selection.
 
-        When ``selection`` is a ``Dict[str, int]``, it is converted into a
-        single single :py:class:`LabelsEntry` (the dict keys becoming the names
-        and the dict values being joined together to form the
-        :py:class:`LabelsEntry` values), which is then used for the selection.
+        When ``selection`` is a ``Dict[str, int]``, it is converted into a single single
+        :py:class:`LabelsEntry` (the dict keys becoming the names and the dict values
+        being joined together to form the :py:class:`LabelsEntry` values), which is then
+        used for the selection.
 
-        When ``selection`` is a :py:class:`LabelsEntry`, this function finds the
-        key in this :py:class:`TensorMap` with the same values as ``selection``
-        for the dimensions/names contained in the ``selection``; and return the
-        corresponding indexes.
+        When ``selection`` is a :py:class:`LabelsEntry`, this function finds the key in
+        this :py:class:`TensorMap` with the same values as ``selection`` for the
+        dimensions/names contained in the ``selection``; and return the corresponding
+        indexes.
 
         :param selection: description of the block to extract
         """
@@ -716,21 +715,21 @@ class TensorMap:
         When ``selection`` is ``None`` (the default), all blocks are returned.
 
         When ``selection`` is an ``int``, this is equivalent to
-        :py:func:`TensorMap.block_by_id`; and for a ``List[int]`` this is
-        equivalent to :py:func:`TensorMap.blocks_by_id`.
+        :py:func:`TensorMap.block_by_id`; and for a ``List[int]`` this is equivalent to
+        :py:func:`TensorMap.blocks_by_id`.
 
-        When ``selection`` is an :py:class:`Labels`, it should only contain a
-        single entry, which will be used for the selection.
+        When ``selection`` is an :py:class:`Labels`, it should only contain a single
+        entry, which will be used for the selection.
 
-        When ``selection`` is a ``Dict[str, int]``, it is converted into a
-        single single :py:class:`LabelsEntry` (the dict keys becoming the names
-        and the dict values being joined together to form the
-        :py:class:`LabelsEntry` values), which is then used for the selection.
+        When ``selection`` is a ``Dict[str, int]``, it is converted into a single single
+        :py:class:`LabelsEntry` (the dict keys becoming the names and the dict values
+        being joined together to form the :py:class:`LabelsEntry` values), which is then
+        used for the selection.
 
-        When ``selection`` is a :py:class:`LabelsEntry`, this function finds all
-        keys in this :py:class:`TensorMap` with the same values as ``selection``
-        for the dimensions/names contained in the ``selection``; and return the
-        corresponding blocks.
+        When ``selection`` is a :py:class:`LabelsEntry`, this function finds all keys in
+        this :py:class:`TensorMap` with the same values as ``selection`` for the
+        dimensions/names contained in the ``selection``; and return the corresponding
+        blocks.
 
         :param selection: description of the blocks to extract
         """

--- a/python/equistore-torch/equistore/torch/documentation.py
+++ b/python/equistore-torch/equistore/torch/documentation.py
@@ -48,6 +48,11 @@ class LabelsEntry:
         32-bit integers.
         """
 
+    def print(self) -> str:
+        """
+        print this entry as a named tuple (i.e. ``(key_1=value_1, key_2=value_2)``)
+        """
+
     def __len__(self) -> int:
         """number of dimensions in this labels entry"""
 

--- a/python/equistore-torch/tests/labels.py
+++ b/python/equistore-torch/tests/labels.py
@@ -143,6 +143,7 @@ def test_repr():
     expected = "LabelsEntry(aaa=1, bbb=2)"
     assert str(labels[0]) == expected
     # assert repr(labels[0]) == expected
+    assert labels[0].print() == "(aaa=1, bbb=2)"
 
     labels = Labels(
         names=("aaa", "bbb"),
@@ -407,6 +408,9 @@ class LabelsEntryWrap:
 
     def values(self) -> Tensor:
         return self._c.values
+
+    def _print(self) -> str:
+        return self._c.print()
 
 
 def test_script():

--- a/python/equistore-torch/tests/labels.py
+++ b/python/equistore-torch/tests/labels.py
@@ -158,15 +158,13 @@ def test_repr():
   3    3
   4    4
   5    5
-  6    6
-"""
+  6    6"""
     assert labels.print(max_entries=-1) == expected
 
     expected = """ aaa  bbb
   0    0
    ...
-  6    6
-"""
+  6    6"""
     assert labels.print(max_entries=0) == expected
     assert labels.print(max_entries=1) == expected
     assert labels.print(max_entries=2) == expected
@@ -177,16 +175,14 @@ def test_repr():
   2    2
    ...
   5    5
-  6    6
-"""
+  6    6"""
     assert labels.print(max_entries=5) == expected
 
     expected = """ aaa  bbb
      0    0
      1    1
       ...
-     6    6
-"""
+     6    6"""
     assert labels.print(max_entries=3, indent=3) == expected
 
     labels = Labels(names=("aaa", "bbb"), values=torch.IntTensor([[0, 0], [0, 1]]))
@@ -211,11 +207,11 @@ def test_indexing():
     # indexing labels with integer
     entry = labels[0]
     assert entry.names == ["a", "b"]
-    assert torch.all(entry.values == torch.IntTensor([[1, 2]]))
+    assert torch.all(entry.values == torch.IntTensor([1, 2]))
 
     entry = labels[-1]
     assert entry.names == ["a", "b"]
-    assert torch.all(entry.values == torch.IntTensor([[3, 4]]))
+    assert torch.all(entry.values == torch.IntTensor([3, 4]))
 
     # indexing labels errors
     message = "out of range for tensor of size \\[2, 2\\] at dimension 0"

--- a/python/equistore-torch/tests/tensor.py
+++ b/python/equistore-torch/tests/tensor.py
@@ -33,8 +33,7 @@ keys: key_1  key_2
         0      0
         1      0
         2      2
-        2      3
-"""
+        2      3"""
     assert expected == str(tensor)
     assert expected == tensor.print(6)
 
@@ -46,8 +45,7 @@ keys: key_1  key_2
         1      0
           ...
         2      5
-        3      5
-"""
+        3      5"""
     assert expected == str(large_tensor)
 
     expected = """TensorMap with 12 blocks
@@ -58,8 +56,7 @@ keys: key_1  key_2
           ...
         1      5
         2      5
-        3      5
-"""
+        3      5"""
     assert expected == large_tensor.print(6)
 
 

--- a/python/equistore-torch/tests/tensor.py
+++ b/python/equistore-torch/tests/tensor.py
@@ -88,13 +88,13 @@ def test_block(tensor):
     assert torch.all(block.values == torch.full((3, 1, 1), 1.0))
 
     # 0 blocks matching criteria
-    msg = "could not find blocks matching the selection 'key_1=4, key_2=3'"
+    msg = "could not find blocks matching the selection \\(key_1=4, key_2=3\\)"
     with pytest.raises(ValueError, match=msg):
         tensor.block({"key_2": 3, "key_1": 4})
 
     # more than one block matching criteria
     msg = (
-        "got more than one matching block for 'key_2=0', use the `blocks` "
+        "got more than one matching block for \\(key_2=0\\), use the `blocks` "
         "function to select more than one block"
     )
     with pytest.raises(ValueError, match=msg):


### PR DESCRIPTION
This is part of #133, making a bunch of breaking changes to the Python API to make sure it is the same as the TorchScript API.

Fix #63


<!-- readthedocs-preview equistore start -->
----
:books: Documentation preview :books:: https://equistore--283.org.readthedocs.build/en/283/

<!-- readthedocs-preview equistore end -->