### PR TITLE
Add `Labels::column` to access a single column in the values

### DIFF
--- a/equistore-torch/include/equistore/torch/labels.hpp
+++ b/equistore-torch/include/equistore/torch/labels.hpp
@@ -78,6 +78,10 @@ public:
         return values_;
     }
 
+    /// Get the values associated with a single dimension (i.e. a single column
+    /// of `values()`) in these labels.
+    torch::Tensor column(std::string dimension);
+
     /// Get the number of entries in this set of Labels.
     ///
     /// This is the same as `values().size(0)`
@@ -235,7 +239,7 @@ public:
     int32_t operator[](const std::string& name) const;
 
     /// implementation of __getitem__, forwarding to one of the operator[]
-    int64_t getitem(torch::IValue index) const;
+    int64_t __getitem__(torch::IValue index) const;
 
     /// Print this entry as a named tuple (i.e. `(key=value, key=value)`).
     std::string print() const;

--- a/python/equistore-core/tests/labels.py
+++ b/python/equistore-core/tests/labels.py
@@ -116,38 +116,38 @@ def test_view():
 
     assert not labels.is_view()
 
-    view = labels["aaa"]
+    view = labels.view("aaa")
     assert view.is_view()
     assert view.names == ["aaa"]
     np.testing.assert_equal(view.values, np.array([[1], [3]]))
 
-    view = labels["bbb"]
+    view = labels.view("bbb")
     assert view.names == ["bbb"]
     np.testing.assert_equal(view.values, np.array([[2], [4]]))
 
-    view = labels[["bbb"]]
+    view = labels.view(["bbb"])
     assert view.is_view()
     assert view.names == ["bbb"]
     np.testing.assert_equal(view.values, np.array([[2], [4]]))
 
-    view = labels[["bbb", "aaa"]]
+    view = labels.view(["bbb", "aaa"])
     assert view.is_view()
     assert view.names == ["bbb", "aaa"]
     np.testing.assert_equal(view.values, np.array([[2, 1], [4, 3]]))
 
-    view = labels[["aaa", "aaa", "aaa"]]
+    view = labels.view(["aaa", "aaa", "aaa"])
     assert view.names == ["aaa", "aaa", "aaa"]
     np.testing.assert_equal(view.values, np.array([[1, 1, 1], [3, 3, 3]]))
 
     message = "'ccc' not found in the dimensions of these Labels"
     with pytest.raises(ValueError, match=message):
-        labels["ccc"]
+        labels.view("ccc")
 
     message = "Labels names must be strings, got <class 'int'> instead"
     with pytest.raises(TypeError, match=message):
-        labels[1, 2]
+        labels.view((1, 2))
 
-    view = labels["aaa"]
+    view = labels.view("aaa")
     message = "can not call `position` on a Labels view, call `to_owned` before"
     with pytest.raises(ValueError, match=message):
         view.position([1])
@@ -157,7 +157,7 @@ def test_view():
     assert owned.position([1]) == 0
     assert owned.position([-1]) is None
 
-    view = labels[["aaa", "aaa"]]
+    view = labels.view(["aaa", "aaa"])
     message = "invalid parameter: labels names must be unique, got 'aaa' multiple times"
     with pytest.raises(EquistoreError, match=message):
         view.to_owned()
@@ -215,7 +215,7 @@ def test_repr():
 
     labels = Labels(names=("aaa", "bbb"), values=np.array([[0, 0], [0, 1]]))
     expected = "LabelsView(\n    bbb\n     0\n     1\n)"
