### PR TITLE
Add operations for manipulating meta data

### DIFF
--- a/docs/src/reference/operations/manipulation/index.rst
+++ b/docs/src/reference/operations/manipulation/index.rst
@@ -9,6 +9,7 @@ Manipulation operations
     one_hot() <one-hot>
     slice() <slice>
     split() <split>
-    [sum/mean/std/variance]_over_samples()  <samples-reduction>
+    [sum/mean/std/variance]_over_samples() <samples-reduction>
     remove_gradients() <remove-gradients>
+    [append/insert/rename/remove]_dimension() <manipulate-dimension>
     to() <to>

--- a/docs/src/reference/operations/manipulation/manipulate-dimension.rst
+++ b/docs/src/reference/operations/manipulation/manipulate-dimension.rst
@@ -1,0 +1,1 @@
+.. automodule:: equistore.operations.manipulate_dimension

--- a/equistore-torch/include/equistore/torch/labels.hpp
+++ b/equistore-torch/include/equistore/torch/labels.hpp
@@ -79,6 +79,18 @@ public:
         return values_;
     }
 
+    /// Append a new dimension with the given `name` and `values`  to the end of these `Labels`
+    TorchLabels append(std::string name, torch::Tensor values);
+
+    /// Insert a new dimension with the given `name` and `values` before `index` in these `Labels`
+    TorchLabels insert(int64_t index, std::string name, torch::Tensor values);
+
+    /// Remove `name` from the dimensions of these `Labels`
+    TorchLabels remove(std::string name);
+
+    /// Rename `old_name` dimensions in these Labels to `new_name`
+    TorchLabels rename(std::string old_name, std::string new_name);
+
     /// Move the values for these Labels to the given `device`
     void to(torch::Device device);
 

--- a/equistore-torch/src/register.cpp
+++ b/equistore-torch/src/register.cpp
@@ -95,6 +95,10 @@ TORCH_LIBRARY(equistore, m) {
         }, DOCSTRING, {torch::arg("names")})
         .def_property("names", &LabelsHolder::names)
         .def_property("values", &LabelsHolder::values)
+        .def("append", &LabelsHolder::append, DOCSTRING, {torch::arg("name"), torch::arg("values")})
+        .def("insert", &LabelsHolder::insert, DOCSTRING, {torch::arg("index"), torch::arg("name"), torch::arg("values")})
+        .def("remove", &LabelsHolder::remove, DOCSTRING, {torch::arg("name")})
+        .def("rename", &LabelsHolder::rename, DOCSTRING, {torch::arg("old"), torch::arg("new")})
         .def("to", &LabelsHolder::to, DOCSTRING,
             {torch::arg("device")}
         )

--- a/python/equistore-core/tests/labels.py
+++ b/python/equistore-core/tests/labels.py
@@ -111,6 +111,44 @@ def test_custom_constructors():
         Labels.range(0, 1)
 
 
+def test_dimensions_manipulation():
+    label = Labels("foo", np.array([[42]]))
+
+    # Labels.insert
+    new_label = label.insert(0, name="bar", values=np.array([10]))
+    assert new_label.names == ["bar", "foo"]
+    np.testing.assert_equal(new_label.values, np.array([[10, 42]]))
+
+    with pytest.raises(ValueError, match="`values` must be a numpy ndarray"):
+        label.insert(0, name="bar", values=[10])
+
+    with pytest.raises(ValueError, match="`values` must be a 1D array"):
+        label.insert(0, name="bar", values=np.array([[10]]))
+
+    # Labels.append
+    new_label = label.append(name="bar", values=np.array([10]))
+    assert new_label.names == ["foo", "bar"]
+    np.testing.assert_equal(new_label.values, np.array([[42, 10]]))
+
+    # Labels.remove
+    removed_label = new_label.remove(name="bar")
+    assert removed_label == label
+
+    with pytest.raises(
+        ValueError, match=r"'baz' not found in the dimensions of these Labels"
+    ):
+        new_label.remove(name="baz")
+
+    # Labels.rename
+    new_label = label.rename("foo", "bar")
+    assert new_label.names == ["bar"]
+
+    with pytest.raises(
+        ValueError, match=r"'baz' not found in the dimensions of these Labels"
+    ):
+        new_label.rename("baz", "foo")
+
+
 def test_view():
     labels = Labels(names=("aaa", "bbb"), values=np.array([[1, 2], [3, 4]]))
 

