### PR TITLE
Fix numpy deprecation warning when using array with single entry as a scalar

### DIFF
--- a/python/equistore-operations/equistore/operations/add.py
+++ b/python/equistore-operations/equistore/operations/add.py
@@ -34,30 +34,29 @@ def add(A: TensorMap, B: Union[float, TensorMap]) -> TensorMap:
     blocks = []
     if isinstance(B, TensorMap):
         _check_same_keys(A, B, "add")
-        for key in A.keys:
-            blockA = A[key]
-            blockB = B[key]
+        for key, block_A in A.items():
+            block_B = B[key]
             _check_blocks(
-                blockA,
-                blockB,
+                block_A,
+                block_B,
                 props=["samples", "components", "properties"],
                 fname="add",
             )
             _check_same_gradients(
-                blockA,
-                blockB,
+                block_A,
+                block_B,
                 props=["samples", "components", "properties"],
                 fname="add",
             )
-            blocks.append(_add_block_block(block_1=blockA, block_2=blockB))
+            blocks.append(_add_block_block(block_1=block_A, block_2=block_B))
+
+    elif isinstance(B, (float, int)):
+        B = float(B)
+        for block_A in A.blocks():
+            blocks.append(_add_block_constant(block=block_A, constant=B))
+
     else:
-        # check if can be converted in float (so if it is a constant value)
-        try:
-            float(B)
-        except TypeError as e:
-            raise TypeError("B should be a TensorMap or a scalar value. ") from e
-        for blockA in A.blocks():
-            blocks.append(_add_block_constant(block=blockA, constant=B))
+        raise TypeError("B should be a TensorMap or a scalar value")
 
     return TensorMap(A.keys, blocks)
 

--- a/python/equistore-operations/equistore/operations/divide.py
+++ b/python/equistore-operations/equistore/operations/divide.py
@@ -53,14 +53,14 @@ def divide(A: TensorMap, B: Union[float, TensorMap]) -> TensorMap:
                 fname="divide",
             )
             blocks.append(_divide_block_block(block_1=block_A, block_2=block_B))
-    else:
-        # check if can be converted in float (so if it is a constant value)
-        try:
-            float(B)
-        except TypeError as e:
-            raise TypeError("B should be a TensorMap or a scalar value. ") from e
-        for block_A in A:
+
+    elif isinstance(B, (float, int)):
+        B = float(B)
+        for block_A in A.blocks():
             blocks.append(_divide_block_constant(block=block_A, constant=B))
+
+    else:
+        raise TypeError("B should be a TensorMap or a scalar value")
 
     return TensorMap(A.keys, blocks)
 

--- a/python/equistore-operations/equistore/operations/multiply.py
+++ b/python/equistore-operations/equistore/operations/multiply.py
@@ -37,30 +37,29 @@ def multiply(A: TensorMap, B: Union[float, TensorMap]) -> TensorMap:
     blocks = []
     if isinstance(B, TensorMap):
         _check_same_keys(A, B, "multiply")
-        for key in A.keys:
-            blockA = A[key]
-            blockB = B[key]
+        for key, block_A in A.items():
+            block_B = B[key]
             _check_blocks(
-                blockA,
-                blockB,
+                block_A,
+                block_B,
                 props=["samples", "components", "properties"],
                 fname="multiply",
             )
             _check_same_gradients(
-                blockA,
-                blockB,
+                block_A,
+                block_B,
                 props=["samples", "components", "properties"],
                 fname="multiply",
             )
-            blocks.append(_multiply_block_block(block_1=blockA, block_2=blockB))
+            blocks.append(_multiply_block_block(block_1=block_A, block_2=block_B))
+
+    elif isinstance(B, (float, int)):
+        B = float(B)
+        for block_A in A.blocks():
+            blocks.append(_multiply_block_constant(block=block_A, constant=B))
+
     else:
-        # check if can be converted in float (so if it is a constant value)
-        try:
-            float(B)
-        except TypeError as e:
-            raise TypeError("B should be a TensorMap or a scalar value. ") from e
-        for blockA in A.blocks():
-            blocks.append(_multiply_block_constant(block=blockA, constant=B))
+        raise TypeError("B should be a TensorMap or a scalar value")
 
     return TensorMap(A.keys, blocks)
 

--- a/python/equistore-operations/equistore/operations/pow.py
+++ b/python/equistore-operations/equistore/operations/pow.py
@@ -24,13 +24,13 @@ def pow(A: TensorMap, B: float) -> TensorMap:
 
     blocks = []
 
