### PR TITLE
Save and load TensorMap from in-memory buffers

### DIFF
--- a/docs/src/reference/c/misc.rst
+++ b/docs/src/reference/c/misc.rst
@@ -24,4 +24,8 @@ Serialization
 
 .. doxygenfunction:: eqs_tensormap_save
 
+.. doxygenfunction:: eqs_tensormap_load_buffer
+
+.. doxygenfunction:: eqs_tensormap_save_buffer
+
 .. doxygentypedef:: eqs_create_array_callback_t

--- a/docs/src/reference/python/io.rst
+++ b/docs/src/reference/python/io.rst
@@ -11,6 +11,8 @@ Serialization
 
 .. autofunction:: equistore.core.io.load_custom_array
 
+.. autofunction:: equistore.core.io.load_buffer_custom_array
+
 .. autofunction:: equistore.core.io.create_numpy_array()
 
 .. autofunction:: equistore.core.io.create_torch_array()

--- a/docs/src/reference/torch/cxx/index.rst
+++ b/docs/src/reference/torch/cxx/index.rst
@@ -13,3 +13,4 @@ To use equistore's TorchScript C++ API, you should ``#include
     tensor
     block
     labels
+    serialization

--- a/docs/src/reference/torch/cxx/serialization.rst
+++ b/docs/src/reference/torch/cxx/serialization.rst
@@ -1,0 +1,6 @@
+Serialization
+=============
+
+.. doxygenfunction:: equistore_torch::save
+
+.. doxygenfunction:: equistore_torch::load

--- a/docs/src/reference/torch/index.rst
+++ b/docs/src/reference/torch/index.rst
@@ -41,8 +41,8 @@ the following pages:
     tensor
     block
     labels
+    serialization
 
-.. TODO: I/O functions are not yet implemented
 .. TODO: operations are not yet available
 
 --------------------------------------------------------------------------------

--- a/docs/src/reference/torch/serialization.rst
+++ b/docs/src/reference/torch/serialization.rst
@@ -1,0 +1,6 @@
+Serialization
+=============
+
+.. autofunction:: equistore.torch.save
+
+.. autofunction:: equistore.torch.load

--- a/equistore-core/include/equistore.h
+++ b/equistore-core/include/equistore.h
@@ -921,6 +921,46 @@ struct eqs_tensormap_t *eqs_tensormap_load_buffer(const uint8_t *buffer,
  */
 eqs_status_t eqs_tensormap_save(const char *path, const struct eqs_tensormap_t *tensor);
 
+/**
+ * Save a tensor map to an in-memory buffer.
+ *
+ * The `realloc` callback should take an existing pointer and a new length, and
+ * grow the allocation. If the pointer is `NULL`, it should create a new
+ * allocation. If it is unable to allocate memory, it should return a `NULL`
+ * pointer. This follows the API of the standard C function `realloc`, with an
+ * additional parameter `user_data` that can be used to hold custom data.
+ *
+ * On input, `*buffer` should contain the address of a starting buffer (which
+ * can be NULL) and `*buffer_count` should contain the size of the allocation.
+ *
+ * On output, `*buffer` will contain the serialized data, and `*buffer_count`
+ * the total number of written bytes (which might be less than the allocation
+ * size).
+ *
+ * Users of this function are responsible for freeing the `*buffer` when they
+ * are done with it, using the function matching the `realloc` callback.
+ *
+ * @param buffer pointer to the buffer the tensor will be stored to, which can
+ *        change due to reallocations.
+ * @param buffer_count pointer to the buffer size on input, number of written
+ *        bytes on output
+ * @param realloc_user_data Custom data for the `realloc` callback. This will
+ *        be passed as the first argument to `realloc` as-is.
+ * @param realloc function that allows to grow the buffer allocation
+ * @param tensor tensor map that will saved to the buffer
+ *
+ * @returns The status code of this operation. If the status is not
+ *          `EQS_SUCCESS`, you can use `eqs_last_error()` to get the full error
+ *          message.
+ */
+eqs_status_t eqs_tensormap_save_buffer(uint8_t **buffer,
+                                       uintptr_t *buffer_count,
+                                       void *realloc_user_data,
+                                       uint8_t *(*realloc)(void *user_data,
+                                                           uint8_t *ptr,
+                                                           uintptr_t new_size),
+                                       const struct eqs_tensormap_t *tensor);
+
 #ifdef __cplusplus
 } // extern "C"
 #endif // __cplusplus

