### PR TITLE
Delete function to get references on rvalues in C++ API

### DIFF
--- a/equistore-core/tests/cpp/blocks.cpp
+++ b/equistore-core/tests/cpp/blocks.cpp
@@ -94,7 +94,7 @@ TEST_CASE("Blocks") {
         CHECK(gradient.properties() == Labels({"properties"}, {{5}, {3}}));
 
         CHECK_THROWS_WITH(
-            block.gradient("not there").values(),
+            block.gradient("not there"),
             "invalid parameter: can not find gradients with respect to 'not there' in this block"
         );
     }

--- a/equistore-core/tests/cpp/tensor.cpp
+++ b/equistore-core/tests/cpp/tensor.cpp
@@ -366,7 +366,8 @@ void check_loaded_tensor(equistore::TensorMap& tensor) {
     CHECK(samples.names()[0] == std::string("structure"));
     CHECK(samples.names()[1] == std::string("center"));
 
-    CHECK(block.values().shape() == std::vector<size_t>{9, 5, 3});
+    auto values = block.values();
+    CHECK(values.shape() == std::vector<size_t>{9, 5, 3});
 
     auto gradient = block.gradient("positions");
     samples = gradient.samples();
@@ -375,5 +376,6 @@ void check_loaded_tensor(equistore::TensorMap& tensor) {
     CHECK(samples.names()[1] == std::string("structure"));
     CHECK(samples.names()[2] == std::string("atom"));
 
-    CHECK(gradient.values().shape() == std::vector<size_t>{59, 3, 5, 3});
+    values = gradient.values();
+    CHECK(values.shape() == std::vector<size_t>{59, 3, 5, 3});
 }

--- a/equistore-torch/include/equistore/torch/array.hpp
+++ b/equistore-torch/include/equistore/torch/array.hpp
@@ -52,9 +52,9 @@ public:
 
     std::unique_ptr<equistore::DataArrayBase> create(std::vector<uintptr_t> shape) const override;
 
-    double* data() override;
+    double* data() & override;
 
-    const std::vector<uintptr_t>& shape() const override;
+    const std::vector<uintptr_t>& shape() const & override;
 
     void reshape(std::vector<uintptr_t> shape) override;
 

--- a/equistore-torch/src/array.cpp
+++ b/equistore-torch/src/array.cpp
@@ -56,7 +56,7 @@ std::unique_ptr<equistore::DataArrayBase> TorchDataArray::create(std::vector<uin
     ));
 }
 
-double* TorchDataArray::data() {
+double* TorchDataArray::data() & {
     if (!this->tensor_.device().is_cpu()) {
         C10_THROW_ERROR(ValueError, "can not access the data of a torch::Tensor not on CPU");
     }
@@ -75,7 +75,7 @@ double* TorchDataArray::data() {
     return static_cast<double*>(this->tensor_.data_ptr());
 }
 
-const std::vector<uintptr_t>& TorchDataArray::shape() const {
+const std::vector<uintptr_t>& TorchDataArray::shape() const & {
     return shape_;
 }
 


### PR DESCRIPTION
Otherwise we can get dangling references since the rvalue immediately goes out of scope. 

Previously, this code would silently result in an empty `sizes` vector:

```cpp
auto sizes = std::vector<size_t>();
for (auto size: block.values().shape()) {
    sizes.push_back(size);
}
```

Now, the code above fails to compile, and forces to put `block.values()` in a temporary.

<!-- readthedocs-preview equistore start -->
----
:books: Documentation preview :books:: https://equistore--302.org.readthedocs.build/en/302/

<!-- readthedocs-preview equistore end -->