-    # check if can be converted in float (so if it is a constant value)
-    try:
-        float(B)
-    except TypeError as e:
-        raise TypeError("B should be a scalar value. ") from e
-    for blockA in A.blocks():
-        blocks.append(_pow_block_constant(block=blockA, constant=B))
+    if isinstance(B, (float, int)):
+        B = float(B)
+    else:
+        raise TypeError("B should be a scalar value")
+
+    for block_A in A.blocks():
+        blocks.append(_pow_block_constant(block=block_A, constant=B))
 
     return TensorMap(A.keys, blocks)
 

--- a/python/equistore-operations/equistore/operations/subtract.py
+++ b/python/equistore-operations/equistore/operations/subtract.py
@@ -35,12 +35,11 @@ def subtract(A: TensorMap, B: Union[float, TensorMap]) -> TensorMap:
     if isinstance(B, TensorMap):
         _check_same_keys(A, B, "subtract")
         B = multiply(B, -1)
+    elif isinstance(B, (float, int)):
+        B = -float(B)
     else:
-        # check if can be converted in float (so if it is a constant value)
-        try:
-            B = -float(B)
-        except TypeError as e:
-            raise TypeError("B should be a TensorMap or a scalar value. ") from e
+        raise TypeError("B should be a TensorMap or a scalar value")
+
     tensor_result = add(A=A, B=B)
 
     return tensor_result

--- a/python/equistore-operations/tests/add.py
+++ b/python/equistore-operations/tests/add.py
@@ -229,18 +229,17 @@ def test_self_add_tensors_gradient(tensor_A, tensor_B, tensor_res_1):
     equistore.allclose_raise(equistore.add(tensor_A, tensor_B), tensor_res_1)
 
 
-@pytest.mark.parametrize("tensor_B", [5.1, np.array([5.1])])
-def test_self_add_scalar_gradient(tensor_A, tensor_B, tensor_res_2):
+def test_self_add_scalar_gradient(tensor_A, tensor_res_2):
     tensor_A_copy = tensor_A.copy()
 
-    equistore.allclose_raise(equistore.add(tensor_A, tensor_B), tensor_res_2)
+    equistore.allclose_raise(equistore.add(tensor_A, 5.1), tensor_res_2)
 
     # Check the tensors haven't be modified in place
     equistore.equal_raise(tensor_A, tensor_A_copy)
 
 
 def test_self_add_error(tensor_A):
-    msg = "B should be a TensorMap or a scalar value."
+    msg = "B should be a TensorMap or a scalar value"
     with pytest.raises(TypeError, match=msg):
         equistore.add(tensor_A, np.ones((3, 4)))
 

--- a/python/equistore-operations/tests/divide.py
+++ b/python/equistore-operations/tests/divide.py
@@ -279,14 +279,11 @@ class TestDivide(unittest.TestCase):
         keys = Labels(names=["key_1", "key_2"], values=np.array([[0, 0], [1, 0]]))
         A = TensorMap(keys, [block_1, block_2])
         B = 5.1
-        C = np.array([5.1])
 
         tensor_sum = equistore.divide(A, B)
-        tensor_sum_array = equistore.divide(A, C)
         tensor_result = TensorMap(keys, [block_res1, block_res2])
 
         self.assertTrue(equistore.allclose(tensor_result, tensor_sum, rtol=1e-8))