--- a/equistore-core/include/equistore.h
+++ b/equistore-core/include/equistore.h
@@ -885,6 +885,29 @@ struct eqs_tensormap_t *eqs_tensormap_load(const char *path,
                                            eqs_create_array_callback_t create_array);
 
 /**
+ * Load a tensor map from the given in-memory buffer.
+ *
+ * Arrays for the values and gradient data will be created with the given
+ * `create_array` callback, and filled by this function with the corresponding
+ * data.
+ *
+ * The memory allocated by this function should be released using
+ * `eqs_tensormap_free`.
+ *
+ * @param buffer buffer containing a previously serialized `eqs_tensormap_t`
+ * @param buffer_count number of elements in the buffer
+ * @param create_array callback function that will be used to create data
+ *                     arrays inside each block
+ *
+ * @returns A pointer to the newly allocated tensor map, or a `NULL` pointer in
+ *          case of error. In case of error, you can use `eqs_last_error()`
+ *          to get the error message.
+ */
+struct eqs_tensormap_t *eqs_tensormap_load_buffer(const uint8_t *buffer,
+                                                  uintptr_t buffer_count,
+                                                  eqs_create_array_callback_t create_array);
+
+/**
  * Save a tensor map to the file at the given path.
  *
  * If the file already exists, it is overwritten.

--- a/equistore-core/include/equistore.hpp
+++ b/equistore-core/include/equistore.hpp
@@ -1931,7 +1931,7 @@ public:
         return TensorMap(ptr);
     }
 
-    /// "Save the given `TensorMap` to a file at `path`.
+    /// Save the given `TensorMap` to a file at `path`.
     ///
     /// `TensorMap` are serialized using numpy's `.npz` format, i.e. a ZIP
     /// file without compression (storage method is `STORED`), where each file

--- a/equistore-torch/CMakeLists.txt
+++ b/equistore-torch/CMakeLists.txt
@@ -59,6 +59,7 @@ set(EQUISTORE_TORCH_SOURCE
     "src/labels.cpp"
     "src/block.cpp"
     "src/tensor.cpp"
+    "src/misc.cpp"
     "src/register.cpp"
 )
 

--- a/equistore-torch/include/equistore/torch.hpp
+++ b/equistore-torch/include/equistore/torch.hpp
@@ -4,3 +4,4 @@
 #include "equistore/torch/labels.hpp"
 #include "equistore/torch/block.hpp"
 #include "equistore/torch/tensor.hpp"
+#include "equistore/torch/misc.hpp"

--- a/equistore-torch/include/equistore/torch/misc.hpp
+++ b/equistore-torch/include/equistore/torch/misc.hpp
@@ -1,0 +1,34 @@
+#ifndef EQUISTORE_TORCH_MISC_HPP
+#define EQUISTORE_TORCH_MISC_HPP
+
+#include <equistore.h>
+#include <vector>
+
+#include <torch/script.h>
+
+#include <equistore.hpp>
+
+#include "equistore/torch/exports.h"
+#include "equistore/torch/tensor.hpp"
+
+namespace equistore_torch {
+
+namespace details {
+    /// Function to be used as `eqs_create_array_callback_t` to load data in
+    /// torch Tensor.
+    EQUISTORE_TORCH_EXPORT eqs_status_t create_torch_array(
+        const uintptr_t* shape_ptr,
+        uintptr_t shape_count,
+        eqs_array_t* array
+    );
+}
+
+/// Load a previously saved `TensorMap` from the given path.
+EQUISTORE_TORCH_EXPORT TorchTensorMap load(const std::string& path);
+
+/// Save the given `TensorMap` to a file at `path`
+EQUISTORE_TORCH_EXPORT void save(const std::string& path, TorchTensorMap tensor);
+
+}
+
+#endif

--- a/equistore-torch/src/misc.cpp
+++ b/equistore-torch/src/misc.cpp
@@ -1,0 +1,41 @@
+#include <torch/torch.h>
+
+#include <equistore.hpp>
+#include <torch/types.h>
+
+#include "equistore/torch/array.hpp"
+#include "equistore/torch/misc.hpp"
+
+using namespace equistore_torch;
+
+
+eqs_status_t equistore_torch::details::create_torch_array(
+    const uintptr_t* shape_ptr,
+    uintptr_t shape_count,
+    eqs_array_t* array
+) {
+    auto sizes = std::vector<int64_t>();
+    for (size_t i=0; i<shape_count; i++) {
+        sizes.push_back(static_cast<int64_t>(shape_ptr[i]));
+    }
+
+    auto options = torch::TensorOptions().device(torch::kCPU).dtype(torch::kF64);
+    auto tensor = torch::zeros(sizes, options);
+
+    auto cxx_array = std::unique_ptr<equistore::DataArrayBase>(new TorchDataArray(tensor));
+    *array = equistore::DataArrayBase::to_eqs_array_t(std::move(cxx_array));
+
+    return EQS_SUCCESS;
+}
+
+
+TorchTensorMap equistore_torch::load(const std::string& path) {
+    return torch::make_intrusive<TensorMapHolder>(
+        equistore::TensorMap::load(path, details::create_torch_array)
+    );
+}
+
+
+void equistore_torch::save(const std::string& path, TorchTensorMap tensor) {
+    equistore::TensorMap::save(path, tensor->as_equistore());
+}

--- a/equistore-torch/src/misc.cpp
+++ b/equistore-torch/src/misc.cpp
@@ -14,18 +14,24 @@ eqs_status_t equistore_torch::details::create_torch_array(
     uintptr_t shape_count,
     eqs_array_t* array
 ) {
-    auto sizes = std::vector<int64_t>();
-    for (size_t i=0; i<shape_count; i++) {
-        sizes.push_back(static_cast<int64_t>(shape_ptr[i]));
-    }
+    return equistore::details::catch_exceptions([](
+        const uintptr_t* shape_ptr,
+        uintptr_t shape_count,
+        eqs_array_t* array
+    ) {
+        auto sizes = std::vector<int64_t>();
+        for (size_t i=0; i<shape_count; i++) {
+            sizes.push_back(static_cast<int64_t>(shape_ptr[i]));
+        }
 
-    auto options = torch::TensorOptions().device(torch::kCPU).dtype(torch::kF64);
-    auto tensor = torch::zeros(sizes, options);
+        auto options = torch::TensorOptions().device(torch::kCPU).dtype(torch::kF64);
+        auto tensor = torch::zeros(sizes, options);
 
-    auto cxx_array = std::unique_ptr<equistore::DataArrayBase>(new TorchDataArray(tensor));
-    *array = equistore::DataArrayBase::to_eqs_array_t(std::move(cxx_array));
+        auto cxx_array = std::unique_ptr<equistore::DataArrayBase>(new TorchDataArray(tensor));
+        *array = equistore::DataArrayBase::to_eqs_array_t(std::move(cxx_array));
 
-    return EQS_SUCCESS;
+        return EQS_SUCCESS;
+    }, shape_ptr, shape_count, array);
 }
 
 

--- a/equistore-torch/src/register.cpp
+++ b/equistore-torch/src/register.cpp
@@ -182,15 +182,17 @@ TORCH_LIBRARY(equistore, m) {
             {torch::arg("max_keys")}
         )
         // TODO
-        // .def_pickle(
-        //     // __getstate__
-        //     [](const torch::intrusive_ptr<TorchTensorMap>& self) -> std::string {
-        //          // TODO
-        //     },
-        //     // __setstate__
-        //     [](std::string state) -> torch::intrusive_ptr<TorchCalculator> {
-        //         // TODO
-        //     })
+        .def_pickle(
+            // __getstate__
+            [](const TorchTensorMap& self) -> std::string {
+                throw std::runtime_error("NOT IMPLEMENTED");
+            },
+            // __setstate__
+            [](std::string buffer) -> TorchTensorMap {
+                return torch::make_intrusive<TensorMapHolder>(
+                    equistore::TensorMap::load_buffer(buffer, details::create_torch_array)
+                );
+            })
         ;
 
     m.def("load", equistore_torch::load);

--- a/equistore-torch/src/register.cpp
+++ b/equistore-torch/src/register.cpp
@@ -5,6 +5,7 @@
 #include "equistore/torch/labels.hpp"
 #include "equistore/torch/block.hpp"
 #include "equistore/torch/tensor.hpp"
+#include "equistore/torch/misc.hpp"
 
 using namespace equistore_torch;
 
@@ -191,4 +192,7 @@ TORCH_LIBRARY(equistore, m) {
         //         // TODO
         //     })
         ;
+
+    m.def("load", equistore_torch::load);
+    m.def("save", equistore_torch::save);
 }

--- a/equistore-torch/tests/CMakeLists.txt
+++ b/equistore-torch/tests/CMakeLists.txt
@@ -36,6 +36,7 @@ foreach(_file_ ${ALL_TESTS})
     get_filename_component(_name_ ${_file_} NAME_WE)
     add_executable(torch-${_name_} ${_file_})
     target_link_libraries(torch-${_name_} equistore_torch catch)
+    target_compile_definitions(torch-${_name_} PRIVATE "-DDATA_NPZ=\"${CMAKE_CURRENT_SOURCE_DIR}/../../equistore/tests/data.npz\"")
 
     add_test(
         NAME torch-${_name_}

--- a/equistore-torch/tests/tensor.cpp
+++ b/equistore-torch/tests/tensor.cpp
@@ -158,6 +158,38 @@ TEST_CASE("TensorMap") {
     }
 }
 
+TEST_CASE("TensorMap serialization") {
+    SECTION("loading file") {
+        // DATA_NPZ is defined by cmake and expand to the path of tests/data.npz
+        auto tensor = equistore_torch::load(DATA_NPZ);
+
+        auto keys = tensor->keys();
+        CHECK(keys->names().size() == 3);
+        CHECK(keys->names()[0] == std::string("spherical_harmonics_l"));
+        CHECK(keys->names()[1] == std::string("center_species"));
+        CHECK(keys->names()[2] == std::string("neighbor_species"));
+        CHECK(keys->count() == 27);
+
+        auto block = tensor->block_by_id(21);
+
+        auto samples = block->samples();
+        CHECK(samples->names().size() == 2);
+        CHECK(samples->names()[0] == std::string("structure"));
+        CHECK(samples->names()[1] == std::string("center"));
+
+        CHECK(block->values().sizes() == std::vector<int64_t>{9, 5, 3});
+
+        auto gradient = block->gradient("positions");
+        samples = gradient->samples();
+        CHECK(samples->names().size() == 3);
+        CHECK(samples->names()[0] == std::string("sample"));
+        CHECK(samples->names()[1] == std::string("structure"));
+        CHECK(samples->names()[2] == std::string("atom"));
+
+        CHECK(gradient->values().sizes() == std::vector<int64_t>{59, 3, 5, 3});
+    }
+}
+
 
 TorchTensorMap test_tensor_map() {
     auto blocks = std::vector<TorchTensorBlock>();

--- a/equistore/build.rs
+++ b/equistore/build.rs
@@ -50,7 +50,7 @@ fn main() {
         equistore_core.push(splitted[..splitted.len() - 1].join("."));
     }
 
-    let mut install_dir = cmake::Config::new(equistore_core)
+    let mut install_dir = cmake::Config::new(&equistore_core)
         .define("CARGO_EXE", env!("CARGO"))
         .define("RUST_BUILD_TARGET", std::env::var("TARGET").unwrap())
         .build();
@@ -60,7 +60,7 @@ fn main() {
 
     println!("cargo:rustc-link-search=native={}", install_dir.display());
     println!("cargo:rerun-if-changed=build.rs");
-    println!("cargo:rerun-if-changed=equistore-core");
+    println!("cargo:rerun-if-changed={}", equistore_core.display());
 
     if cfg!(feature = "static") && !rustc_version_at_least("1.63.0") {
         println!("cargo:rustc-cfg=static_and_rustc_older_1_63");

--- a/equistore/src/c_api.rs
+++ b/equistore/src/c_api.rs
@@ -478,4 +478,18 @@ extern "C" {
         path: *const ::std::os::raw::c_char,
         tensor: *const eqs_tensormap_t,
     ) -> eqs_status_t;
+    #[must_use]
+    pub fn eqs_tensormap_save_buffer(
+        buffer: *mut *mut u8,
+        buffer_count: *mut usize,
+        realloc_user_data: *mut ::std::os::raw::c_void,
+        realloc: ::std::option::Option<
+            unsafe extern "C" fn(
+                user_data: *mut ::std::os::raw::c_void,
+                ptr: *mut u8,
+                new_size: usize,
+            ) -> *mut u8,
+        >,
+        tensor: *const eqs_tensormap_t,
+    ) -> eqs_status_t;
 }

--- a/equistore/src/c_api.rs
+++ b/equistore/src/c_api.rs
@@ -468,6 +468,11 @@ extern "C" {
         path: *const ::std::os::raw::c_char,
         create_array: eqs_create_array_callback_t,
     ) -> *mut eqs_tensormap_t;
+    pub fn eqs_tensormap_load_buffer(
+        buffer: *const u8,
+        buffer_count: usize,
+        create_array: eqs_create_array_callback_t,
+    ) -> *mut eqs_tensormap_t;
     #[must_use]
     pub fn eqs_tensormap_save(
         path: *const ::std::os::raw::c_char,

--- a/equistore/src/io.rs
+++ b/equistore/src/io.rs
@@ -8,10 +8,6 @@ use crate::{TensorMap, Error, Array};
 
 /// Load the serialized tensor map from the given path.
 ///
-/// Arrays for the values and gradient data will be created with the given
-/// `create_array` callback, and filled by this function with the corresponding
-/// data.
-///
 /// `TensorMap` are serialized using numpy's `.npz` format, i.e. a ZIP file
 /// without compression (storage method is STORED), where each file is stored as
 /// a `.npy` array. Both the ZIP and NPY format are well documented:
@@ -50,6 +46,23 @@ pub fn load(path: impl AsRef<std::path::Path>) -> Result<TensorMap, Error> {
     let ptr = unsafe {
         crate::c_api::eqs_tensormap_load(
             path.as_ptr(),
+            Some(create_ndarray)
+        )
+    };
+
+    check_ptr(ptr)?;
+
+    return Ok(unsafe { TensorMap::from_raw(ptr) });
+}
+
+/// Load a serialized `TensorMap` from a `buffer`.
+///
+/// See the [`load`] function for more information on the data format.
+pub fn load_buffer(buffer: &[u8]) -> Result<TensorMap, Error> {
+    let ptr = unsafe {
+        crate::c_api::eqs_tensormap_load_buffer(
+            buffer.as_ptr(),
+            buffer.len(),
             Some(create_ndarray)
         )
     };

--- a/equistore/tests/serialization.rs
+++ b/equistore/tests/serialization.rs
@@ -5,7 +5,6 @@ use equistore::TensorMap;
 #[test]
 fn load_file() {
     let tensor = equistore::io::load("./tests/data.npz").unwrap();
-
     check_tensor(&tensor);
 }
 
@@ -18,6 +17,20 @@ fn load_buffer() {
 
     let tensor = equistore::io::load_buffer(&buffer).unwrap();
     check_tensor(&tensor);
+}
+
+#[test]
+fn save_buffer() {
+    let mut file = std::fs::File::open("./tests/data.npz").unwrap();
+    let mut buffer = Vec::new();
+    file.read_to_end(&mut buffer).unwrap();
+
+    let tensor = equistore::io::load_buffer(&buffer).unwrap();
+
+    let mut saved = Vec::new();
+    equistore::io::save_buffer(&tensor, &mut saved).unwrap();
+
+    assert_eq!(buffer, saved);
 }
 
 

--- a/equistore/tests/serialization.rs
+++ b/equistore/tests/serialization.rs
@@ -1,7 +1,27 @@
+use std::io::Read;
+
+use equistore::TensorMap;
+
 #[test]
 fn load_file() {
     let tensor = equistore::io::load("./tests/data.npz").unwrap();
 
+    check_tensor(&tensor);
+}
+
+
+#[test]
+fn load_buffer() {
+    let mut file = std::fs::File::open("./tests/data.npz").unwrap();
+    let mut buffer = Vec::new();
+    file.read_to_end(&mut buffer).unwrap();
+
+    let tensor = equistore::io::load_buffer(&buffer).unwrap();
+    check_tensor(&tensor);
+}
+
+
+fn check_tensor(tensor: &TensorMap) {
     assert_eq!(tensor.keys().names(), ["spherical_harmonics_l", "center_species", "neighbor_species"]);
     assert_eq!(tensor.keys().count(), 27);
 

--- a/python/equistore-core/equistore/core/_c_api.py
+++ b/python/equistore-core/equistore/core/_c_api.py
@@ -298,3 +298,12 @@ def setup_functions(lib):
         POINTER(eqs_tensormap_t),
     ]
     lib.eqs_tensormap_save.restype = _check_status
+
+    lib.eqs_tensormap_save_buffer.argtypes = [
+        POINTER(ctypes.c_char_p),
+        POINTER(c_uintptr_t),
+        ctypes.c_void_p,
+        CFUNCTYPE(ctypes.c_char_p, ctypes.c_void_p, ctypes.c_char_p, c_uintptr_t),
+        POINTER(eqs_tensormap_t),
+    ]
+    lib.eqs_tensormap_save_buffer.restype = _check_status

--- a/python/equistore-core/equistore/core/_c_api.py
+++ b/python/equistore-core/equistore/core/_c_api.py
@@ -286,6 +286,13 @@ def setup_functions(lib):
     ]
     lib.eqs_tensormap_load.restype = POINTER(eqs_tensormap_t)
 
+    lib.eqs_tensormap_load_buffer.argtypes = [
+        ctypes.c_char_p,
+        c_uintptr_t,
+        eqs_create_array_callback_t,
+    ]
+    lib.eqs_tensormap_load_buffer.restype = POINTER(eqs_tensormap_t)
+
     lib.eqs_tensormap_save.argtypes = [
         ctypes.c_char_p,
         POINTER(eqs_tensormap_t),

--- a/python/equistore-core/equistore/core/io.py
+++ b/python/equistore-core/equistore/core/io.py
@@ -10,6 +10,7 @@ from ._c_lib import _get_library
 from .block import TensorBlock
 from .data.array import ArrayWrapper, _is_numpy_array, _is_torch_array
 from .labels import Labels
+from .status import _save_exception
 from .tensor import TensorMap
 from .utils import catch_exceptions
 
@@ -48,18 +49,17 @@ def create_torch_array(shape_ptr, shape_count, array):
     array[0] = wrapper.into_eqs_array()
 
 
-def load(file: Union[str, bytes, pathlib.Path, BinaryIO], use_numpy=False) -> TensorMap:
+def load(file: Union[str, pathlib.Path, BinaryIO], use_numpy=False) -> TensorMap:
     """
     Load a previously saved :py:class:`TensorMap` from the given file.
-
-    ``file`` can be a string or :py:class:`pathlib.Path` containing the path to the file
-    to load, or a file-like object that should be opened in binary mode.
 
     :py:class:`TensorMap` are serialized using numpy's ``.npz`` format, i.e. a ZIP file
     without compression (storage method is ``STORED``), where each file is stored as a
     ``.npy`` array. See the C API documentation for more information on the format.
 
-    :param file: file to load
+    :param file: file to load: this can be a string, a :py:class:`pathlib.Path`
+        containing the path to the file to load, or a file-like object that should be
+        opened in binary mode.
     :param use_numpy: should we use numpy or the native implementation? Numpy should be
         able to process more dtypes than the native implementation, which is limited to
         float64, but the native implementation is usually faster than going through
@@ -68,12 +68,7 @@ def load(file: Union[str, bytes, pathlib.Path, BinaryIO], use_numpy=False) -> Te
     if use_numpy:
         return _read_npz(file)
     else:
-        if isinstance(file, str):
-            file = file.encode("utf8")
-        elif isinstance(file, pathlib.Path):
-            file = bytes(file)
-
-        if isinstance(file, bytes):
+        if isinstance(file, (str, pathlib.Path)):
             return load_custom_array(file, create_numpy_array)
         else:
             # assume we have a file-like object
@@ -88,21 +83,24 @@ CreateArrayCallback = Callable[
 ]
 
 
-def load_custom_array(path: bytes, create_array: CreateArrayCallback) -> TensorMap:
+def load_custom_array(
+    path: Union[str, pathlib.Path],
+    create_array: CreateArrayCallback,
+) -> TensorMap:
     """
-    Load a previously saved :py:class:`TensorMap` from the given path using a
-    custom array creation callback.
+    Load a previously saved :py:class:`TensorMap` from the given path using a custom
+    array creation callback.
 
     This is an advanced functionality, which should not be needed by most users.
 
-    This function allows to specify the kind of array to use when loading the
-    data through the `create_array` callback. This callback should take three
-    arguments: a pointer to the shape, the number of elements in the shape, and
-    a pointer to the ``eqs_array_t`` to be filled.
+    This function allows to specify the kind of array to use when loading the data
+    through the ``create_array`` callback. This callback should take three arguments: a
+    pointer to the shape, the number of elements in the shape, and a pointer to the
+    ``eqs_array_t`` to be filled.
 
     :py:func:`equistore.core.io.create_numpy_array` and
-    :py:func:`equistore.core.io.create_torch_array` can be used to load data
-    into numpy and torch arrays respectively.
+    :py:func:`equistore.core.io.create_torch_array` can be used to load data into numpy
+    and torch arrays respectively.
 
     :param path: path of the file to load
     :param create_array: callback used to create arrays as needed
@@ -110,35 +108,44 @@ def load_custom_array(path: bytes, create_array: CreateArrayCallback) -> TensorM
 
     lib = _get_library()
 
+    if isinstance(path, str):
+        path = path.encode("utf8")
+    elif isinstance(path, pathlib.Path):
+        path = bytes(path)
+
     ptr = lib.eqs_tensormap_load(path, eqs_create_array_callback_t(create_array))
 
     return TensorMap._from_ptr(ptr)
 
 
 def load_buffer_custom_array(
-    buffer: bytes,
+    buffer: Union[bytes, bytearray],
     create_array: CreateArrayCallback,
 ) -> TensorMap:
     """
-    Load a previously saved :py:class:`TensorMap` from the given buffer using a
-    custom array creation callback.
+    Load a previously saved :py:class:`TensorMap` from the given buffer using a custom
+    array creation callback.
 
     This is an advanced functionality, which should not be needed by most users.
 
-    This function allows to specify the kind of array to use when loading the
-    data through the `create_array` callback. This callback should take three
-    arguments: a pointer to the shape, the number of elements in the shape, and
-    a pointer to the ``eqs_array_t`` to be filled.
+    This function allows to specify the kind of array to use when loading the data
+    through the ``create_array`` callback. This callback should take three arguments: a
+    pointer to the shape, the number of elements in the shape, and a pointer to the
+    ``eqs_array_t`` to be filled.
 
     :py:func:`equistore.core.io.create_numpy_array` and
-    :py:func:`equistore.core.io.create_torch_array` can be used to load data
-    into numpy and torch arrays respectively.
+    :py:func:`equistore.core.io.create_torch_array` can be used to load data into numpy
+    and torch arrays respectively.
 
     :param buffer: in-memory buffer containing a saved :py:class:`TensorMap`
     :param create_array: callback used to create arrays as needed
     """
 
     lib = _get_library()
+
+    if isinstance(buffer, bytearray):
+        char_array = ctypes.c_char * len(buffer)
+        buffer = char_array.from_buffer(buffer)
 
     ptr = lib.eqs_tensormap_load_buffer(
         buffer,
@@ -149,37 +156,105 @@ def load_buffer_custom_array(
     return TensorMap._from_ptr(ptr)
 
 
-def save(path: str, tensor: TensorMap, use_numpy=False):
-    """Save the given :py:class:`TensorMap` to a file at ``path``.
+def save(
+    file: Union[str, pathlib.Path, BinaryIO],
+    tensor: TensorMap,
+    use_numpy=False,
+):
+    """Save the given :py:class:`TensorMap` to a ``file``.
 
-    :py:class:`TensorMap` are serialized using numpy's ``.npz`` format, i.e. a
-    ZIP file without compression (storage method is ``STORED``), where each file
-    is stored as a ``.npy`` array. See the C API documentation for more
-    information on the format.
+    :py:class:`TensorMap` are serialized using numpy's ``.npz`` format, i.e. a ZIP file
+    without compression (storage method is ``STORED``), where each file is stored as a
+    ``.npy`` array. See the C API documentation for more information on the format.
 
-    :param path: path of the file where to save the data
+    :param file: where to save the data. This can be a string, :py:class:`pathlib.Path`
+        containing the path to the file to load, or a file-like object that should be
+        opened in binary mode.
     :param tensor: tensor to save
-    :param use_numpy: should we use numpy or the native implementation? Numpy
-        should be able to process more dtypes than the native implementation,
-        which is limited to float64, but the native implementation is usually
-        faster than going through numpy.
+    :param use_numpy: should we use numpy or the native implementation? Numpy should be
+        able to process more dtypes than the native implementation, which is limited to
+        float64, but the native implementation is usually faster than going through
+        numpy.
     """
     if not isinstance(tensor, TensorMap):
         raise TypeError(f"tensor should be a 'TensorMap', not {type(tensor)}")
 
-    if not path.endswith(".npz"):
-        path += ".npz"
-        warnings.warn(
-            message=f"adding '.npz' extension, the file will be saved at '{path}'",
-            stacklevel=1,
-        )
+    if isinstance(file, (str, pathlib.Path)):
+        if not file.endswith(".npz"):
+            file += ".npz"
+            warnings.warn(
+                message=f"adding '.npz' extension, the file will be saved at '{file}'",
+                stacklevel=1,
+            )
 
     if use_numpy:
         all_entries = _tensor_map_to_dict(tensor)
-        np.savez(path, **all_entries)
+        np.savez(file, **all_entries)
     else:
         lib = _get_library()
-        lib.eqs_tensormap_save(path.encode("utf8"), tensor._ptr)
+        if isinstance(file, str):
+            lib.eqs_tensormap_save(file.encode("utf8"), tensor._ptr)
+        elif isinstance(file, pathlib.Path):
+            lib.eqs_tensormap_save(bytes(file), tensor._ptr)
+        else:
+            # assume we have a file-like object
+            buffer = save_buffer_raw_(tensor)
+            file.write(buffer.raw)
+
+
+def save_buffer_raw_(tensor: TensorMap):
+    """Save a TensorMap to an in-memory buffer, returning the data as a ctypes array"""
+
+    lib = _get_library()
+
+    def realloc(buffer, _ptr, new_size):
+        try:
+            # convert void* to PyObject* and dereference to get a PyObject
+            buffer = ctypes.cast(buffer, ctypes.POINTER(ctypes.py_object))
+            buffer = buffer.contents.value
+
+            # resize the buffer to grow it
+            ctypes.resize(buffer, new_size)
+            buffer._length_ = new_size
+
+            return ctypes.addressof(buffer)
+        except Exception as e:
+            # we don't want to propagate exceptions through C, so we catch anything
+            # here, save the error and return a NULL pointer
+            error = RuntimeError("failed to allocate more memory in realloc")
+            error.__cause__ = e
+            _save_exception(error)
+            return None
+
+    # start with a buffer of 1024 bytes in a ctypes string buffer (i.e. array of c_char)
+    # we will be able to resize the allocation in `realloc` above, but the type will
+    # stay `array of 1024 c_char elements`.
+    buffer = ctypes.create_string_buffer(1024)
+
+    # store the initial pointer and buffer_size on the stack, they will be modified by
+    # `eqs_tensormap_save_buffer`
+    buffer_ptr = ctypes.c_char_p(ctypes.addressof(buffer))
+    buffer_size = c_uintptr_t(buffer._length_)
+
+    realloc_type = ctypes.CFUNCTYPE(
+        ctypes.c_char_p, ctypes.c_void_p, ctypes.c_char_p, c_uintptr_t
+    )
+
+    lib.eqs_tensormap_save_buffer(
+        buffer_ptr,
+        buffer_size,
+        # convert PyObject to void* to pass it to realloc
+        ctypes.cast(ctypes.pointer(ctypes.py_object(buffer)), ctypes.c_void_p),
+        realloc_type(realloc),
+        tensor._ptr,
+    )
+
+    # remove extra data from the buffer, resizing it to the number of written bytes
+    # (stored in buffer_size by `eqs_tensormap_save_buffer`)
+    ctypes.resize(buffer, buffer_size.value)
+    buffer._length_ = buffer_size.value
+
+    return buffer
 
 
 def _array_to_numpy(array):

--- a/python/equistore-core/equistore/core/tensor.py
+++ b/python/equistore-core/equistore/core/tensor.py
@@ -1,8 +1,6 @@
 import copy
 import ctypes
-import os
 import sys
-import tempfile
 from typing import Dict, List, Sequence, Tuple, Union
 
 
@@ -88,7 +86,7 @@ class TensorMap:
         return obj
 
     @classmethod
-    def _from_pickle(cls, buffer: bytes):
+    def _from_pickle(cls, buffer: Union[bytes, bytearray]):
         """
         Passed to pickler to reconstruct TensorMap from bytes object
         """
@@ -124,17 +122,11 @@ class TensorMap:
         """
         import equistore.core
 
-        path = os.path.join(tempfile.gettempdir(), str(id(self)) + ".npz")
-        try:
-            equistore.core.save(path, self)
-            with open(path, "rb") as f:
-                data = f.read()
-        finally:
-            os.remove(path)
+        buffer = equistore.core.io.save_buffer_raw_(self)
         if protocol >= 5:
-            return self._from_pickle, (PickleBuffer(data),)
+            return self._from_pickle, (PickleBuffer(buffer),)
         else:
-            return self._from_pickle, (data,)
+            return self._from_pickle, (buffer.raw,)
 
     def __len__(self):
         return len(self.keys)

--- a/python/equistore-core/tests/data.py
+++ b/python/equistore-core/tests/data.py
@@ -225,7 +225,7 @@ def test_parent_keepalive():
     path = os.path.join(
         os.path.dirname(__file__), "..", "..", "..", "equistore", "tests", "data.npz"
     )
-    tensor = equistore.core.io.load_custom_array(path, create_test_array)
+    tensor = equistore.core.io.load_custom_array(path.encode("utf8"), create_test_array)
 
     values = tensor.block(0).values
     assert isinstance(values, equistore.core.data.extract.ExternalCpuArray)

--- a/python/equistore-core/tests/serialization.py
+++ b/python/equistore-core/tests/serialization.py
@@ -64,13 +64,21 @@ def test_load(use_numpy, memory_buffer):
 # using tmpdir as pytest-built-in fixture
 # https://docs.pytest.org/en/7.1.x/how-to/tmp_path.html#the-tmpdir-and-tmpdir-factory-fixtures
 @pytest.mark.parametrize("use_numpy", (True, False))
-def test_save(use_numpy, tmpdir, tensor):
+@pytest.mark.parametrize("memory_buffer", (True, False))
+def test_save(use_numpy, memory_buffer, tmpdir, tensor):
     """Check that as saved file loads fine with numpy."""
-    tmpfile = "serialize-test.npz"
+
+    if memory_buffer:
+        file = io.BytesIO()
+    else:
+        file = "serialize-test.npz"
 
     with tmpdir.as_cwd():
-        equistore.core.save(tmpfile, tensor, use_numpy=use_numpy)
-        data = np.load(tmpfile)
+        equistore.core.save(file, tensor, use_numpy=use_numpy)
+        if memory_buffer:
+            file.seek(0)
+
+        data = np.load(file)
 
     assert len(data.keys()) == 29
 

--- a/python/equistore-core/tests/serialization.py
+++ b/python/equistore-core/tests/serialization.py
@@ -1,3 +1,4 @@
+import io
 import os
 import pickle
 import sys
@@ -17,17 +18,29 @@ def tensor():
 
 
 @pytest.mark.parametrize("use_numpy", (True, False))
-def test_load(use_numpy):
+@pytest.mark.parametrize("memory_buffer", (True, False))
+def test_load(use_numpy, memory_buffer):
+    path = os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        "..",
+        "..",
+        "equistore",
+        "tests",
+        "data.npz",
+    )
+
+    if memory_buffer:
+        with open(path, "rb") as fd:
+            buffer = fd.read()
+
+        assert isinstance(buffer, bytes)
+        file = io.BytesIO(buffer)
+    else:
+        file = path
+
     tensor = equistore.core.load(
-        os.path.join(
-            os.path.dirname(__file__),
-            "..",
-            "..",
-            "..",
-            "equistore",
-            "tests",
-            "data.npz",
-        ),
+        file,
         use_numpy=use_numpy,
     )
 

--- a/python/equistore-torch/equistore/torch/__init__.py
+++ b/python/equistore-torch/equistore/torch/__init__.py
@@ -18,12 +18,16 @@ else:
 
 if os.environ.get("EQUISTORE_IMPORT_FOR_SPHINX") is not None:
     from .documentation import Labels, LabelsEntry, TensorBlock, TensorMap
+    from .documentation import load, save
 else:
     _load_library()
     Labels = torch.classes.equistore.Labels
     LabelsEntry = torch.classes.equistore.LabelsEntry
     TensorBlock = torch.classes.equistore.TensorBlock
     TensorMap = torch.classes.equistore.TensorMap
+
+    load = torch.ops.equistore.load
+    save = torch.ops.equistore.save
 
 
 __all__ = [

--- a/python/equistore-torch/equistore/torch/documentation.py
+++ b/python/equistore-torch/equistore/torch/documentation.py
@@ -838,3 +838,30 @@ class TensorMap:
         :param max_keys: how many keys to include in the output. Use ``-1`` to
             include all keys.
         """
+
+
+def load(path: str) -> TensorMap:
+    """
+    Load a previously saved :py:class:`TensorMap` from the given path.
+
+    :py:class:`TensorMap` are serialized using numpy's ``.npz`` format, i.e. a
+    ZIP file without compression (storage method is ``STORED``), where each file
+    is stored as a ``.npy`` array. See the C API documentation for more
+    information on the format.
+
+    :param path: path of the file to load
+    """
+
+
+def save(path: str, tensor: TensorMap):
+    """
+    Save the given :py:class:`TensorMap` to a file at ``path``.
+
+    :py:class:`TensorMap` are serialized using numpy's ``.npz`` format, i.e. a
+    ZIP file without compression (storage method is ``STORED``), where each file
+    is stored as a ``.npy`` array. See the C API documentation for more
+    information on the format.
+
+    :param path: path of the file where to save the data
+    :param tensor: tensor to save
+    """

--- a/python/equistore-torch/tests/serialization.py
+++ b/python/equistore-torch/tests/serialization.py
@@ -53,3 +53,8 @@ def test_save(tmpdir, tensor):
         data = equistore.torch.load(tmpfile)
 
     assert len(data.keys) == 4
+
+
+def test_pickle():
+    # TODO when we have save
+    pass

--- a/python/equistore-torch/tests/serialization.py
+++ b/python/equistore-torch/tests/serialization.py
@@ -1,0 +1,55 @@
+import os
+
+import pytest
+import torch
+
+import equistore.torch
+
+from . import utils
+
+
+@pytest.fixture
+def tensor():
+    return utils.tensor(dtype=torch.float64)
+
+
+def test_load():
+    tensor = equistore.torch.load(
+        os.path.join(
+            os.path.dirname(__file__),
+            "..",
+            "..",
+            "..",
+            "equistore",
+            "tests",
+            "data.npz",
+        ),
+    )
+
+    assert tensor.keys.names == [
+        "spherical_harmonics_l",
+        "center_species",
+        "neighbor_species",
+    ]
+    assert len(tensor.keys) == 27
+
+    block = tensor.block(
+        dict(spherical_harmonics_l=2, center_species=6, neighbor_species=1)
+    )
+    assert block.samples.names == ["structure", "center"]
+    assert block.values.shape == (9, 5, 3)
+
+    gradient = block.gradient("positions")
+    assert gradient.samples.names == ["sample", "structure", "atom"]
+    assert gradient.values.shape == (59, 3, 5, 3)
+
+
+def test_save(tmpdir, tensor):
+    """Check that we can save and load a tensor to a file"""
+    tmpfile = "serialize-test.npz"
+
+    with tmpdir.as_cwd():
+        equistore.torch.save(tmpfile, tensor)
+        data = equistore.torch.load(tmpfile)
+
+    assert len(data.keys) == 4

--- a/python/equistore-torch/tests/serialization.py
+++ b/python/equistore-torch/tests/serialization.py
@@ -1,6 +1,5 @@
 import os
 
-import pytest
 import torch
 
 import equistore.torch
@@ -8,24 +7,7 @@ import equistore.torch
 from . import utils
 
 
-@pytest.fixture
-def tensor():
-    return utils.tensor(dtype=torch.float64)
-
-
-def test_load():
-    tensor = equistore.torch.load(
-        os.path.join(
-            os.path.dirname(__file__),
-            "..",
-            "..",
-            "..",
-            "equistore",
-            "tests",
-            "data.npz",
-        ),
-    )
-
+def check_tensor(tensor):
     assert tensor.keys.names == [
         "spherical_harmonics_l",
         "center_species",
@@ -44,9 +26,27 @@ def test_load():
     assert gradient.values.shape == (59, 3, 5, 3)
 
 
-def test_save(tmpdir, tensor):
+def test_load():
+    loaded = equistore.torch.load(
+        os.path.join(
+            os.path.dirname(__file__),
+            "..",
+            "..",
+            "..",
+            "equistore",
+            "tests",
+            "data.npz",
+        ),
+    )
+
+    check_tensor(loaded)
+
+
+def test_save(tmpdir):
     """Check that we can save and load a tensor to a file"""
     tmpfile = "serialize-test.npz"
+
+    tensor = utils.tensor(dtype=torch.float64)
 
     with tmpdir.as_cwd():
         equistore.torch.save(tmpfile, tensor)
@@ -55,6 +55,22 @@ def test_save(tmpdir, tensor):
     assert len(data.keys) == 4
 
 
-def test_pickle():
-    # TODO when we have save
-    pass
+def test_pickle(tmpdir):
+    tensor = equistore.torch.load(
+        os.path.join(
+            os.path.dirname(__file__),
+            "..",
+            "..",
+            "..",
+            "equistore",
+            "tests",
+            "data.npz",
+        ),
+    )
+    tmpfile = "serialize-test.npz"
+
+    with tmpdir.as_cwd():
+        torch.save(tensor, tmpfile)
+        loaded = torch.load(tmpfile)
+
+    check_tensor(loaded)

--- a/python/equistore-torch/tests/utils.py
+++ b/python/equistore-torch/tests/utils.py
@@ -3,10 +3,10 @@ import torch
 from equistore.torch import Labels, TensorBlock, TensorMap
 
 
-def tensor():
+def tensor(dtype=torch.float32, device="cpu"):
     """A dummy tensor map to be used in tests"""
     block_1 = TensorBlock(
-        values=torch.full((3, 1, 1), 1.0),
+        values=torch.full((3, 1, 1), 1.0, dtype=dtype, device=device),
         samples=Labels(["s"], torch.IntTensor([[0], [2], [4]])),
         components=[Labels(["c"], torch.IntTensor([[0]]))],
         properties=Labels(["p"], torch.IntTensor([[0]])),
@@ -15,14 +15,14 @@ def tensor():
         parameter="g",
         gradient=TensorBlock(
             samples=Labels(["sample", "g"], torch.IntTensor([[0, -2], [2, 3]])),
-            values=torch.full((2, 1, 1), 11.0),
+            values=torch.full((2, 1, 1), 11.0, dtype=dtype, device=device),
             components=block_1.components,
             properties=block_1.properties,
         ),
     )
 
     block_2 = TensorBlock(
-        values=torch.full((3, 1, 3), 2.0),
+        values=torch.full((3, 1, 3), 2.0, dtype=dtype, device=device),
         samples=Labels(["s"], torch.IntTensor([[0], [1], [3]])),
         components=[Labels(["c"], torch.IntTensor([[0]]))],
         properties=Labels(["p"], torch.IntTensor([[3], [4], [5]])),
@@ -30,7 +30,7 @@ def tensor():
     block_2.add_gradient(
         parameter="g",
         gradient=TensorBlock(
-            values=torch.full((3, 1, 3), 12.0),
+            values=torch.full((3, 1, 3), 12.0, dtype=dtype, device=device),
             samples=Labels(
                 ["sample", "g"], torch.IntTensor([[0, -2], [0, 3], [2, -2]])
             ),
@@ -40,7 +40,7 @@ def tensor():
     )
 
     block_3 = TensorBlock(
-        values=torch.full((4, 3, 1), 3.0),
+        values=torch.full((4, 3, 1), 3.0, dtype=dtype, device=device),
         samples=Labels(["s"], torch.IntTensor([[0], [3], [6], [8]])),
         components=[Labels(["c"], torch.IntTensor([[0], [1], [2]]))],
         properties=Labels(["p"], torch.IntTensor([[0]])),
@@ -48,7 +48,7 @@ def tensor():
     block_3.add_gradient(
         parameter="g",
         gradient=TensorBlock(
-            values=torch.full((1, 3, 1), 13.0),
+            values=torch.full((1, 3, 1), 13.0, dtype=dtype, device=device),
             samples=Labels(["sample", "g"], torch.IntTensor([[1, -2]])),
             components=block_3.components,
             properties=block_3.properties,
@@ -56,7 +56,7 @@ def tensor():
     )
 
     block_4 = TensorBlock(
-        values=torch.full((4, 3, 1), 4.0),
+        values=torch.full((4, 3, 1), 4.0, dtype=dtype, device=device),
         samples=Labels(["s"], torch.IntTensor([[0], [1], [2], [5]])),
         components=[Labels(["c"], torch.IntTensor([[0], [1], [2]]))],
         properties=Labels(["p"], torch.IntTensor([[0]])),
@@ -64,7 +64,7 @@ def tensor():
     block_4.add_gradient(
         parameter="g",
         gradient=TensorBlock(
-            values=torch.full((2, 3, 1), 14.0),
+            values=torch.full((2, 3, 1), 14.0, dtype=dtype, device=device),
             samples=Labels(["sample", "g"], torch.IntTensor([[0, 1], [3, 3]])),
             components=block_4.components,
             properties=block_4.properties,
@@ -79,13 +79,13 @@ def tensor():
     return TensorMap(keys, [block_1, block_2, block_3, block_4])
 
 
-def large_tensor():
-    t = tensor()
+def large_tensor(dtype=torch.float32, device="cpu"):
+    t = tensor(dtype=dtype, device=device)
     blocks = [block.copy() for _, block in t.items()]
 
     for i in range(8):
         block = TensorBlock(
-            values=torch.full((4, 3, 1), 4.0),
+            values=torch.full((4, 3, 1), 4.0, dtype=dtype, device=device),
             samples=Labels(["s"], torch.IntTensor([[0], [1], [4], [5]])),
             components=[Labels(["c"], torch.IntTensor([[0], [1], [2]]))],
             properties=Labels(["p"], torch.IntTensor([[i]])),
@@ -93,7 +93,7 @@ def large_tensor():
         block.add_gradient(
             parameter="g",
             gradient=TensorBlock(
-                values=torch.full((2, 3, 1), 14.0),
+                values=torch.full((2, 3, 1), 14.0, dtype=dtype, device=device),
                 samples=Labels(["sample", "g"], torch.IntTensor([[0, 1], [3, 3]])),
                 components=block.components,
                 properties=block.properties,

--- a/python/scripts/generate-declarations.py
+++ b/python/scripts/generate-declarations.py
@@ -144,6 +144,8 @@ def type_to_ctypes(type):
                 name = _typedecl_name(type.type.type)
                 if name == "char":
                     return "POINTER(ctypes.c_char_p)"
+                elif name == "uint8_t":
+                    return "POINTER(ctypes.c_char_p)"
 
                 name = c_type_name(name)
                 return f"POINTER(POINTER({name}))"

--- a/python/scripts/generate-declarations.py
+++ b/python/scripts/generate-declarations.py
@@ -105,6 +105,8 @@ def c_type_name(name):
         return "c_uintptr_t"
     elif name == "void":
         return "None"
+    elif name == "uint8_t":
+        return "ctypes.c_uint8"
     elif name == "int32_t":
         return "ctypes.c_int32"
     elif name == "uint32_t":
@@ -155,6 +157,8 @@ def type_to_ctypes(type):
             if name == "void":
                 return "ctypes.c_void_p"
             elif name == "char":
+                return "ctypes.c_char_p"
+            elif name == "uint8_t":
                 return "ctypes.c_char_p"
             else:
                 return f"POINTER({c_type_name(name)})"

--- a/python/scripts/include/stdint.h
+++ b/python/scripts/include/stdint.h
@@ -2,4 +2,5 @@ typedef int uint64_t;
 typedef int int64_t;
 typedef int int32_t;
 typedef int uint32_t;
+typedef int uint8_t;
 typedef int uintptr_t;


### PR DESCRIPTION
Part of #133 
Fix #94

This allow implementing the Pickle protocol without writing to a file first, and to reduce the number of copies when loading data/sharing data with other python processes.

<!-- readthedocs-preview equistore start -->
----
:books: Documentation preview :books:: https://equistore--298.org.readthedocs.build/en/298/

<!-- readthedocs-preview equistore end -->