--- a/python/equistore-operations/equistore/operations/__init__.py
+++ b/python/equistore-operations/equistore/operations/__init__.py
@@ -44,6 +44,12 @@ from .equal_metadata import (
 )
 from .join import join
 from .lstsq import lstsq
+from .manipulate_dimension import (
+    append_dimension,
+    remove_dimension,
+    rename_dimension,
+    insert_dimension,
+)
 from .multiply import multiply
 from .one_hot import one_hot
 from .ones_like import ones_like, ones_like_block
@@ -77,6 +83,7 @@ __all__ = [
     "allclose_block",
     "allclose_block_raise",
     "allclose_raise",
+    "append_dimension",
     "block_from_array",
     "block_to",
     "checks_enabled",
@@ -93,6 +100,7 @@ __all__ = [
     "equal_metadata_block_raise",
     "equal_metadata_raise",
     "equal_raise",
+    "insert_dimension",
     "join",
     "lstsq",
     "mean_over_samples",
@@ -105,6 +113,8 @@ __all__ = [
     "random_uniform_like",
     "random_uniform_like_block",
     "remove_gradients",
+    "remove_dimension",
+    "rename_dimension",
     "slice",
     "slice_block",
     "solve",

--- a/python/equistore-operations/equistore/operations/manipulate_dimension.py
+++ b/python/equistore-operations/equistore/operations/manipulate_dimension.py
@@ -1,0 +1,311 @@
+"""
+Manipulating TensorMap dimensions
+=================================
+
+Functions for manipulating dimensions of a :py:class:`equistore.TensorMap` (i.e.
+changing the columns of the :py:class:`equistore.Labels` within).
+
+.. autofunction:: equistore.append_dimension
+
+.. autofunction:: equistore.insert_dimension
+
+.. autofunction:: equistore.remove_dimension
+
+.. autofunction:: equistore.rename_dimension
+"""
+import numpy as np
+
+from equistore.core import TensorBlock, TensorMap
+
+
+def _check_axis(axis: str):
+    if axis not in ["keys", "samples", "properties"]:
+        raise ValueError(
+            f"{axis} is not a valid axis. Choose from 'keys', 'samples' or 'properties'"
+        )
+
+
+def append_dimension(
+    tensor: TensorMap,
+    axis: str,
+    name: str,
+    values: np.ndarray,
+) -> TensorMap:
+    """Append a :py:class:`equistore.Labels` dimension along the given axis.
+
+    For ``axis=="samples"`` the new dimension is `not` appended to gradients.
+
+    :param tensor: the input :py:class:`TensorMap`.
+    :param axis: axis for which the ``name`` should be appended. Allowed are ``"keys"``,
+                 ``"properties"`` or ``"samples"``.
+    :param name: name of the dimension be appended
+    :param values: values of the dimension to be appended
+
+
+    :raises ValueError: if ``axis`` is a not valid value
+
+    :return: a new :py:class:`equistore.TensorMap` with appended labels dimension.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> import equistore
+    >>> values = np.array([[1, 2], [3, 4]])
+    >>> block = equistore.block_from_array(values)
+    >>> keys = equistore.Labels(["foo"], np.array([[0]]))
+    >>> tensor = equistore.TensorMap(keys=keys, blocks=[block])
+    >>> tensor
+    TensorMap with 1 blocks
+    keys: foo
+           0
+    >>> equistore.append_dimension(
+    ...     tensor, name="bar", values=np.array([1]), axis="keys"
+    ... )
+    TensorMap with 1 blocks
+    keys: foo  bar
+           0    1
+    """
+    kwargs = dict(tensor=tensor, axis=axis, name=name, values=values)
+    if axis == "keys":
+        index = len(tensor.keys.names)
+        return insert_dimension(index=index, **kwargs)
+    elif axis == "samples":
+        index = len(tensor.sample_names)
+        return insert_dimension(index=index, **kwargs)
+    elif axis == "properties":
+        index = len(tensor.property_names)
+        return insert_dimension(index=index, **kwargs)
+    else:
+        raise ValueError(
+            f"{axis} is not a valid axis. Choose from 'keys', 'samples' or 'properties'"
+        )
+
+
+def insert_dimension(
+    tensor: TensorMap,
+    axis: str,
+    index: int,
+    name: str,
+    values: np.ndarray,
+) -> TensorMap:
+    """Insert a :py:class:`equistore.Labels` dimension along the given axis before the
+    given index.
+
+    For ``axis=="samples"`` a new dimension is `not` appended to gradients.
+
+    :param tensor: the input :py:class:`TensorMap`.
+    :param axis: axis for which the ``name`` should be inserted. Allowed are ``"keys"``,
+                 ``"properties"`` or ``"samples"``.
+    :param index: index before the new dimension is inserted.
+    :param name: the name to be inserted
+    :param values: values to be inserted
+
+    :raises ValueError: if ``axis`` is a not valid value
+
+    :return: a new :py:class:`equistore.TensorMap` with inserted labels dimension.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> import equistore
+    >>> values = np.array([[1, 2], [3, 4]])
+    >>> block = equistore.block_from_array(values)
+    >>> keys = equistore.Labels(["foo"], np.array([[0]]))
+    >>> tensor = equistore.TensorMap(keys=keys, blocks=[block])
+    >>> tensor
+    TensorMap with 1 blocks
+    keys: foo
+           0
+    >>> equistore.insert_dimension(
+    ...     tensor, index=0, name="bar", values=np.array([1]), axis="keys"
+    ... )
+    TensorMap with 1 blocks
+    keys: bar  foo
+           1    0
+    """
+    _check_axis(axis)
+
+    keys = tensor.keys
+    if axis == "keys":
+        keys = keys.insert(index=index, name=name, values=values)
+
+    blocks = []
+    for block in tensor:
+        samples = block.samples
+        properties = block.properties
+
+        if axis == "samples":
+            samples = samples.insert(index=index, name=name, values=values)
+        elif axis == "properties":
+            properties = properties.insert(index=index, name=name, values=values)
+
+        new_block = TensorBlock(
+            values=block.values,
+            samples=samples,
+            components=block.components,
+            properties=properties,
+        )
+
+        for parameter, gradient in block.gradients():
+            new_block.add_gradient(
+                parameter=parameter,
+                gradient=TensorBlock(
+                    values=gradient.values,
+                    samples=gradient.samples,
+                    components=gradient.components,
+                    properties=properties,
+                ),
+            )
+
+        blocks.append(new_block)
+
+    return TensorMap(keys=keys, blocks=blocks)
+
+
+def remove_dimension(tensor: TensorMap, axis: str, name: str) -> TensorMap:
+    """Remove a :py:class:`equistore.Labels` dimension along the given axis.
+
+    Removal can only be performed if the resulting :py:class:`equistore.Labels`
+    instance will be unique.
+
+    For ``axis=="samples"`` the dimension is not removed from gradients.
+
+    :param tensor: the input :py:class:`TensorMap`.
+    :param axis: axis for which ``name`` should be removed. Allowed are ``"keys"``,
+                 ``"properties"`` or ``"samples"``.
+    :param name: the :py:class:`equistore.Labels` name to be removed
+
+    :raises ValueError: if ``axis`` is a not valid value
+    :raises ValueError: if the only dimension should be removed
+    :raises ValueError: if name is not part of the axis
+
+    :return: a new :py:class:`equistore.TensorMap` with removed labels dimension.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> import equistore
+    >>> values = np.array([[1, 2], [3, 4]])
+    >>> block = equistore.block_from_array(values)
+    >>> keys = equistore.Labels(["key", "extra"], np.array([[0, 0]]))
+    >>> tensor = equistore.TensorMap(keys=keys, blocks=[block])
+    >>> tensor
+    TensorMap with 1 blocks
+    keys: key  extra
+           0     0
+    >>> equistore.remove_dimension(tensor, axis="keys", name="extra")
+    TensorMap with 1 blocks
+    keys: key
+           0
+    """
+    _check_axis(axis)
+
+    keys = tensor.keys
+    if axis == "keys":
+        keys = keys.remove(name=name)
+
+    blocks = []
+    for block in tensor:
+        samples = block.samples
+        properties = block.properties
+
+        if axis == "samples":
+            samples = samples.remove(name)
+        elif axis == "properties":
+            properties = properties.remove(name)
+
+        new_block = TensorBlock(
+            values=block.values,
+            samples=samples,
+            components=block.components,
+            properties=properties,
+        )
+
+        for parameter, gradient in block.gradients():
+            new_block.add_gradient(
+                parameter=parameter,
+                gradient=TensorBlock(
+                    values=gradient.values,
+                    samples=gradient.samples,
+                    components=gradient.components,
+                    properties=properties,
+                ),
+            )
+
+        blocks.append(new_block)
+
+    return TensorMap(keys=keys, blocks=blocks)
+
+
+def rename_dimension(tensor: TensorMap, axis: str, old: str, new: str) -> TensorMap:
+    """Rename a :py:class:`equistore.Labels` dimension name for a given axis.
+
+    :param tensor: the input :py:class:`TensorMap`.
+    :param axis: axis for which the names should be appended. Allowed are ``"keys"``,
+                 ``"properties"`` or ``"samples"``.
+    :param old: name to be replaced
+    :param new: name after the replacement
+
+    :raises ValueError: if ``axis`` is a not valid value
+
+    :return: a `new` :py:class:`equistore.TensorMap` with renamed labels dimension.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> import equistore
+    >>> values = np.array([[1, 2], [3, 4]])
+    >>> block = equistore.block_from_array(values)
+    >>> keys = equistore.Labels(["foo"], np.array([[0]]))
+    >>> tensor = equistore.TensorMap(keys=keys, blocks=[block])
+    >>> tensor
+    TensorMap with 1 blocks
+    keys: foo
+           0
+    >>> equistore.rename_dimension(tensor, axis="keys", old="foo", new="bar")
+    TensorMap with 1 blocks
+    keys: bar
+           0
+
+    """
+    _check_axis(axis)
+
+    keys = tensor.keys
+    if axis == "keys":
+        keys = keys.rename(old, new)
+
+    blocks = []
+    for block in tensor:
+        samples = block.samples
+        properties = block.properties
+
+        if axis == "samples":
+            samples = samples.rename(old, new)
+        elif axis == "properties":
+            properties = properties.rename(old, new)
+
+        new_block = TensorBlock(
+            values=block.values,
+            samples=samples,
+            components=block.components,
+            properties=properties,
+        )
+
+        for parameter, gradient in block.gradients():
+            gradient_samples = gradient.samples
+            if axis == "samples" and old in gradient_samples.names:
+                gradient_samples = gradient_samples.rename(old, new)
+
+            new_block.add_gradient(
+                parameter=parameter,
+                gradient=TensorBlock(
+                    values=gradient.values,
+                    samples=gradient_samples,
+                    components=gradient.components,
+                    properties=properties,
+                ),
+            )
+
+        blocks.append(new_block)
+
+    return TensorMap(keys=keys, blocks=blocks)

--- a/python/equistore-operations/tests/manipulate_labels_column.py
+++ b/python/equistore-operations/tests/manipulate_labels_column.py
@@ -1,0 +1,236 @@
+import os
+
+import numpy as np
+import pytest
+from numpy.testing import assert_equal
+
+import equistore
+from equistore import Labels, TensorBlock, TensorMap
+
+
+DATA_ROOT = os.path.join(os.path.dirname(__file__), "data")
+
+
+def tensor():
+    return equistore.load(
+        os.path.join(DATA_ROOT, "qm7-power-spectrum.npz"), use_numpy=True
+    )
+
+
+def tensor_extra():
+    """TensorMap with gradient containing extra columns in keys, samples, properties"""
+    block = TensorBlock(
+        values=np.array([[42]]),
+        samples=Labels(["sample", "extra"], np.array([[0, 0]])),
+        components=[],
+        properties=Labels(["properties", "extra"], np.array([[0, 0]])),
+    )
+
+    block.add_gradient("gradient", block.copy())
+
+    keys = Labels(["keys", "extra"], np.array([[0, 0]]))
+    return TensorMap(keys=keys, blocks=[block])
+
+
+def test_append_keys():
+    values = np.arange(17)
+    new_tensor = equistore.append_dimension(
+        tensor(),
+        axis="keys",
+        name="foo",
+        values=values,
+    )
+
+    assert new_tensor.keys.names[-1] == "foo"
+    assert_equal(new_tensor.keys.values[:, -1], values)
+
+
+def test_append_samples():
+    values = np.array([42])
+    new_tensor = equistore.append_dimension(
+        tensor_extra(),
+        axis="samples",
+        name="foo",
+        values=values,
+    )
+
+    assert new_tensor.sample_names[-1] == "foo"
+
+    for block in new_tensor:
+        assert block.samples.values[:, -1] == values
+
+
+def test_append_properties():
+    values = np.arange(80)
+    new_tensor = equistore.append_dimension(
+        tensor(),
+        axis="properties",
+        name="foo",
+        values=values,
+    )
+
+    assert new_tensor.property_names[-1] == "foo"
+
+    for block in new_tensor:
+        assert_equal(block.properties.values[:, -1], values)
+
+        for _, gradient in block.gradients():
+            assert gradient.properties.names[-1] == "foo"
+            assert_equal(gradient.properties.values[:, -1], values)
+
+
+def test_append_unknown_axis():
+    with pytest.raises(ValueError, match="foo is not a valid axis."):
+        equistore.append_dimension(tensor(), axis="foo", name="foo", values=10)
+
+
+def test_insert_keys():
+    values = np.arange(17)
+    index = 0
+    new_tensor = equistore.insert_dimension(
+        tensor(),
+        axis="keys",
+        index=index,
+        name="foo",
+        values=values,
+    )
+
+    assert new_tensor.keys.names[index] == "foo"
+    assert_equal(new_tensor.keys.values[:, index], values)
+
+
+def test_insert_samples():
+    values = np.array([42])
+    index = 0
+    new_tensor = equistore.insert_dimension(
+        tensor_extra(),
+        axis="samples",
+        index=index,
+        name="foo",
+        values=values,
+    )
+
+    assert new_tensor.sample_names[index] == "foo"
+
+    for block in new_tensor:
+        assert block.samples.values[:, index] == values
+
+
+def test_insert_properties():
+    values = np.arange(80)
+    index = 0
+    new_tensor = equistore.insert_dimension(
+        tensor(),
+        axis="properties",
+        index=index,
+        name="foo",
+        values=values,
+    )
+
+    assert new_tensor.property_names[index] == "foo"
+
+    for block in new_tensor:
+        assert_equal(block.properties.values[:, index], values)
+
+        for _, gradient in block.gradients():
+            assert gradient.properties.names[index] == "foo"
+            assert_equal(gradient.properties.values[:, index], np.arange(80))
+
+
+def test_insert_unknown_axis():
+    with pytest.raises(ValueError, match="foo is not a valid axis."):
+        equistore.insert_dimension(tensor(), axis="foo", index=0, name="foo", values=10)
+
+
+def test_rename_keys():
+    old = tensor().keys.names[0]
+
+    new_tensor = equistore.rename_dimension(tensor(), axis="keys", old=old, new="foo")
+    assert new_tensor.keys.names[0] == "foo"
+
+
+def test_rename_samples():
+    new_tensor = equistore.rename_dimension(
+        tensor(), old="structure", new="foo", axis="samples"
+    )
+    assert new_tensor.sample_names[0] == "foo"
+
+    for block in new_tensor:
+        for parameter, gradient in block.gradients():
+            if parameter == "positions":
+                gradient_sample_names = ["sample", "foo", "atom"]
+            elif parameter == "cell":
+                gradient_sample_names = ["sample"]
+            assert gradient.samples.names == gradient_sample_names
+
+
+def test_rename_properties():
+    old = tensor().property_names[0]
+
+    new_tensor = equistore.rename_dimension(
+        tensor(),
+        axis="properties",
+        old=old,
+        new="foo",
+    )
+    assert new_tensor.property_names[0] == "foo"
+
+    for block in new_tensor:
+        for _, gradient in block.gradients():
+            assert gradient.properties.names[0] == "foo"
+
+
+def test_rename_unknown_axis():
+    with pytest.raises(ValueError, match="foo is not a valid axis."):
+        equistore.rename_dimension(
+            tensor(),
+            axis="foo",
+            old="foo",
+            new="foo",
+        )
+
+
+def test_remove_keys():
+    new_tensor = equistore.remove_dimension(tensor_extra(), axis="keys", name="extra")
+    assert new_tensor.keys.names == ["keys"]
+
+
+def test_remove_samples():
+    new_tensor = equistore.remove_dimension(
+        tensor_extra(),
+        axis="samples",
+        name="extra",
+    )
+    assert new_tensor.sample_names == ["sample"]
+
+
+def test_remove_properties():
+    new_tensor = equistore.remove_dimension(
+        tensor_extra(),
+        axis="properties",
+        name="extra",
+    )
+    assert new_tensor.property_names == ["properties"]
+
+    for block in new_tensor:
+        for _, gradient in block.gradients():
+            assert gradient.properties.names == ["properties"]
+
+
+def test_remove_unknown_axis():
+    with pytest.raises(ValueError, match="foo is not a valid axis."):
+        equistore.remove_dimension(
+            tensor(),
+            axis="foo",
+            name="foo",
+        )
+
+
+def test_not_unique_after():
+    """Test error raise if the the labels after the removal would be not valid."""
+    match = (
+        r"invalid parameter: can not have the same label value multiple time: \[1, 1\] "
+        r"is already present at position 0"
+    )
+    with pytest.raises(equistore.core.status.EquistoreError, match=match):
+        equistore.remove_dimension(tensor(), name="species_center", axis="keys")

--- a/python/equistore-torch/equistore/torch/documentation.py
+++ b/python/equistore-torch/equistore/torch/documentation.py
@@ -298,6 +298,111 @@ class Labels:
         different values)
         """
 
+    def append(self, name: str, values: torch.Tensor) -> "Labels":
+        """Append a new dimension to the end of the :py:class:`Labels`.
+
+        :param name: name of the new dimension
+        :param values: 1D array of values for the new dimension
+
+        >>> import torch
+        >>> from equistore.torch import Labels
+        >>> label = Labels("foo", torch.tensor([[42]]))
+        >>> print(label)
+        Labels(
+            foo
+            42
+        )
+        >>> print(label.append(name="bar", values=torch.tensor([10])))
+        Labels(
+            foo  bar
+            42   10
+        )
+        """
+
+    def insert(self, index: int, name: str, values: torch.Tensor) -> "Labels":
+        """Insert a new dimension before ``index`` in the :py:class:`Labels`.
+
+        :param index: index before the new dimension is inserted
+        :param name: name of the new dimension
+        :param values: 1D array of values for the new dimension
+
+        >>> import torch
+        >>> from equistore.torch import Labels
+        >>> label = Labels("foo", torch.tensor([[42]]))
+        >>> print(label)
+        Labels(
+            foo
+            42
+        )
+        >>> print(label.insert(0, name="bar", values=torch.tensor([10])))
+        Labels(
+            bar  foo
+            10   42
+        )
+        """
+
+    def remove(self, name: str) -> "Labels":
+        """Remove ``name`` from the dimensions of the :py:class:`Labels`.
+
+        Removal can only be performed if the resulting :py:class:`Labels` instance will
+        be unique.
+
+        :param name: name to be removed
+        :raises ValueError: if the name is not present.
+
+        >>> import torch
+        >>> from equistore.torch import Labels
+        >>> label = Labels(["foo", "bar"], torch.tensor([[42, 10]]))
+        >>> print(label)
+        Labels(
+            foo  bar
+            42   10
+        )
+        >>> print(label.remove(name="bar"))
+        Labels(
+            foo
+            42
+        )
+
+        If the new :py:class:`Labels` is not unique an error is raised.
+
+        >>> label = Labels(["foo", "bar"], torch.tensor([[42, 10], [42, 11]]))
+        >>> print(label)
+        Labels(
+            foo  bar
+            42   10
+            42   11
+        )
+        >>> try:
+        ...     label.remove(name="bar")
+        ... except RuntimeError as e:
+        ...     print(e)
+        ...
+        invalid parameter: can not have the same label value multiple time: [42] is already present at position 0
+        """  # noqa E501
+
+    def rename(self, old: str, new: str) -> "Labels":
+        """Rename the ``old`` dimension to ``new`` in the :py:class:`Labels`.
+
+        :param old: name to be replaced
+        :param new: name after the replacement
+        :raises ValueError: if old is not present.
+
+        >>> import torch
+        >>> from equistore.torch import Labels
+        >>> label = Labels("foo", torch.tensor([[42]]))
+        >>> print(label)
+        Labels(
+            foo
+            42
+        )
+        >>> print(label.rename("foo", "bar"))
+        Labels(
+            bar
+            42
+        )
+        """
+
     def to(self, device):
         """move the values for these Labels to the given ``device``"""
 


### PR DESCRIPTION
This PR adds an operations to manipulate Labels as well as the Labels columns stored in TensorMaps as `keys`, `samples` or `properties`.

<!-- readthedocs-preview equistore start -->
----
:books: Documentation preview :books:: https://equistore--299.org.readthedocs.build/en/299/

<!-- readthedocs-preview equistore end -->