### PR TITLE
Implement Labels::union and Labels::intersection

### DIFF
--- a/docs/src/reference/c/block.rst
+++ b/docs/src/reference/c/block.rst
@@ -6,15 +6,18 @@ TensorBlock
 The following functions operate on :c:type:`eqs_block_t`:
 
 - :c:func:`eqs_block`: create new blocks
+- :c:func:`eqs_block_copy`: copy existing blocks
 - :c:func:`eqs_block_free`: free allocated blocks
 - :c:func:`eqs_block_labels`: get one of the :c:struct:`eqs_labels_t` associated with this block
 - :c:func:`eqs_block_data`: get one of the :c:struct:`eqs_array_t` associated with this block
 - :c:func:`eqs_block_add_gradient`: add gradient data to this block
 - :c:func:`eqs_block_gradients_list`: get the list of gradients in this block
 
----------------------------------------------------------------------
+--------------------------------------------------------------------------------
 
 .. doxygenfunction:: eqs_block
+
+.. doxygenfunction:: eqs_block_copy
 
 .. doxygenfunction:: eqs_block_free
 

--- a/docs/src/reference/c/labels.rst
+++ b/docs/src/reference/c/labels.rst
@@ -3,3 +3,27 @@ Labels
 
 .. doxygenstruct:: eqs_labels_t
     :members:
+
+The following functions operate on :c:type:`eqs_labels_t`:
+
+- :c:func:`eqs_labels_create`: create the Rust-side data for the labels
+- :c:func:`eqs_labels_clone`: increment the reference count of the Rust-side data
+- :c:func:`eqs_labels_free`: decrement the reference count of the Rust-side data,
+  and free the data when it reaches 0
+- :c:func:`eqs_labels_position`: get the position of an entry in the labels
+- :c:func:`eqs_labels_union`: get the union of two labels
+- :c:func:`eqs_labels_intersection`: get the intersection of two labels
+
+--------------------------------------------------------------------------------
+
+.. doxygenfunction:: eqs_labels_create
+
+.. doxygenfunction:: eqs_labels_clone
+
+.. doxygenfunction:: eqs_labels_free
+
+.. doxygenfunction:: eqs_labels_position
+
+.. doxygenfunction:: eqs_labels_union
+
+.. doxygenfunction:: eqs_labels_intersection

--- a/docs/src/reference/c/tensor.rst
+++ b/docs/src/reference/c/tensor.rst
@@ -6,6 +6,7 @@ TensorMap
 The following functions operate on :c:type:`eqs_tensormap_t`:
 
 - :c:func:`eqs_tensormap`: create new tensor map
+- :c:func:`eqs_tensormap_copy`: copy existing tensor maps
 - :c:func:`eqs_tensormap_free`: free allocated tensor maps
 - :c:func:`eqs_tensormap_keys`: get the keys defined in a tensor map as :c:struct:`eqs_labels_t`
 - :c:func:`eqs_tensormap_block_by_id`: get a :c:struct:`eqs_block_t` in a tensor map from its index
@@ -15,9 +16,11 @@ The following functions operate on :c:type:`eqs_tensormap_t`:
 - :c:func:`eqs_tensormap_components_to_properties`: move entries from component labels to properties labels
 
 
----------------------------------------------------------------------
+--------------------------------------------------------------------------------
 
 .. doxygenfunction:: eqs_tensormap
+
+.. doxygenfunction:: eqs_tensormap_copy
 
 .. doxygenfunction:: eqs_tensormap_free
 

--- a/equistore-core/Cargo.toml
+++ b/equistore-core/Cargo.toml
@@ -17,6 +17,7 @@ bench = false
 
 [dependencies]
 ahash = "0.7"
+hashbrown = "0.13"
 indexmap = "1"
 once_cell = "1"
 smallvec = {version = "1", features = ["union"]}