-        self.assertTrue(equistore.allclose(tensor_result, tensor_sum_array, rtol=1e-8))
 
     def test_self_divide_error(self):
         block_1 = TensorBlock(
@@ -303,7 +300,7 @@ class TestDivide(unittest.TestCase):
             keys = equistore.divide(A, B)
         self.assertEqual(
             str(cm.exception),
-            "B should be a TensorMap or a scalar value. ",
+            "B should be a TensorMap or a scalar value",
         )
 
 

--- a/python/equistore-operations/tests/multiply.py
+++ b/python/equistore-operations/tests/multiply.py
@@ -266,14 +266,11 @@ class TestMultiply(unittest.TestCase):
         keys = Labels(names=["key_1", "key_2"], values=np.array([[0, 0], [1, 0]]))
         A = TensorMap(keys, [block_1, block_2])
         B = 5.1
-        C = np.array([5.1])
 
         tensor_sum = equistore.multiply(A, B)
-        tensor_sum_array = equistore.multiply(A, C)
         tensor_result = TensorMap(keys, [block_res_1, block_res_2])
 
         self.assertTrue(equistore.allclose(tensor_result, tensor_sum))
-        self.assertTrue(equistore.allclose(tensor_result, tensor_sum_array))
 
     def test_self_multiply_error(self):
         block_1 = TensorBlock(
@@ -290,7 +287,7 @@ class TestMultiply(unittest.TestCase):
             keys = equistore.multiply(A, B)
         self.assertEqual(
             str(cm.exception),
-            "B should be a TensorMap or a scalar value. ",
+            "B should be a TensorMap or a scalar value",
         )
 
 

--- a/python/equistore-operations/tests/pow.py
+++ b/python/equistore-operations/tests/pow.py
@@ -111,14 +111,10 @@ class TestPow:
 
         keys = Labels(names=["key_1", "key_2"], values=np.array([[0, 0], [1, 0]]))
 
-        C = np.array([2.0])
-
         tensor_sum = equistore.pow(A, B)
-        tensor_sum_array = equistore.pow(A, C)
         tensor_result = TensorMap(keys, [block_res_1, block_res_2])
 
         assert equistore.allclose(tensor_result, tensor_sum)
-        assert equistore.allclose(tensor_result, tensor_sum_array)
         # Check not modified in place
         assert equistore.equal(A, A_copy)
 
@@ -233,14 +229,10 @@ class TestPow:
         )
         keys = Labels(names=["key_1"], values=np.array([[0]]))
 
-        C = np.array([2.0])
-
         tensor_pow = equistore.pow(A, B)
-        tensor_pow_array = equistore.pow(A, C)
         tensor_result = TensorMap(keys, [block_res_1])
 
         assert equistore.allclose(tensor_result, tensor_pow)
-        assert equistore.allclose(tensor_result, tensor_pow_array)
 
     def test_self_pow_scalar_sqrt_gradient(self):
         b1_s0 = np.array([1, 2])
@@ -342,14 +334,10 @@ class TestPow:
 
         keys = Labels(names=["key_1", "key_2"], values=np.array([[0, 0], [1, 0]]))
 
-        C = np.array([0.5])
-
         tensor_sum = equistore.pow(A, B)
-        tensor_sum_array = equistore.pow(A, C)
         tensor_result = TensorMap(keys, [block_res_1, block_res_2])
 
         assert equistore.allclose(tensor_result, tensor_sum)
-        assert equistore.allclose(tensor_result, tensor_sum_array)
 
     def test_self_pow_error(self):
         block_1 = TensorBlock(
@@ -362,7 +350,7 @@ class TestPow:
         A = TensorMap(keys, [block_1])
         B = np.ones((3, 4))
 
-        with pytest.raises(TypeError, match="B should be a scalar value. "):
+        with pytest.raises(TypeError, match="B should be a scalar value"):
             keys = equistore.pow(A, B)
 
 

--- a/python/equistore-operations/tests/subtract.py
+++ b/python/equistore-operations/tests/subtract.py
@@ -264,14 +264,11 @@ class TestSubtract(unittest.TestCase):
         keys = Labels(names=["key_1", "key_2"], values=np.array([[0, 0], [1, 0]]))
         A = TensorMap(keys, [block_1, block_2])
         B = -5.1
-        C = np.array([-5.1])
 
         tensor_sum = equistore.subtract(A, B)
-        tensor_sum_array = equistore.subtract(A, C)
         tensor_result = TensorMap(keys, [block_res_1, block_res_2])
 
         self.assertTrue(equistore.allclose(tensor_result, tensor_sum))
-        self.assertTrue(equistore.allclose(tensor_result, tensor_sum_array))
 
     def test_self_subtract_error(self):
         block_1 = TensorBlock(
@@ -288,7 +285,7 @@ class TestSubtract(unittest.TestCase):
             keys = equistore.subtract(A, B)
         self.assertEqual(
             str(cm.exception),
-            "B should be a TensorMap or a scalar value. ",
+            "B should be a TensorMap or a scalar value",
         )
 
 


### PR DESCRIPTION
This also removes some `try/catch` blocks, which will help with TorchScript support (#280 is another step in this direction).


<!-- readthedocs-preview equistore start -->
----
:books: Documentation preview :books:: https://equistore--292.org.readthedocs.build/en/292/

<!-- readthedocs-preview equistore end -->