### PR TITLE
Bump minimal rust version to 1.63

### DIFF
--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -35,7 +35,7 @@ jobs:
           # check the build on a stock Ubuntu 20.04, which uses cmake 3.16, and
           # with our minimal supported rust version
           - os: ubuntu-20.04
-            rust-version: 1.61
+            rust-version: 1.63
             container: ubuntu:20.04
             rust-target: x86_64-unknown-linux-gnu
             cargo-build-flags: --features=rayon

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -12,7 +12,7 @@ build:
   tools:
     # Set the version of Python and other tools we need
     python: "3.10"
-    rust: "1.64"
+    rust: "1.64"  # RDT does not offer our minimal version 1.63
   jobs:
     post_install:
       # install equistore-torch with the CPU version of PyTorch we can not use

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -12,7 +12,7 @@ build:
   tools:
     # Set the version of Python and other tools we need
     python: "3.10"
-    rust: "1.61"
+    rust: "1.64"
   jobs:
     post_install:
       # install equistore-torch with the CPU version of PyTorch we can not use

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -20,7 +20,7 @@ on equistore:
 - **the rust compiler**: you will need both ``rustc`` (the compiler) and
   ``cargo`` (associated build tool). You can install both using `rustup`_, or
   use a version provided by your operating system. We need at least Rust version
-  1.61 to build equistore.
+  1.63 to build equistore.
 - **Python**: you can install ``Python`` and ``pip`` from your operating system.
   We require a Python version of at least 3.7.
 - **tox**: a Python test runner, cf https://tox.readthedocs.io/en/latest/. You

--- a/equistore-core/Cargo.toml
+++ b/equistore-core/Cargo.toml
@@ -3,7 +3,7 @@ name = "equistore-core"
 version = "0.1.0"
 edition = "2021"
 publish = false
-rust-version = "1.61"
+rust-version = "1.63"
 exclude = [
     "tests"
 ]
@@ -16,7 +16,7 @@ crate-type = ["cdylib", "staticlib"]
 bench = false
 
 [dependencies]
-ahash = "0.7"
+ahash = "0.8"
 hashbrown = "0.13"
 indexmap = "1"
 once_cell = "1"

--- a/equistore/Cargo.toml
+++ b/equistore/Cargo.toml
@@ -2,7 +2,7 @@
 name = "equistore"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.61"
+rust-version = "1.63"
 include = [
     "build.rs",
     "src/",
@@ -28,4 +28,3 @@ static = []
 cmake = "0.1.49"
 which = "4"
 glob = "0.3"
-rustc_version = "0.4"

--- a/equistore/build.rs
+++ b/equistore/build.rs
@@ -1,10 +1,6 @@
 use std::path::PathBuf;
 use std::process::Command;
 
-fn rustc_version_at_least(version: &str) -> bool {
-    rustc_version::version().unwrap() >= rustc_version::Version::parse(version).unwrap()
-}
-
 fn main() {
     let mut equistore_core = PathBuf::from("../equistore-core");
 
@@ -61,8 +57,4 @@ fn main() {
     println!("cargo:rustc-link-search=native={}", install_dir.display());
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-changed={}", equistore_core.display());
-
-    if cfg!(feature = "static") && !rustc_version_at_least("1.63.0") {
-        println!("cargo:rustc-cfg=static_and_rustc_older_1_63");
-    }
 }

--- a/equistore/src/lib.rs
+++ b/equistore/src/lib.rs
@@ -29,13 +29,6 @@
 #![allow(clippy::missing_errors_doc, clippy::missing_panics_doc, clippy::missing_safety_doc)]
 #![allow(clippy::similar_names, clippy::borrow_as_ptr, clippy::uninlined_format_args)]
 
-#[cfg(all(test, static_and_rustc_older_1_63))]
-fn fail_build() {
-    // We need rustc>=1.63 for tests because of
-    // https://github.com/rust-lang/rust/issues/100066
-    compile_error!("the 'static' feature requires rustc>=1.63 for tests");
-}
-
 pub mod c_api;
 
 pub mod errors;

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -3,7 +3,7 @@ name = "equistore-python"
 version = "0.0.0"
 edition = "2021"
 publish = false
-rust-version = "1.61"
+rust-version = "1.63"
 
 [lib]
 path = "lib.rs"


### PR DESCRIPTION
Our dependencies are starting to do this as well (https://github.com/Stebalien/tempfile/pull/241) so we have to follow.

<!-- readthedocs-preview equistore start -->
----
:books: Documentation preview :books:: https://equistore--308.org.readthedocs.build/en/308/

<!-- readthedocs-preview equistore end -->