### PR TITLE
Remove 'tensor' of a joined TensorMap if possible

### DIFF
--- a/python/equistore-operations/equistore/operations/join.py
+++ b/python/equistore-operations/equistore/operations/join.py
@@ -7,29 +7,184 @@ import numpy as np
 from equistore.core import Labels, TensorBlock, TensorMap
 
 from ._utils import _check_same_keys
+from .manipulate_dimension import remove_dimension
 
 
-def join(tensors: List[TensorMap], axis: str):
+def _disjoint_tensor_labels(tensors: List[TensorMap], axis: str) -> bool:
+    """Checks if all labels in a list of TensorMaps are disjoint.
+
+    We have to perform a check from all tensors to all others to ensure it
+    they are "fully" disjoint.
+    """
+    for i_tensor, first_tensor in enumerate(tensors[:-1]):
+        for second_tensor in tensors[i_tensor + 1 :]:
+            for key, first_block in first_tensor.items():
+                second_block = second_tensor.block(key)
+                if axis == "samples":
+                    first_labels = first_block.samples
+                    second_labels = second_block.samples
+                elif axis == "properties":
+                    first_labels = first_block.properties
+                    second_labels = second_block.properties
+
+                if len(first_labels.intersection(second_labels)):
+                    return False
+
+    return True
+
+
+def join(
+    tensors: List[TensorMap], axis: str, remove_tensor_name: bool = False
+) -> TensorMap:
     """Join a sequence of :py:class:`TensorMap` along an axis.
 
-    The ``axis`` parameter specifies the type join. For example, if
-    ``axis='properties'`` it will be the `tensor_maps` will be joined along the
+    The ``axis`` parameter specifies the type of joining. For example, if
+    ``axis='properties'`` the tensor maps in `tensors` will be joined along the
     `properties` dimension and for ``axis='samples'`` they will be the along the
-    samples dimension.
-
-    ``join`` will create an additional label `tensor` specifiying the original index in
-    the list of `tensor_maps`.  If `sample`/`property` names are not the same in all
-    `tensor_maps` they will be unified with a general name ``"property"``.
+    `samples` dimension.
 
     :param tensors:
         sequence of :py:class:`TensorMap` for join
     :param axis:
         A string indicating how the tensormaps are stacked. Allowed
         values are ``'properties'`` or ``'samples'``.
+    :param remove_tensor_name:
+        Remove the extra ``tensor`` dimension from labels if possible. See examples
+        above for the case where this is applicable.
 
     :return tensor_joined:
         The stacked :py:class:`TensorMap` with more properties or samples
         than the input TensorMap.
+
+    Examples
+    --------
+    Possible clashes of the meta data like ``samples``/``properties`` will be resolved
+    by one of the three following strategies:
+
+    1. If Labels names are the same, the values are unique and
+       ``remove_tensor_name=True`` we keep the names and join the values
+
+       >>> import numpy as np
+       >>> import equistore
+       >>> from equistore import Labels, TensorBlock, TensorMap
+
+       >>> values = np.array([[1.1, 2.1, 3.1]])
+       >>> samples = Labels("sample", np.array([[0]]))
+
+       Define two disjoint :py:class:`Labels`.
+
+       >>> properties_1 = Labels("n", np.array([[0], [2], [3]]))
+       >>> properties_2 = Labels("n", np.array([[1], [4], [5]]))
+
+       >>> block_1 = TensorBlock(
+       ...     values=values,
+       ...     samples=Labels.single(),
+       ...     components=[],
+       ...     properties=properties_1,
+       ... )
+       >>> block_2 = TensorBlock(
+       ...     values=values,
+       ...     samples=Labels.single(),
+       ...     components=[],
+       ...     properties=properties_2,
+       ... )
+
+       >>> tensor_1 = TensorMap(keys=Labels.single(), blocks=[block_1])
+       >>> tensor_2 = TensorMap(keys=Labels.single(), blocks=[block_2])
+
+       joining along the properties leads
+
+       >>> joined_tensor = equistore.join(
+       ...     [tensor_1, tensor_2], axis="properties", remove_tensor_name=True
+       ... )
+       >>> joined_tensor[0].properties
+       Labels(
+           n
+           0
+           2
+           3
+           1
+           4
+           5
+       )
+
+       If ``remove_tensor_name=False`` There will be an extra dimension ``tensor``
+       added
+
+       >>> joined_tensor = equistore.join(
+       ...     [tensor_1, tensor_2], axis="properties", remove_tensor_name=False
+       ... )
+       >>> joined_tensor[0].properties
+       Labels(
+           tensor  n
+             0     0
+             0     2
+             0     3
+             1     1
+             1     4
+             1     5
+       )
+
+    2. If Labels names are the same but the values are not unique, a new dimension
+       ``"tensor"`` is added to the names.
+
+       >>> properties_3 = Labels("n", np.array([[0], [2], [3]]))
+
+       ``properties_3`` has the same name and also shares values with ``properties_1``
+       as defined above.
+
+       >>> block_3 = TensorBlock(
+       ...     values=values,
+       ...     samples=Labels.single(),
+       ...     components=[],
+       ...     properties=properties_3,
+       ... )
+       >>> tensor_3 = TensorMap(keys=Labels.single(), blocks=[block_3])
+
+       joining along properties leads to
+
+       >>> joined_tensor = equistore.join([tensor_1, tensor_3], axis="properties")
+       >>> joined_tensor[0].properties
+       Labels(
+           tensor  n
+             0     0
+             0     2
+             0     3
+             1     0
+             1     2
+             1     3
+       )
+
+    3. If Labels names are different we change the names to ("tensor", "property"). This
+       case is only supposed to happen when joining in the property dimension, hence the
+       choice of names:
+
+       >>> properties_4 = Labels(["a", "b"], np.array([[0, 0], [1, 2], [1, 3]]))
+
+       ``properties_4`` has the different names compared to ``properties_1``
+       defined above.
+
+       >>> block_4 = TensorBlock(
+       ...     values=values,
+       ...     samples=Labels.single(),
+       ...     components=[],
+       ...     properties=properties_4,
+       ... )
+       >>> tensor_4 = TensorMap(keys=Labels.single(), blocks=[block_4])
+
+       joining along properties leads to
+
+        >>> joined_tensor = equistore.join([tensor_1, tensor_4], axis="properties")
+        >>> joined_tensor[0].properties
+        Labels(
+            tensor  property
+              0        0
+              0        1
+              0        2
+              1        0
+              1        1
+              1        2
+        )
     """
 
     if not isinstance(tensors, (list, tuple)):
