### PR TITLE
Keep `Labels.values` on the initial device in TorchScript

### DIFF
--- a/docs/src/reference/c/labels.rst
+++ b/docs/src/reference/c/labels.rst
@@ -13,6 +13,8 @@ The following functions operate on :c:type:`eqs_labels_t`:
 - :c:func:`eqs_labels_position`: get the position of an entry in the labels
 - :c:func:`eqs_labels_union`: get the union of two labels
 - :c:func:`eqs_labels_intersection`: get the intersection of two labels
+- :c:func:`eqs_labels_set_user_data`: store some data inside the labels for later retrieval
+- :c:func:`eqs_labels_user_data`: retrieve data stored earlier in the labels
 
 --------------------------------------------------------------------------------
 
@@ -27,3 +29,7 @@ The following functions operate on :c:type:`eqs_labels_t`:
 .. doxygenfunction:: eqs_labels_union
 
 .. doxygenfunction:: eqs_labels_intersection
+
+.. doxygenfunction:: eqs_labels_set_user_data
+
+.. doxygenfunction:: eqs_labels_user_data

--- a/docs/src/reference/cxx/labels.rst
+++ b/docs/src/reference/cxx/labels.rst
@@ -3,3 +3,9 @@ Labels
 
 .. doxygenclass:: equistore::Labels
     :members:
+
+
+--------------------------------------------------------------------------------
+
+.. doxygenclass:: equistore::LabelsUserData
+    :members:

