### PR TITLE
Adapt torch.TensorBlock gradients() as in core.TensorBlock

### DIFF
--- a/equistore-torch/include/equistore/torch/block.hpp
+++ b/equistore-torch/include/equistore/torch/block.hpp
@@ -107,7 +107,7 @@ public:
     TorchTensorBlock gradient(const std::string& parameter) const;
 
     /// Get a all gradients and associated parameters in this block
-    std::unordered_map<std::string, TorchTensorBlock> gradients();
+    std::vector<std::tuple<std::string, TorchTensorBlock>> gradients();
 
     /// Implementation of __repr__/__str__ for Python
     std::string __repr__() const;

--- a/equistore-torch/src/block.cpp
+++ b/equistore-torch/src/block.cpp
@@ -103,11 +103,10 @@ TorchTensorBlock TensorBlockHolder::gradient(const std::string& parameter) const
 
     return torch::make_intrusive<TensorBlockHolder>(block_.gradient(parameter), gradient_parameter);
 }
-
-std::unordered_map<std::string, TorchTensorBlock> TensorBlockHolder::gradients() {
-    auto result = std::unordered_map<std::string, TorchTensorBlock>();
+std::vector<std::tuple<std::string, TorchTensorBlock>> TensorBlockHolder::gradients() {
+    auto result = std::vector<std::tuple<std::string, TorchTensorBlock>>();
     for (const auto& parameter: this->gradients_list()) {
-        result.emplace(parameter, this->gradient(parameter));
+        result.push_back(std::make_tuple(parameter, this->gradient(parameter)));
     }
     return result;
 }

--- a/equistore-torch/tests/block.cpp
+++ b/equistore-torch/tests/block.cpp
@@ -74,7 +74,7 @@ TEST_CASE("Blocks") {
         CHECK(sample_names[1] == "g");
 
         for (const auto& entry: block.gradients()) {
-            CHECK(entry.first == "g");
+            CHECK(std::get<0>(entry) == "g");
         }
     }
 }

--- a/python/equistore-torch/tests/block.py
+++ b/python/equistore-torch/tests/block.py
@@ -1,4 +1,4 @@
-from typing import Dict, List
+from typing import List, Tuple
 
 import pytest
 import torch
@@ -159,8 +159,9 @@ def test_gradients():
         gradient = block.gradient("not-there")
 
     gradients = block.gradients()
-    assert isinstance(gradients, dict)
-    assert list(gradients.keys()) == ["g"]
+    assert isinstance(gradients, list)
+    assert len(gradients) == 1
+    assert gradients[0][0] == "g"
 
 
 # define a wrapper class to make sure the types TorchScript uses for of all
@@ -213,7 +214,7 @@ class TensorBlockWrap:
     def gradient(self, parameter: str) -> TensorBlock:
         return self._c.gradient(parameter=parameter)
 
-    def gradients(self) -> Dict[str, TensorBlock]:
+    def gradients(self) -> List[Tuple[str, TensorBlock]]:
         return self._c.gradients()
 
 


### PR DESCRIPTION
Am I missing something in core that prevents this change? Or do I "just" need to refactor all tests and functions

<!-- readthedocs-preview equistore start -->
----
:books: Documentation preview :books:: https://equistore--309.org.readthedocs.build/en/309/

<!-- readthedocs-preview equistore end -->