### PR TITLE
Torch: get a single block without selection in `TensorMap.block`

### DIFF
--- a/equistore-torch/src/register.cpp
+++ b/equistore-torch/src/register.cpp
@@ -161,7 +161,7 @@ TORCH_LIBRARY(equistore, m) {
             {torch::arg("indices")}
         )
         .def("block", &TensorMapHolder::block_torch, DOCSTRING,
-            {torch::arg("selection")}
+            {torch::arg("selection") = torch::IValue()}
         )
         .def("blocks", &TensorMapHolder::blocks_torch, DOCSTRING,
             {torch::arg("selection") = torch::IValue()}

--- a/python/equistore-torch/equistore/torch/documentation.py
+++ b/python/equistore-torch/equistore/torch/documentation.py
@@ -763,7 +763,7 @@ class TensorMap:
 
     def block(
         self,
-        selection: Union[int, Labels, LabelsEntry, Dict[str, int]],
+        selection: Union[None, int, Labels, LabelsEntry, Dict[str, int]] = None,
     ) -> TensorBlock:
         """
         Get the single block in this :py:class:`TensorMap` matching the ``selection``.


### PR DESCRIPTION
Previously, `tensor.block()` would fail even if there is a single block in the TensorMap