--- a/equistore-core/include/equistore.h
+++ b/equistore-core/include/equistore.h
@@ -309,6 +309,43 @@ eqs_status_t eqs_labels_position(struct eqs_labels_t labels,
 eqs_status_t eqs_labels_create(struct eqs_labels_t *labels);
 
 /**
+ * Update the registered user data in `labels`
+ *
+ * This function changes the registered user data in the Rust Labels to be
+ * `user_data`; and store the corresponding `user_data_delete` function to be
+ * called once the labels go out of scope.
+ *
+ * Any existing user data will be released (by calling the provided
+ * `user_data_delete` function) before overwriting with the new data.
+ *
+ * @param labels set of labels where we want to add user data
+ * @param user_data pointer to the data
+ * @param user_data_delete function pointer that will be used (if not NULL)
+ *                         to free the memory associated with `data` when the
+ *                         `labels` are freed.
+ * @returns The status code of this operation. If the status is not
+ *          `EQS_SUCCESS`, you can use `eqs_last_error()` to get the full
+ *          error message.
+ */
+eqs_status_t eqs_labels_set_user_data(struct eqs_labels_t labels,
+                                      void *user_data,
+                                      void (*user_data_delete)(void*));
+
+/**
+ * Get the registered user data in `labels` in `*user_data`.
+ *
+ * If no data has been registered, `*user_data` will be NULL.
+ *
+ * @param labels set of labels containing user data
+ * @param user_data this will be set to the pointer than was registered with
+ *                  these `labels`
+ * @returns The status code of this operation. If the status is not
+ *          `EQS_SUCCESS`, you can use `eqs_last_error()` to get the full
+ *          error message.
+ */
+eqs_status_t eqs_labels_user_data(struct eqs_labels_t labels, void **user_data);
+
+/**
  * Make a copy of `labels` inside `clone`.
  *
  * Since `eqs_labels_t` are immutable, the copy is actually just a reference

--- a/equistore-core/src/c_api/labels.rs
+++ b/equistore-core/src/c_api/labels.rs
@@ -213,6 +213,76 @@ pub unsafe extern fn eqs_labels_create(
     })
 }
 
+/// Update the registered user data in `labels`
+///
+/// This function changes the registered user data in the Rust Labels to be
+/// `user_data`; and store the corresponding `user_data_delete` function to be
+/// called once the labels go out of scope.
+///
+/// Any existing user data will be released (by calling the provided
+/// `user_data_delete` function) before overwriting with the new data.
+///
+/// @param labels set of labels where we want to add user data
+/// @param user_data pointer to the data
+/// @param user_data_delete function pointer that will be used (if not NULL)
+///                         to free the memory associated with `data` when the
+///                         `labels` are freed.
+/// @returns The status code of this operation. If the status is not
+///          `EQS_SUCCESS`, you can use `eqs_last_error()` to get the full
+///          error message.
+#[no_mangle]
+pub unsafe extern fn eqs_labels_set_user_data(
+    labels: eqs_labels_t,
+    user_data: *mut c_void,
+    user_data_delete: Option<unsafe extern fn(*mut c_void)>
+) -> eqs_status_t {
+    catch_unwind(|| {
+        if !labels.is_rust() {
+            return Err(Error::InvalidParameter(
+                "these labels do not support calling eqs_labels_set_user_data, \
+                call eqs_labels_create first".into()
+            ));
+        }
+
+        let rust_labels = &*labels.internal_ptr_.cast::<Labels>();
+        rust_labels.set_user_data(user_data, user_data_delete);
+
+        Ok(())
+    })
+}
+
+/// Get the registered user data in `labels` in `*user_data`.
+///
+/// If no data has been registered, `*user_data` will be NULL.
+///
+/// @param labels set of labels containing user data
+/// @param user_data this will be set to the pointer than was registered with
+///                  these `labels`
+/// @returns The status code of this operation. If the status is not
+///          `EQS_SUCCESS`, you can use `eqs_last_error()` to get the full
+///          error message.
+#[no_mangle]
+pub unsafe extern fn eqs_labels_user_data(
+    labels: eqs_labels_t,
+    user_data: *mut *mut c_void,
+) -> eqs_status_t {
+    catch_unwind(|| {
+        check_pointers!(user_data);
+
+        if !labels.is_rust() {
+            return Err(Error::InvalidParameter(
+                "these labels do not support calling eqs_labels_get_user_data, \
+                call eqs_labels_create first".into()
+            ));
+        }
+
+        let rust_labels = &*labels.internal_ptr_.cast::<Labels>();
+        *user_data = rust_labels.user_data();
+
+        Ok(())
+    })
+}
+
 /// Make a copy of `labels` inside `clone`.
 ///
 /// Since `eqs_labels_t` are immutable, the copy is actually just a reference

--- a/equistore-core/src/c_api/tensor.rs
+++ b/equistore-core/src/c_api/tensor.rs
@@ -90,7 +90,7 @@ pub unsafe extern fn eqs_tensormap(
         };
 
         let keys = eqs_labels_to_rust(&keys)?;
-        let tensor = TensorMap::new((*keys).clone(), blocks_vec)?;
+        let tensor = TensorMap::new(keys, blocks_vec)?;
 
         // force the closure to capture the full unwind_wrapper, not just
         // unwind_wrapper.0

--- a/equistore-core/src/io/load.rs
+++ b/equistore-core/src/io/load.rs
@@ -76,7 +76,7 @@ pub fn load<R, F>(reader: R, create_array: F) -> Result<TensorMap, Error>
         )?,);
     }
 
-    return TensorMap::new(keys, blocks);
+    return TensorMap::new(Arc::new(keys), blocks);
 }
 
 #[allow(clippy::needless_pass_by_value)]

--- a/equistore-core/src/tensor/keys_to_properties.rs
+++ b/equistore-core/src/tensor/keys_to_properties.rs
@@ -111,7 +111,7 @@ impl TensorMap {
             }
         }
 
-        return TensorMap::new(splitted_keys.new_keys, new_blocks);
+        return TensorMap::new(Arc::new(splitted_keys.new_keys), new_blocks);
     }
 }
 

--- a/equistore-core/src/tensor/keys_to_samples.rs
+++ b/equistore-core/src/tensor/keys_to_samples.rs
@@ -99,7 +99,7 @@ impl TensorMap {
             }
         }
 
-        return TensorMap::new(splitted_keys.new_keys, new_blocks);
+        return TensorMap::new(Arc::new(splitted_keys.new_keys), new_blocks);
     }
 }
 

--- a/equistore-core/src/tensor/mod.rs
+++ b/equistore-core/src/tensor/mod.rs
@@ -123,7 +123,7 @@ impl TensorMap {
     /// must contain the same kind of data (same labels names, same gradients
     /// defined on all blocks).
     #[allow(clippy::similar_names)]
-    pub fn new(keys: Labels, blocks: Vec<TensorBlock>) -> Result<TensorMap, Error> {
+    pub fn new(keys: Arc<Labels>, blocks: Vec<TensorBlock>) -> Result<TensorMap, Error> {
         if blocks.len() != keys.count() {
             return Err(Error::InvalidParameter(format!(
                 "expected the same number of blocks as the number of \
@@ -169,7 +169,7 @@ impl TensorMap {
         }
 
         Ok(TensorMap {
-            keys: Arc::new(keys),
+            keys: keys,
             blocks,
         })
     }
@@ -299,7 +299,7 @@ mod tests {
         ).unwrap();
 
         let result = TensorMap::new(
-            (*example_labels(vec!["keys"], vec![[0], [1]])).clone(),
+            example_labels(vec!["keys"], vec![[0], [1]]),
             vec![block_1, block_2],
         );
         assert!(result.is_ok());
@@ -320,7 +320,7 @@ mod tests {
         ).unwrap();
 
         let result = TensorMap::new(
-            (*example_labels(vec!["keys"], vec![[0], [1]])).clone(),
+            example_labels(vec!["keys"], vec![[0], [1]]),
             vec![block_1, block_2],
         );
         assert_eq!(
@@ -345,7 +345,7 @@ mod tests {
         ).unwrap();
 
         let result = TensorMap::new(
-            (*example_labels(vec!["keys"], vec![[0], [1]])).clone(),
+            example_labels(vec!["keys"], vec![[0], [1]]),
             vec![block_1, block_2],
         );
         assert_eq!(
@@ -371,7 +371,7 @@ mod tests {
         ).unwrap();
 
         let result = TensorMap::new(
-            (*example_labels(vec!["keys"], vec![[0], [1]])).clone(),
+            example_labels(vec!["keys"], vec![[0], [1]]),
             vec![block_1, block_2],
         );
         assert_eq!(
@@ -396,7 +396,7 @@ mod tests {
         ).unwrap();
 
         let result = TensorMap::new(
-            (*example_labels(vec!["keys"], vec![[0], [1]])).clone(),
+            example_labels(vec!["keys"], vec![[0], [1]]),
             vec![block_1, block_2],
         );
         assert_eq!(
@@ -425,7 +425,7 @@ mod tests {
             [1, 2], [3, 0], [4, 3],
         ]);
 
-        let tensor = TensorMap::new((*keys).clone(), blocks).unwrap();
+        let tensor = TensorMap::new(keys, blocks).unwrap();
 
         let mut selection = LabelsBuilder::new(vec!["key_1", "key_2"]).unwrap();
         selection.add(&[1, 1]).unwrap();

--- a/equistore-core/src/tensor/utils.rs
+++ b/equistore-core/src/tensor/utils.rs
@@ -14,7 +14,7 @@ pub struct KeyAndBlock<'a> {
 }
 
 /// Result of the `remove_dimensions_from_keys` function
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct RemovedDimensionsKeys {
     /// keys without the dimensions
     pub(super) new_keys: Labels,

--- a/equistore-torch/include/equistore/torch/labels.hpp
+++ b/equistore-torch/include/equistore/torch/labels.hpp
@@ -79,6 +79,9 @@ public:
         return values_;
     }
 
+    /// Move the values for these Labels to the given `device`
+    void to(torch::Device device);
+
     /// Get the values associated with a single dimension (i.e. a single column
     /// of `values()`) in these labels.
     torch::Tensor column(std::string dimension);

--- a/equistore-torch/include/equistore/torch/labels.hpp
+++ b/equistore-torch/include/equistore/torch/labels.hpp
@@ -1,6 +1,7 @@
 #ifndef EQUISTORE_TORCH_LABELS_HPP
 #define EQUISTORE_TORCH_LABELS_HPP
 
+#include <c10/core/Device.h>
 #include <string>
 #include <vector>
 

--- a/equistore-torch/src/labels.cpp
+++ b/equistore-torch/src/labels.cpp
@@ -265,6 +265,20 @@ LabelsHolder LabelsHolder::to_owned() const {
     }
 }
 
+void LabelsHolder::to(torch::Device device) {
+    // first move the values
+    values_ = values_.to(device);
+
+    // then make sure that when accessing these labels again we still have the
+    // values on the same device by updating the registered user data
+    auto user_data = equistore::LabelsUserData(
+        new torch::Tensor(values_),
+        [](void* tensor) { delete static_cast<torch::Tensor*>(tensor); }
+    );
+
+    labels_->set_user_data(std::move(user_data));
+}
+
 torch::optional<int64_t> LabelsHolder::position(torch::IValue entry) const {
     const auto& labels = this->as_equistore();
 

--- a/equistore-torch/src/register.cpp
+++ b/equistore-torch/src/register.cpp
@@ -94,6 +94,9 @@ TORCH_LIBRARY(equistore, m) {
         }, DOCSTRING, {torch::arg("names")})
         .def_property("names", &LabelsHolder::names)
         .def_property("values", &LabelsHolder::values)
+        .def("to", &LabelsHolder::to, DOCSTRING,
+            {torch::arg("device")}
+        )
         .def("position", &LabelsHolder::position, DOCSTRING,
             {torch::arg("entry")}
         )

--- a/equistore/src/c_api.rs
+++ b/equistore/src/c_api.rs
@@ -340,6 +340,19 @@ extern "C" {
     #[must_use]
     pub fn eqs_labels_create(labels: *mut eqs_labels_t) -> eqs_status_t;
     #[must_use]
+    pub fn eqs_labels_set_user_data(
+        labels: eqs_labels_t,
+        user_data: *mut ::std::os::raw::c_void,
+        user_data_delete: ::std::option::Option<
+            unsafe extern "C" fn(arg1: *mut ::std::os::raw::c_void),
+        >,
+    ) -> eqs_status_t;
+    #[must_use]
+    pub fn eqs_labels_user_data(
+        labels: eqs_labels_t,
+        user_data: *mut *mut ::std::os::raw::c_void,
+    ) -> eqs_status_t;
+    #[must_use]
     pub fn eqs_labels_clone(labels: eqs_labels_t, clone: *mut eqs_labels_t) -> eqs_status_t;
     #[must_use]
     pub fn eqs_labels_union(

--- a/equistore/src/labels.rs
+++ b/equistore/src/labels.rs
@@ -135,8 +135,8 @@ pub struct Labels {
 // Labels can be sent to other thread safely since eqs_labels_t uses an
 // `Arc<equistore_core::Labels>`, so freeing them from another thread is fine
 unsafe impl Send for Labels {}
-// &Labels can be sent to other thread safely since there is no interior
-// mutability
+// &Labels can be sent to other thread safely since there is no un-synchronized
+// interior mutability (`user_data` is protected by RwLock).
 unsafe impl Sync for Labels {}
 
 impl std::fmt::Debug for Labels {

--- a/python/equistore-core/equistore/core/_c_api.py
+++ b/python/equistore-core/equistore/core/_c_api.py
@@ -109,6 +109,19 @@ def setup_functions(lib):
     ]
     lib.eqs_labels_create.restype = _check_status
 
+    lib.eqs_labels_set_user_data.argtypes = [
+        eqs_labels_t,
+        ctypes.c_void_p,
+        CFUNCTYPE(None, ctypes.c_void_p),
+    ]
+    lib.eqs_labels_set_user_data.restype = _check_status
+
+    lib.eqs_labels_user_data.argtypes = [
+        eqs_labels_t,
+        POINTER(POINTER(None)),
+    ]
+    lib.eqs_labels_user_data.restype = _check_status
+
     lib.eqs_labels_clone.argtypes = [
         eqs_labels_t,
         POINTER(eqs_labels_t),

--- a/python/equistore-core/equistore/core/labels.py
+++ b/python/equistore-core/equistore/core/labels.py
@@ -436,6 +436,14 @@ class Labels:
         """
         return self._values
 
+    def to(self, device):
+        """
+        Move the values for these Labels to the given ``device``.
+
+        This is a no-op for the Python version of equistore, and is only defined for
+        compatibility with the TorchScript version of equistore.
+        """
+
     def position(self, entry: Union[LabelsEntry, Sequence[int]]) -> Optional[int]:
         """
         Get the position of the given ``entry`` in this set of

--- a/python/equistore-torch/equistore/torch/documentation.py
+++ b/python/equistore-torch/equistore/torch/documentation.py
@@ -44,8 +44,17 @@ class LabelsEntry:
     @property
     def values(self) -> torch.Tensor:
         """
-        values associated with each dimensions of this Labels entry, stored as
-        32-bit integers.
+        Values associated with each dimensions of this :py:class:`LabelsEntry`, stored
+        as 32-bit integers.
+
+        .. warning::
+
+            The ``values`` should be treated as immutable/read-only (we would like to
+            enforce this automatically, but PyTorch can not mark a
+            :py:class:`torch.Tensor` as immutable)
+
+            Any modification to this tensor can break the underlying data structure, or
+            make it out of sync with the ``values``.
         """
 
     def print(self) -> str:
@@ -195,8 +204,17 @@ class Labels:
     @property
     def values(self) -> torch.Tensor:
         """
-        values associated with each dimensions of the :py:class:`Labels`, stored
-        as 2-dimensional tensor of 32-bit integers
+        Values associated with each dimensions of the :py:class:`Labels`, stored
+        as 2-dimensional tensor of 32-bit integers.
+
+        .. warning::
+
+            The ``values`` should be treated as immutable/read-only (we would like to
+            enforce this automatically, but PyTorch can not mark a
+            :py:class:`torch.Tensor` as immutable)
+
+            Any modification to this tensor can break the underlying data structure, or
+            make it out of sync with the ``values``.
         """
 
     @staticmethod

--- a/python/equistore-torch/equistore/torch/documentation.py
+++ b/python/equistore-torch/equistore/torch/documentation.py
@@ -298,6 +298,9 @@ class Labels:
         different values)
         """
 
+    def to(self, device):
+        """move the values for these Labels to the given ``device``"""
+
     def position(
         self, entry: Union[LabelsEntry, torch.Tensor, List[int], Tuple[int, ...]]
     ) -> Optional[int]:

--- a/python/equistore-torch/tests/labels.py
+++ b/python/equistore-torch/tests/labels.py
@@ -293,6 +293,25 @@ def test_eq():
     assert labels_1[1] == labels_3[1]
 
 
+def test_to():
+    devices = []
+    if torch.backends.mps.is_available() and torch.backends.mps.is_built():
+        devices.append("mps")
+        devices.append(torch.device("mps"))
+
+    if torch.cuda.is_available():
+        devices.append("cuda")
+        devices.append("cuda:0")
+        devices.append(torch.device("cuda"))
+
+    for device in devices:
+        labels = Labels(names=("a", "b"), values=torch.IntTensor([[0, 0], [0, 1]]))
+        assert labels.values.device.type == "cpu"
+
+        labels.to(device)
+        assert labels.values.device.type == torch.device(device).type
+
+
 def test_position():
     labels = Labels(names=("a", "b"), values=torch.IntTensor([[0, 0], [0, 1]]))
 
@@ -399,6 +418,9 @@ class LabelsWrap:
 
     def values(self) -> Tensor:
         return self._c.values
+
+    def to(self, device: torch.device):
+        return self._c.to(device)
 
     def position(self, entry: Union[List[int], LabelsEntry]) -> Optional[int]:
         return self._c.position(entry=entry)


### PR DESCRIPTION
Fix #290 

<!-- readthedocs-preview equistore start -->
----
:books: Documentation preview :books:: https://equistore--291.org.readthedocs.build/en/291/

<!-- readthedocs-preview equistore end -->