@@ -126,7 +281,7 @@ def join(tensors: List[TensorMap], axis: str):
     else:
         tensor_joined = tensor.keys_to_properties("tensor")
 
-    # TODO: once we have functions to manipulate meta data we can try to
-    # remove the `tensor` label entry after joining.
-
-    return tensor_joined
+    if remove_tensor_name and _disjoint_tensor_labels(tensors, axis):
+        return remove_dimension(tensor_joined, name="tensor", axis=axis)
+    else:
+        return tensor_joined

--- a/python/equistore-operations/tests/join.py
+++ b/python/equistore-operations/tests/join.py
@@ -252,3 +252,36 @@ def test_join_samples_with_different_sample_names():
 
     with pytest.raises(ValueError, match="Sample names are not the same!"):
         equistore.join([tensor_map_a, tensor_map_b], axis="samples")
+
+
+def test_split_join_samples(tensor):
+    """Test if split and joining along `samples` results in the same TensorMap."""
+
+    labels_1 = Labels(names=["structure"], values=np.arange(4).reshape(-1, 1))
+    labels_2 = Labels(names=["structure"], values=np.arange(4, 10).reshape(-1, 1))
+
+    split_tensors = equistore.split(
+        tensor=tensor, axis="samples", grouped_labels=[labels_1, labels_2]
+    )
+    joined_tensor = equistore.join(
+        split_tensors, axis="samples", remove_tensor_name=True
+    )
+
+    assert joined_tensor == tensor
+
+
+def test_split_join_properties(tensor):
+    """Test if split and joining along `properties` results in the same TensorMap."""
+    properties = tensor[0].properties
+
+    labels_1 = Labels(names=properties.names, values=properties.values[:5])
+    labels_2 = Labels(names=properties.names, values=properties.values[5:])
+
+    split_tensors = equistore.split(
+        tensor=tensor, axis="properties", grouped_labels=[labels_1, labels_2]
+    )
+    joined_tensor = equistore.join(
+        split_tensors, axis="properties", remove_tensor_name=True
+    )
+
+    assert joined_tensor == tensor


### PR DESCRIPTION
Adds the functionality to `join` to remove the `"tensor"` column name while joining TensorMaps.

Due to torch-script I can not use a try-catch block like

```python
try:
    return remove_labels_column(tensor_joined, name="tensor", axis=axis)
except EquistoreError:
    return tensor_joined
```

Instead, I have to check the uniqueness on the Python level before calling `remove_labels_column`. If someone has an idea to get around the his I am happy to change this. 