-    assert str(labels["bbb"]) == expected
+    assert str(labels.view("bbb")) == expected
 
     labels = Labels(
         names=("aaa", "bbb"), values=np.array([[111111111, 2], [3, 444444444]])
@@ -241,6 +241,13 @@ def test_indexing():
     assert entry.names == ["a", "b"]
     np.testing.assert_equal(entry.values, np.array([3, 4]))
 
+    # indexing labels with string
+    column = labels["a"]
+    np.testing.assert_equal(column, np.array([1, 3]))
+
+    column = labels["b"]
+    np.testing.assert_equal(column, np.array([2, 4]))
+
     # indexing labels errors
     message = "index 3 is out of bounds for axis 0 with size 2"
     with pytest.raises(IndexError, match=message):
@@ -249,6 +256,14 @@ def test_indexing():
     message = "index -7 is out of bounds for axis 0 with size 2"
     with pytest.raises(IndexError, match=message):
         labels[-7]
+
+    message = "column names must be a string, got <class 'float'> instead"
+    with pytest.raises(TypeError, match=message):
+        labels[3.4]
+
+    message = "'cc' not found in the dimensions of these Labels"
+    with pytest.raises(ValueError, match=message):
+        labels["cc"]
 
     # indexing entry with integer
     entry = labels[0]

--- a/python/equistore-operations/equistore/operations/abs.py
+++ b/python/equistore-operations/equistore/operations/abs.py
@@ -62,8 +62,7 @@ def _abs_block(block: TensorBlock) -> TensorBlock:
         diff_components = len(gradient.components) - len(block.components)
         # The sign_values have the same dimensions as that of the block.values.
         # Reshape the sign_values to allow multiplication with gradient.values
-        gradient_samples_sample = gradient.samples["sample"].values[:, 0]
-        new_grad = gradient.values[:] * sign_values[gradient_samples_sample].reshape(
+        new_grad = gradient.values[:] * sign_values[gradient.samples["sample"]].reshape(
             (-1,) + (1,) * diff_components + _shape
         )
 

--- a/python/equistore-operations/equistore/operations/divide.py
+++ b/python/equistore-operations/equistore/operations/divide.py
@@ -113,11 +113,8 @@ def _divide_block_block(block_1: TensorBlock, block_2: TensorBlock) -> TensorBlo
 
         values_grad = []
         for i_sample in range(len(block_1.samples)):
-            samples_1 = gradient_1.samples["sample"].values
-            i_sample_grad_1 = np.where(samples_1 == i_sample)[0]
-
-            samples_2 = gradient_2.samples["sample"].values
-            i_sample_grad_2 = np.where(samples_2 == i_sample)[0]
+            i_sample_grad_1 = np.where(gradient_1.samples["sample"] == i_sample)[0]
+            i_sample_grad_2 = np.where(gradient_2.samples["sample"] == i_sample)[0]
 
             value_grad = (
                 -block_1.values[i_sample]

--- a/python/equistore-operations/equistore/operations/multiply.py
+++ b/python/equistore-operations/equistore/operations/multiply.py
@@ -112,11 +112,8 @@ def _multiply_block_block(block_1: TensorBlock, block_2: TensorBlock) -> TensorB
 
         gradient_values = []
         for i_sample in range(len(block_1.samples)):
-            gradient_samples_1 = gradient_1.samples["sample"].values
-            i_sample_grad_1 = np.where(gradient_samples_1 == i_sample)[0]
-
-            gradient_samples_2 = gradient_2.samples["sample"].values
-            i_sample_grad_2 = np.where(gradient_samples_2 == i_sample)[0]
+            i_sample_grad_1 = np.where(gradient_1.samples["sample"] == i_sample)[0]
+            i_sample_grad_2 = np.where(gradient_2.samples["sample"] == i_sample)[0]
 
             gradient_values.append(
                 block_1.values[i_sample] * gradient_2.values[i_sample_grad_2]

--- a/python/equistore-operations/equistore/operations/one_hot.py
+++ b/python/equistore-operations/equistore/operations/one_hot.py
@@ -61,11 +61,11 @@ def one_hot(labels: Labels, dimension: Labels) -> np.ndarray:
     name = dimension.names[0]
 
     indices = np.zeros(len(labels), dtype=np.int64)
-    for i, entry in enumerate(labels[name].values):
-        position = dimension.position(entry)
+    for i, entry in enumerate(labels[name]):
+        position = dimension.position([entry])
         if position is None:
             raise ValueError(
-                f"{name}={entry[0]} is present in the labels, but was not found in "
+                f"{name}={entry} is present in the labels, but was not found in "
                 "the dimension"
             )
         indices[i] = position

--- a/python/equistore-operations/equistore/operations/pow.py
+++ b/python/equistore-operations/equistore/operations/pow.py
@@ -59,11 +59,10 @@ def _pow_block_constant(block: TensorBlock, constant: float) -> TensorBlock:
         # I want the difference between the number of components of the gradients and
         # the values
         diff_components = len(gradient_values.shape) - len(block.values.shape)
-        gradient_samples_sample = gradient.samples["sample"].values[:, 0]
         values_grad.append(
             constant
             * gradient_values
-            * block.values[gradient_samples_sample].reshape(
+            * block.values[gradient.samples["sample"]].reshape(
                 (-1,) + (1,) * diff_components + _shape
             )
             ** (constant - 1)

--- a/python/equistore-operations/equistore/operations/slice.py
+++ b/python/equistore-operations/equistore/operations/slice.py
@@ -173,7 +173,7 @@ def _slice_block(block: TensorBlock, axis: str, labels: Labels) -> TensorBlock:
 
     if axis == "samples":
         # only keep the same names as `labels`
-        all_samples = block.samples[labels.names]
+        all_samples = block.samples.view(labels.names)
         # create an arrays of bools indicating which samples indices to keep
         samples_mask = np.array([s in labels for s in all_samples])
         new_values = block.values[samples_mask]
@@ -192,7 +192,7 @@ def _slice_block(block: TensorBlock, axis: str, labels: Labels) -> TensorBlock:
     else:
         assert axis == "properties"
         # only keep the same names as `labels`
-        all_properties = block.properties[list(labels.names)]
+        all_properties = block.properties.view(list(labels.names))
         # create an arrays of bools indicating which samples indices to keep
         properties_mask = np.array([p in labels for p in all_properties])
         new_values = block.values[..., properties_mask]
@@ -227,7 +227,7 @@ def _slice_block(block: TensorBlock, axis: str, labels: Labels) -> TensorBlock:
 
         # Create a samples filter for the Gradient TensorBlock
         if axis == "samples":
-            grad_samples_mask = samples_mask[gradient.samples["sample"].values[:, 0]]
+            grad_samples_mask = samples_mask[gradient.samples["sample"]]
             new_grad_samples = gradient.samples.values[grad_samples_mask]
 
             if new_grad_samples.shape[0] != 0:

--- a/python/equistore-operations/equistore/operations/unique_metadata.py
+++ b/python/equistore-operations/equistore/operations/unique_metadata.py
@@ -210,10 +210,10 @@ def _unique_from_blocks(
     all_values = []
     for block in blocks:
         if axis == "samples":
-            all_values.append(block.samples[names].values)
+            all_values.append(block.samples.view(names).values)
         else:
             assert axis == "properties"
-            all_values.append(block.properties[names].values)
+            all_values.append(block.properties.view(names).values)
 
     unique_values = np.unique(np.vstack(all_values), axis=0)
     return Labels(names=names, values=unique_values)

--- a/python/equistore-operations/tests/slice.py
+++ b/python/equistore-operations/tests/slice.py
@@ -93,7 +93,7 @@ def _check_sliced_block_samples(block, sliced_block, structures_to_keep):
         assert np.max(sliced_gradient.samples["sample"]) < sliced_block.values.shape[0]
 
         # other columns in the gradient samples have been sliced correctly
-        gradient_sample_filter = samples_filter[gradient.samples["sample"].values[:, 0]]
+        gradient_sample_filter = samples_filter[gradient.samples["sample"]]
         if len(gradient.samples.names) > 1:
             expected = gradient.samples.values[gradient_sample_filter, 1:]
             sliced_gradient_samples = sliced_gradient.samples.values[:, 1:]

--- a/python/equistore-operations/tests/split.py
+++ b/python/equistore-operations/tests/split.py
@@ -72,7 +72,7 @@ class TestSplitSamples(unittest.TestCase):
                 self.assertEqual(len(split_block.components[c_i]), c_size)
             # Equal values tensor
             samples_filter = np.array(
-                [s in grouped_labels[i] for s in block.samples[target_names]]
+                [s in grouped_labels[i] for s in block.samples.view(target_names)]
             )
             self.assertTrue(
                 np.all(split_block.values == block.values[samples_filter, ...])
@@ -92,7 +92,7 @@ class TestSplitSamples(unittest.TestCase):
 
                 # other columns in the gradient samples have been sliced correctly
 
-                gradient_samples_sample = gradient.samples["sample"].values[:, 0]
+                gradient_samples_sample = gradient.samples["sample"]
                 gradient_sample_filter = samples_filter[gradient_samples_sample]
                 if len(gradient.samples.names) > 1:
                     expected = gradient.samples.values[gradient_sample_filter, 1:]
@@ -296,7 +296,7 @@ class TestSplitProperties(unittest.TestCase):
                 self.assertEqual(len(split_block.components[c_i]), c_size)
             # Equal values tensor
             properties_filter = np.array(
-                [p in grouped_labels[i] for p in block.properties[target_names]]
+                [p in grouped_labels[i] for p in block.properties.view(target_names)]
             )
             self.assertTrue(
                 np.all(split_block.values == block.values[..., properties_filter])
@@ -318,7 +318,7 @@ class TestSplitProperties(unittest.TestCase):
                     len(
                         [
                             p
-                            for p in gradient.properties[target_names]
+                            for p in gradient.properties.view(target_names)
                             if p in target_idxs
                         ]
                     ),
@@ -587,9 +587,9 @@ def _unique_indices(
     all_idxs = []
     for block in blocks:
         if axis == "samples":
-            block_idxs = block.samples[names]
+            block_idxs = block.samples.view(names)
         else:
-            block_idxs = block.properties[names]
+            block_idxs = block.properties.view(names)
 
         for idx in block_idxs:
             all_idxs.append(idx)

--- a/python/equistore-torch/equistore/torch/documentation.py
+++ b/python/equistore-torch/equistore/torch/documentation.py
@@ -113,7 +113,7 @@ class Labels:
     a subset of columns/dimensions:
 
     >>> # single dimension
-    >>> view = labels["atom"]  # or labels.view("atom")
+    >>> view = labels.view("atom")
     >>> view.names
     ['atom']
     >>> view.values
@@ -121,7 +121,7 @@ class Labels:
             [2],
             [5]], dtype=torch.int32)
     >>> # multiple dimensions
-    >>> view = labels[["atom", "structure"]]
+    >>> view = labels.view(["atom", "structure"])
     >>> view.names
     ['atom', 'structure']
     >>> view.values
@@ -135,9 +135,8 @@ class Labels:
     >>> owned_labels.is_view()
     False
 
-
-    One can also iterate over labels entries, or directly index the
-    :py:class:`Labels` to get them
+    One can also iterate over labels entries, or directly index the :py:class:`Labels`
+    to get a specific entry
 
     >>> entry = labels[0]  # or labels.entry(0)
     >>> entry.names
@@ -151,6 +150,12 @@ class Labels:
     LabelsEntry(structure=0, atom=2, species_center=1)
     LabelsEntry(structure=0, atom=5, species_center=1)
 
+    Or get all the values associated with a given dimension/column name
+
+    >>> labels.column("atom")
+    tensor([1, 2, 5], dtype=torch.int32)
+    >>> labels["atom"]  # alternative syntax for the above
+    tensor([1, 2, 5], dtype=torch.int32)
 
     Labels can be checked for equality:
 
@@ -239,7 +244,7 @@ class Labels:
         """number of entries in these labels"""
 
     @overload
-    def __getitem__(self, dimensions: StrSequence) -> "Labels":
+    def __getitem__(self, dimension: str) -> torch.Tensor:
         pass
 
     @overload
@@ -248,15 +253,14 @@ class Labels:
 
     def __getitem__(self, index):
         """
-        When indexing with a string or list of string, create a view containing
-        only the specified dimensions.
+        When indexing with a string, get the values for the corresponding dimension as a
+        1-dimensional array (i.e. :py:func:`Labels.column`).
 
-        When indexing with an integer, get the corresponding row/labels entry.
+        When indexing with an integer, get the corresponding row/labels entry (i.e.
+        :py:func:`Labels.entry`).
 
-        If you get errors about the output of ``labels[index]`` being unknown
-        when using :py:func:`torch.jit.script`, you should use
-        :py:func:`Labels.entry` and :py:func:`Labels.view` instead to refine the
-        types.
+        See also :py:func:`Labels.view` to extract the values associated with multiple
+        columns/dimensions.
         """
 
     def __contains__(
@@ -341,6 +345,18 @@ class Labels:
 
     def entry(self, index: int) -> LabelsEntry:
         """get a single entry in these labels, see also :py:func:`Labels.__getitem__`"""
+
+    def column(self, dimension: str) -> torch.Tensor:
+        """
+        Get the values associated with a single dimension in these labels (i.e. a single
+        column of :py:attr:`Labels.values`) as a 1-dimensional array.
+
+        .. seealso::
+
+            :py:func:`Labels.__getitem__` as the main way to use this function
+
+            :py:func:`Labels.view` to access multiple columns simultaneously
+        """
 
     def view(self, dimensions: StrSequence) -> "Labels":
         """get a view for the specified columns in these labels, see also


### PR DESCRIPTION
And make `Labels::__getitem__` use this instead of view.

This mean that code trying to compute some gradient will go from looking like this:

```py
data = some_function(block.values[gradient.samples["sample"].values.reshape(-1)] )
```

to this, which is much closer to the previous version

```py
data = some_function(block.values[gradient.samples["sample"]] )
```

<!-- readthedocs-preview equistore start -->
----
:books: Documentation preview :books:: https://equistore--295.org.readthedocs.build/en/295/

<!-- readthedocs-preview equistore end -->