--- a/equistore-core/include/equistore.h
+++ b/equistore-core/include/equistore.h
@@ -326,6 +326,78 @@ eqs_status_t eqs_labels_create(struct eqs_labels_t *labels);
 eqs_status_t eqs_labels_clone(struct eqs_labels_t labels, struct eqs_labels_t *clone);
 
 /**
+ * Take the union of two `eqs_labels_t`.
+ *
+ * If requested, this function can also give the positions in the union where
+ * each entry of the input `eqs_labels_t` ended up.
+ *
+ * This function allocates memory for `result` which must be released
+ * `eqs_labels_free` when you don't need it anymore.
+ *
+ * @param first first set of labels
+ * @param second second set of labels
+ * @param result empty labels, on output will contain the union of `first` and
+ *        `second`
+ * @param first_mapping if you want the mapping from the positions of entries
+ *        in `first` to the positions in `result`, this should be a pointer
+ *        to an array containing `first.count` elements, to be filled by this
+ *        function. Otherwise it should be a `NULL` pointer.
+ * @param first_mapping_count number of elements in the `first_mapping` array
+ * @param second_mapping if you want the mapping from the positions of entries
+ *        in `second` to the positions in `result`, this should be a pointer
+ *        to an array containing `second.count` elements, to be filled by this
+ *        function. Otherwise it should be a `NULL` pointer.
+ * @param second_mapping_count number of elements in the `second_mapping` array
+ * @returns The status code of this operation. If the status is not
+ *          `EQS_SUCCESS`, you can use `eqs_last_error()` to get the full
+ *          error message.
+ */
+eqs_status_t eqs_labels_union(struct eqs_labels_t first,
+                              struct eqs_labels_t second,
+                              struct eqs_labels_t *result,
+                              int64_t *first_mapping,
+                              uintptr_t first_mapping_count,
+                              int64_t *second_mapping,
+                              uintptr_t second_mapping_count);
+
+/**
+ * Take the intersection of two `eqs_labels_t`.
+ *
+ * If requested, this function can also give the positions in the intersection
+ * where each entry of the input `eqs_labels_t` ended up.
+ *
+ * This function allocates memory for `result` which must be released
+ * `eqs_labels_free` when you don't need it anymore.
+ *
+ * @param first first set of labels
+ * @param second second set of labels
+ * @param result empty labels, on output will contain the union of `first` and
+ *        `second`
+ * @param first_mapping if you want the mapping from the positions of entries
+ *        in `first` to the positions in `result`, this should be a pointer to
+ *        an array containing `first.count` elements, to be filled by this
+ *        function. Otherwise it should be a `NULL` pointer. If an entry in
+ *        `first` is not used in `result`, the mapping will be set to -1.
+ * @param first_mapping_count number of elements in the `first_mapping` array
+ * @param second_mapping if you want the mapping from the positions of entries
+ *        in `second` to the positions in `result`, this should be a pointer
+ *        to an array containing `second.count` elements, to be filled by this
+ *        function. Otherwise it should be a `NULL` pointer. If an entry in
+ *        `first` is not used in `result`, the mapping will be set to -1.
+ * @param second_mapping_count number of elements in the `second_mapping` array
+ * @returns The status code of this operation. If the status is not
+ *          `EQS_SUCCESS`, you can use `eqs_last_error()` to get the full
+ *          error message.
+ */
+eqs_status_t eqs_labels_intersection(struct eqs_labels_t first,
+                                     struct eqs_labels_t second,
+                                     struct eqs_labels_t *result,
+                                     int64_t *first_mapping,
+                                     uintptr_t first_mapping_count,
+                                     int64_t *second_mapping,
+                                     uintptr_t second_mapping_count);
+
+/**
  * Decrease the reference count of `labels`, and release the corresponding
  * memory once the reference count reaches 0.
  *

--- a/equistore-core/include/equistore.hpp
+++ b/equistore-core/include/equistore.hpp
@@ -507,6 +507,184 @@ public:
         return NDArray<int32_t>::operator()(i, j);
     }
 
+    /// Take the union of these `Labels` with `other`.
+    ///
+    /// If requested, this function can also give the positions in the
+    /// union where each entry of the input `Labels` ended up.
+    ///
+    /// @param other the `Labels` we want to take the union with
+    /// @param first_mapping if you want the mapping from the positions of
+    ///        entries in `this` to the positions in the union, this should be
+    ///        a pointer to an array containing `this->count()` elements, to be
+    ///        filled by this function. Otherwise it should be a `nullptr`.
+    /// @param first_mapping_count number of elements in `first_mapping`
+    /// @param second_mapping if you want the mapping from the positions of
+    ///        entries in `other` to the positions in the union, this should be
+    ///        a pointer to an array containing `other.count()` elements, to be
+    ///        filled by this function. Otherwise it should be a `nullptr`.
+    /// @param second_mapping_count number of elements in `second_mapping`
+    /// @returns The status code of this operation. If the status is not
+    ///          `EQS_SUCCESS`, you can use `eqs_last_error()` to get the full
+    ///          error message.
+    Labels set_union(
+        const Labels& other,
+        int64_t* first_mapping = nullptr,
+        size_t first_mapping_count = 0,
+        int64_t* second_mapping = nullptr,
+        size_t second_mapping_count = 0
+    ) const {
+        eqs_labels_t result;
+        std::memset(&result, 0, sizeof(result));
+
+        details::check_status(eqs_labels_union(
+            labels_,
+            other.labels_,
+            &result,
+            first_mapping,
+            first_mapping_count,
+            second_mapping,
+            second_mapping_count
+        ));
+
+        return Labels(result);
+    }
+
+    /// Take the union of these `Labels` with `other`.
+    ///
+    /// If requested, this function can also give the positions in the
+    /// union where each entry of the input `Labels` ended up.
+    ///
+    /// @param other the `Labels` we want to take the union with
+    /// @param first_mapping if you want the mapping from the positions of
+    ///        entries in `this` to the positions in the union, this should be
+    ///        a vector containing `this->count()` elements, to be filled by
+    ///        this function. Otherwise it should be an empty vector.
+    /// @param second_mapping if you want the mapping from the positions of
+    ///        entries in `other` to the positions in the union, this should be
+    ///        a vector containing `other.count()` elements, to be filled by
+    ///        this function. Otherwise it should be an empty vector.
+    /// @returns The status code of this operation. If the status is not
+    ///          `EQS_SUCCESS`, you can use `eqs_last_error()` to get the full
+    ///          error message.
+    Labels set_union(
+        const Labels& other,
+        std::vector<int64_t>& first_mapping,
+        std::vector<int64_t>& second_mapping
+    ) const {
+        auto first_mapping_ptr = first_mapping.data();
+        auto first_mapping_count = first_mapping.size();
+        if (first_mapping_count == 0) {
+            first_mapping_ptr = nullptr;
+        }
+
+        auto second_mapping_ptr = second_mapping.data();
+        auto second_mapping_count = second_mapping.size();
+        if (second_mapping_count == 0) {
+            second_mapping_ptr = nullptr;
+        }
+
+        return this->set_union(
+            other,
+            first_mapping_ptr,
+            first_mapping_count,
+            second_mapping_ptr,
+            second_mapping_count
+        );
+    }
+
+    /// Take the intersection of these `Labels` with `other`.
+    ///
+    /// If requested, this function can also give the positions in the
+    /// intersection where each entry of the input `Labels` ended up.
+    ///
+    /// @param other the `Labels` we want to take the intersection with
+    /// @param first_mapping if you want the mapping from the positions of
+    ///        entries in `this` to the positions in the intersection, this
+    ///        should be a pointer to an array containing `this->count()`
+    ///        elements, to be filled by this function. Otherwise it should be a
+    ///        `nullptr`. If an entry in `this` is not used in the intersection,
+    ///        the mapping will be set to -1.
+    /// @param first_mapping_count number of elements in `first_mapping`
+    /// @param second_mapping if you want the mapping from the positions of
+    ///        entries in `other` to the positions in the intersection, this
+    ///        should be a pointer to an array containing `other.count()`
+    ///        elements, to be filled by this function. Otherwise it should be a
+    ///        `nullptr`. If an entry in `other` is not used in the
+    ///        intersection, the mapping will be set to -1.
+    /// @param second_mapping_count number of elements in `second_mapping`
+    /// @returns The status code of this operation. If the status is not
+    ///          `EQS_SUCCESS`, you can use `eqs_last_error()` to get the full
+    ///          error message.
+    Labels set_intersection(
+        const Labels& other,
+        int64_t* first_mapping = nullptr,
+        size_t first_mapping_count = 0,
+        int64_t* second_mapping = nullptr,
+        size_t second_mapping_count = 0
+    ) const {
+        eqs_labels_t result;
+        std::memset(&result, 0, sizeof(result));
+
+        details::check_status(eqs_labels_intersection(
+            labels_,
+            other.labels_,
+            &result,
+            first_mapping,
+            first_mapping_count,
+            second_mapping,
+            second_mapping_count
+        ));
+
+        return Labels(result);
+    }
+
+    /// Take the intersection of this `Labels` with `other`.
+    ///
+    /// If requested, this function can also give the positions in the
+    /// intersection where each entry of the input `Labels` ended up.
+    ///
+    /// @param other the `Labels` we want to take the intersection with
+    /// @param first_mapping if you want the mapping from the positions of
+    ///        entries in `this` to the positions in the intersection, this
+    ///        should be a vector containing `this->count()` elements, to be
+    ///        filled by this function. Otherwise it should be an empty vector.
+    ///        If an entry in `this` is not used in the intersection, the
+    ///        mapping will be set to -1.
+    /// @param second_mapping if you want the mapping from the positions of
+    ///        entries in `other` to the positions in the intersection, this
+    ///        should be a vector containing `other.count()` elements, to be
+    ///        filled by this function. Otherwise it should be an empty vector.
+    ///        If an entry in `other` is not used in the intersection, the
+    ///        mapping will be set to -1.
+    /// @returns The status code of this operation. If the status is not
+    ///          `EQS_SUCCESS`, you can use `eqs_last_error()` to get the full
+    ///          error message.
+    Labels set_intersection(
+        const Labels& other,
+        std::vector<int64_t>& first_mapping,
+        std::vector<int64_t>& second_mapping
+    ) const {
+        auto first_mapping_ptr = first_mapping.data();
+        auto first_mapping_count = first_mapping.size();
+        if (first_mapping_count == 0) {
+            first_mapping_ptr = nullptr;
+        }
+
+        auto second_mapping_ptr = second_mapping.data();
+        auto second_mapping_count = second_mapping.size();
+        if (second_mapping_count == 0) {
+            second_mapping_ptr = nullptr;
+        }
+
+        return this->set_intersection(
+            other,
+            first_mapping_ptr,
+            first_mapping_count,
+            second_mapping_ptr,
+            second_mapping_count
+        );
+    }
+
 private:
     Labels(): NDArray(static_cast<const int32_t*>(nullptr), {0, 0}) {
         std::memset(&labels_, 0, sizeof(labels_));

--- a/equistore-core/tests/cpp/labels.cpp
+++ b/equistore-core/tests/cpp/labels.cpp
@@ -42,3 +42,63 @@ TEST_CASE("Labels") {
         "invalid parameter: 'not an ident' is not a valid label name"
     );
 }
+
+
+TEST_CASE("Set operations") {
+    SECTION("union") {
+        auto first = Labels({"aa", "bb"}, {{0, 1}, {1, 2}});
+        auto second = Labels({"aa", "bb"}, {{2, 3}, {1, 2}, {4, 5}});
+
+        auto first_mapping = std::vector<int64_t>(first.count());
+        auto second_mapping = std::vector<int64_t>(second.count());
+
+        auto union_ = first.set_union(second, first_mapping, second_mapping);
+
+        CHECK(union_.size() == 2);
+        CHECK(union_.names()[0] == std::string("aa"));
+        CHECK(union_.names()[1] == std::string("bb"));
+
+        CHECK(union_.count() == 4);
+        CHECK(union_(0, 0) == 0);
+        CHECK(union_(0, 1) == 1);
+
+        CHECK(union_(1, 0) == 1);
+        CHECK(union_(1, 1) == 2);
+
+        CHECK(union_(2, 0) == 2);
+        CHECK(union_(2, 1) == 3);
+
+        CHECK(union_(3, 0) == 4);
+        CHECK(union_(3, 1) == 5);
+
+        auto expected = std::vector<int64_t>{0, 1};
+        CHECK(first_mapping == expected);
+
+        expected = std::vector<int64_t>{2, 1, 3};
+        CHECK(second_mapping == expected);
+    }
+
+    SECTION("intersection") {
+        auto first = Labels({"aa", "bb"}, {{0, 1}, {1, 2}});
+        auto second = Labels({"aa", "bb"}, {{2, 3}, {1, 2}, {4, 5}});
+
+        auto first_mapping = std::vector<int64_t>(first.count());
+        auto second_mapping = std::vector<int64_t>(second.count());
+
+        auto intersection = first.set_intersection(second, first_mapping, second_mapping);
+
+        CHECK(intersection.size() == 2);
+        CHECK(intersection.names()[0] == std::string("aa"));
+        CHECK(intersection.names()[1] == std::string("bb"));
+
+        CHECK(intersection.count() == 1);
+        CHECK(intersection(0, 0) == 1);
+        CHECK(intersection(0, 1) == 2);
+
+        auto expected = std::vector<int64_t>{-1, 0};
+        CHECK(first_mapping == expected);
+
+        expected = std::vector<int64_t>{-1, 0, -1};
+        CHECK(second_mapping == expected);
+    }
+}

--- a/equistore-torch/include/equistore/torch/labels.hpp
+++ b/equistore-torch/include/equistore/torch/labels.hpp
@@ -130,6 +130,22 @@ public:
     // `nullopt`)
     LabelsHolder to_owned() const;
 
+    /// Get the union of `this` and `other`
+    TorchLabels set_union(const TorchLabels& other) const;
+
+    /// Get the union of `this` and `other`, as well as the mapping from
+    /// positions of entries in the input to the position of entries in the
+    /// output.
+    std::tuple<TorchLabels, torch::Tensor, torch::Tensor> union_and_mapping(const TorchLabels& other) const;
+
+    /// Get the intersection of `this` and `other`
+    TorchLabels set_intersection(const TorchLabels& other) const;
+
+    /// Get the intersection of `this` and `other`, as well as the mapping from
+    /// positions of entries in the input to the position of entries in the
+    /// output.
+    std::tuple<TorchLabels, torch::Tensor, torch::Tensor> intersection_and_mapping(const TorchLabels& other) const;
+
 private:
     /// marker type to differentiate the private constructor below from the main
     /// one

--- a/equistore-torch/src/register.cpp
+++ b/equistore-torch/src/register.cpp
@@ -98,6 +98,10 @@ TORCH_LIBRARY(equistore, m) {
         )
         .def("is_view", &LabelsHolder::is_view)
         .def("to_owned", [](const TorchLabels& self){ return torch::make_intrusive<LabelsHolder>(self->to_owned()); })
+        .def("union", &LabelsHolder::set_union, DOCSTRING, {torch::arg("other")})
+        .def("union_and_mapping", &LabelsHolder::union_and_mapping, DOCSTRING, {torch::arg("other")})
+        .def("intersection", &LabelsHolder::set_intersection, DOCSTRING, {torch::arg("other")})
+        .def("intersection_and_mapping", &LabelsHolder::intersection_and_mapping, DOCSTRING, {torch::arg("other")})
         ;
 
     m.class_<TensorBlockHolder>("TensorBlock")

--- a/equistore/src/c_api.rs
+++ b/equistore/src/c_api.rs
@@ -342,6 +342,26 @@ extern "C" {
     #[must_use]
     pub fn eqs_labels_clone(labels: eqs_labels_t, clone: *mut eqs_labels_t) -> eqs_status_t;
     #[must_use]
+    pub fn eqs_labels_union(
+        first: eqs_labels_t,
+        second: eqs_labels_t,
+        result: *mut eqs_labels_t,
+        first_mapping: *mut i64,
+        first_mapping_count: usize,
+        second_mapping: *mut i64,
+        second_mapping_count: usize,
+    ) -> eqs_status_t;
+    #[must_use]
+    pub fn eqs_labels_intersection(
+        first: eqs_labels_t,
+        second: eqs_labels_t,
+        result: *mut eqs_labels_t,
+        first_mapping: *mut i64,
+        first_mapping_count: usize,
+        second_mapping: *mut i64,
+        second_mapping_count: usize,
+    ) -> eqs_status_t;
+    #[must_use]
     pub fn eqs_labels_free(labels: *mut eqs_labels_t) -> eqs_status_t;
     #[must_use]
     pub fn eqs_register_data_origin(

--- a/python/equistore-core/equistore/core/_c_api.py
+++ b/python/equistore-core/equistore/core/_c_api.py
@@ -115,6 +115,28 @@ def setup_functions(lib):
     ]
     lib.eqs_labels_clone.restype = _check_status
 
+    lib.eqs_labels_union.argtypes = [
+        eqs_labels_t,
+        eqs_labels_t,
+        POINTER(eqs_labels_t),
+        POINTER(ctypes.c_int64),
+        c_uintptr_t,
+        POINTER(ctypes.c_int64),
+        c_uintptr_t,
+    ]
+    lib.eqs_labels_union.restype = _check_status
+
+    lib.eqs_labels_intersection.argtypes = [
+        eqs_labels_t,
+        eqs_labels_t,
+        POINTER(eqs_labels_t),
+        POINTER(ctypes.c_int64),
+        c_uintptr_t,
+        POINTER(ctypes.c_int64),
+        c_uintptr_t,
+    ]
+    lib.eqs_labels_intersection.restype = _check_status
+
     lib.eqs_labels_free.argtypes = [
         POINTER(eqs_labels_t),
     ]

--- a/python/equistore-core/tests/labels.py
+++ b/python/equistore-core/tests/labels.py
@@ -302,3 +302,35 @@ def test_eq():
     assert labels_1[0] != labels_3[0]
     assert labels_1[0] != labels_4[0]
     assert labels_1[1] == labels_3[1]
+
+
+def test_union():
+    first = Labels(["aa", "bb"], np.array([[0, 1], [1, 2]]))
+    second = Labels(["aa", "bb"], np.array([[2, 3], [1, 2], [4, 5]]))
+
+    union = first.union(second)
+    assert union.names == ["aa", "bb"]
+    assert np.all(union.values == np.array([[0, 1], [1, 2], [2, 3], [4, 5]]))
+
+    union_2, first_mapping, second_mapping = first.union_and_mapping(second)
+
+    assert union == union_2
+    assert np.all(first_mapping == np.array([0, 1]))
+    assert np.all(second_mapping == np.array([2, 1, 3]))
+
+
+def test_intersection():
+    first = Labels(["aa", "bb"], np.array([[0, 1], [1, 2]]))
+    second = Labels(["aa", "bb"], np.array([[2, 3], [1, 2], [4, 5]]))
+
+    intersection = first.intersection(second)
+    assert intersection.names == ["aa", "bb"]
+    assert np.all(intersection.values == np.array([[1, 2]]))
+
+    intersection_2, first_mapping, second_mapping = first.intersection_and_mapping(
+        second
+    )
+
+    assert intersection == intersection_2
+    assert np.all(first_mapping == np.array([-1, 0]))
+    assert np.all(second_mapping == np.array([-1, 0, -1]))

--- a/python/equistore-operations/tests/equal_metadata.py
+++ b/python/equistore-operations/tests/equal_metadata.py
@@ -177,8 +177,8 @@ def test_after_drop(test_tensor_map_1):
     new_key = Labels(
         test_tensor_map_1.keys.names, np.array([tuple(test_tensor_map_1.keys[0])])
     )
-    new_tesnor = equistore.drop_blocks(test_tensor_map_1, new_key)
-    assert not equistore.equal_metadata(test_tensor_map_1, new_tesnor)
+    new_tensor = equistore.drop_blocks(test_tensor_map_1, new_key)
+    assert not equistore.equal_metadata(test_tensor_map_1, new_tensor)
 
 
 def test_after_drop_raise(test_tensor_map_1):
@@ -186,10 +186,10 @@ def test_after_drop_raise(test_tensor_map_1):
     new_key = Labels(
         test_tensor_map_1.keys.names, np.array([tuple(test_tensor_map_1.keys[0])])
     )
-    new_tesnor = equistore.drop_blocks(test_tensor_map_1, new_key)
+    new_tensor = equistore.drop_blocks(test_tensor_map_1, new_key)
     error_message = "should have the same number of blocks, got 17 and 16"
     with pytest.raises(NotEqualError, match=error_message):
-        equistore.equal_metadata_raise(test_tensor_map_1, new_tesnor)
+        equistore.equal_metadata_raise(test_tensor_map_1, new_tensor)
 
 
 def test_single_nonexisting_meta(test_tensor_map_1, test_tensor_map_2):

--- a/python/equistore-torch/equistore/torch/documentation.py
+++ b/python/equistore-torch/equistore/torch/documentation.py
@@ -285,6 +285,53 @@ class Labels:
         labels.
         """
 
+    def union(self, other: "Labels") -> "Labels":
+        """
+        Take the union of these :py:class:`Labels` with ``other``.
+
+        If you want to know where entries in ``self`` and ``other`` ends up in the
+        union, you can use :py:meth:`Labels.union_and_mapping`.
+        """
+
+    def union_and_mapping(
+        self, other: "Labels"
+    ) -> Tuple["Labels", torch.Tensor, torch.Tensor]:
+        """
+        Take the union of these :py:class:`Labels` with ``other``.
+
+        This function also returns the position in the union where each entry of the
+        input :py:class::`Labels` ended up.
+
+        :return: Tuple containing the union, a :py:class:`torch.Tensor` containing the
+            position in the union of the entries from ``self``, and a
+            :py:class:`torch.Tensor` containing the position in the union of the
+            entries from ``other``.
+        """
+
+    def intersection(self, other: "Labels") -> "Labels":
+        """
+        Take the intersection of these :py:class:`Labels` with ``other``.
+
+        If you want to know where entries in ``self`` and ``other`` ends up in the
+        intersection, you can use :py:meth:`Labels.intersection_and_mapping`.
+        """
+
+    def intersection_and_mapping(
+        self, other: "Labels"
+    ) -> Tuple["Labels", torch.Tensor, torch.Tensor]:
+        """
+        Take the intersection of these :py:class:`Labels` with ``other``.
+
+        This function also returns the position in the intersection where each entry of
+        the input :py:class::`Labels` ended up.
+
+        :return: Tuple containing the intersection, a :py:class:`torch.Tensor`
+            containing the position in the intersection of the entries from ``self``,
+            and a :py:class:`torch.Tensor` containing the position in the intersection
+            of the entries from ``other``. If entries in ``self`` or ``other`` are not
+            used in the output, the mapping for them is set to ``-1``.
+        """
+
     def print(self, max_entries: int, indent: int) -> str:
         """print these :py:class:`Labels` to a string
 
@@ -330,7 +377,7 @@ class TensorBlock:
     a separate set of samples and possibly components, but which shares the same
     property labels as the original :py:class:`TensorBlock`.
 
-    ..  seealso::
+    .. seealso::
 
         The pure Python version of this class
         :py:class:`equistore.core.TensorBlock`, and the :ref:`differences


### PR DESCRIPTION
These function perform the corresponding set operation over Labels entries, and optionally return the mapping from the positions in the inputs to the position in the output.

Still TODO: 
- [x] update operations to use these functions where needed. 

<!-- readthedocs-preview equistore start -->
----
:books: Documentation preview :books:: https://equistore--287.org.readthedocs.build/en/287/

<!-- readthedocs-preview equistore end -->