### PR TITLE
Add labels.permute and permute_dimension

### DIFF
--- a/docs/src/reference/operations/manipulation/index.rst
+++ b/docs/src/reference/operations/manipulation/index.rst
@@ -6,10 +6,10 @@ Manipulation operations
 
     drop_blocks() <drop-blocks>
     join() <join>
+    manipulate dimension <manipulate-dimension>
     one_hot() <one-hot>
+    remove_gradients() <remove-gradients>
+    samples reduction <samples-reduction>
     slice() <slice>
     split() <split>
-    [sum/mean/std/variance]_over_samples() <samples-reduction>
-    remove_gradients() <remove-gradients>
-    [append/insert/rename/remove]_dimension() <manipulate-dimension>
     to() <to>

--- a/equistore-torch/include/equistore/torch/labels.hpp
+++ b/equistore-torch/include/equistore/torch/labels.hpp
@@ -85,6 +85,9 @@ public:
     /// Insert a new dimension with the given `name` and `values` before `index` in these `Labels`
     TorchLabels insert(int64_t index, std::string name, torch::Tensor values);
 
+    /// Permute dimensions of these `Labels`
+    TorchLabels permute(std::vector<int64_t> dimensions_indexes);
+
     /// Remove `name` from the dimensions of these `Labels`
     TorchLabels remove(std::string name);
 

--- a/equistore-torch/src/register.cpp
+++ b/equistore-torch/src/register.cpp
@@ -97,6 +97,7 @@ TORCH_LIBRARY(equistore, m) {
         .def_property("values", &LabelsHolder::values)
         .def("append", &LabelsHolder::append, DOCSTRING, {torch::arg("name"), torch::arg("values")})
         .def("insert", &LabelsHolder::insert, DOCSTRING, {torch::arg("index"), torch::arg("name"), torch::arg("values")})
+        .def("permute", &LabelsHolder::permute, DOCSTRING, {torch::arg("dimensions_indexes")})
         .def("remove", &LabelsHolder::remove, DOCSTRING, {torch::arg("name")})
         .def("rename", &LabelsHolder::rename, DOCSTRING, {torch::arg("old"), torch::arg("new")})
         .def("to", &LabelsHolder::to, DOCSTRING,

--- a/python/equistore-core/equistore/core/labels.py
+++ b/python/equistore-core/equistore/core/labels.py
@@ -492,6 +492,39 @@ class Labels:
 
         return Labels(names=new_names, values=new_values)
 
+    def permute(self, dimensions_indexes: List[int]) -> "Labels":
+        """Permute dimensions according to ``dimensions_indexes`` in the
+        :py:class:`Labels`.
+
+        :param dimensions_indexes: desired ordering of the dimensions
+        :raises ValueError: if length of ``dimensions_indexes`` does not match the
+            Labels length
+        :raises ValueError: if duplicate values are present in ``dimensions_indexes``
+
+        >>> import numpy as np
+        >>> from equistore import Labels
+        >>> label = Labels(["foo", "bar", "baz"], np.array([[42, 10, 3]]))
+        >>> label
+        Labels(
+            foo  bar  baz
+            42   10    3
+        )
+        >>> label.permute([2, 0, 1])
+        Labels(
+            baz  foo  bar
+             3   42   10
+        )
+        """
+        if len(dimensions_indexes) != len(self.names):
+            raise ValueError(
+                f"the length of `dimensions_indexes` ({len(dimensions_indexes)}) does "
+                f"not match the number of dimensions in the Labels ({len(self.names)})"
+            )
+
+        names = [self.names[d] for d in dimensions_indexes]
+
+        return Labels(names=names, values=self.values[:, dimensions_indexes])
+
     def remove(self, name: str) -> "Labels":
         """Remove ``name`` from the dimensions of the :py:class:`Labels`.
 

--- a/python/equistore-core/tests/labels.py
+++ b/python/equistore-core/tests/labels.py
@@ -135,7 +135,7 @@ def test_dimensions_manipulation():
     assert removed_label == label
 
     with pytest.raises(
-        ValueError, match=r"'baz' not found in the dimensions of these Labels"
+        ValueError, match="'baz' not found in the dimensions of these Labels"
     ):
         new_label.remove(name="baz")
 
@@ -144,9 +144,23 @@ def test_dimensions_manipulation():
     assert new_label.names == ["bar"]
 
     with pytest.raises(
-        ValueError, match=r"'baz' not found in the dimensions of these Labels"
+        ValueError, match="'baz' not found in the dimensions of these Labels"
     ):
         new_label.rename("baz", "foo")
+
+    # Labels.permute
+    label = Labels(["foo", "bar", "baz"], np.array([[42, 10, 3]]))
+
+    new_label = label.permute([-1, 0, 1])
+    assert new_label.names == ["baz", "foo", "bar"]
+    np.testing.assert_equal(new_label.values, np.array([[3, 42, 10]]))
+
+    match = (
+        r"the length of `dimensions_indexes` \(2\) does not match the number of "
+        r"dimensions in the Labels \(3\)"
+    )
+    with pytest.raises(ValueError, match=match):
+        label.permute([2, 0])
 
 
 def test_view():

--- a/python/equistore-operations/equistore/operations/__init__.py
+++ b/python/equistore-operations/equistore/operations/__init__.py
@@ -46,9 +46,10 @@ from .join import join
 from .lstsq import lstsq
 from .manipulate_dimension import (
     append_dimension,
+    insert_dimension,
+    permute_dimensions,
     remove_dimension,
     rename_dimension,
-    insert_dimension,
 )
 from .multiply import multiply
 from .one_hot import one_hot
@@ -109,6 +110,7 @@ __all__ = [
     "one_hot",
     "ones_like",
     "ones_like_block",
+    "permute_dimensions",
     "pow",
     "random_uniform_like",
     "random_uniform_like_block",

--- a/python/equistore-torch/equistore/torch/documentation.py
+++ b/python/equistore-torch/equistore/torch/documentation.py
@@ -341,6 +341,30 @@ class Labels:
         )
         """
 
+    def permute(self, dimensions_indexes: List[int]) -> "Labels":
+        """Permute dimensions according to ``dimensions_indexes`` in the
+        :py:class:`Labels`.
+
+        :param dimensions_indexes: desired ordering of the dimensions
+        :raises ValueError: if length of ``dimensions_indexes`` does not match the
+            Labels length
+        :raises ValueError: if duplicate values are present in ``dimensions_indexes``
+
+        >>> import torch
+        >>> from equistore.torch import Labels
+        >>> label = Labels(["foo", "bar", "baz"], torch.tensor([[42, 10, 3]]))
+        >>> print(label)
+        Labels(
+            foo  bar  baz
+            42   10    3
+        )
+        >>> print(label.permute([2, 0, 1]))
+        Labels(
+            baz  foo  bar
+             3   42   10
+        )
+        """
+
     def remove(self, name: str) -> "Labels":
         """Remove ``name`` from the dimensions of the :py:class:`Labels`.
 


### PR DESCRIPTION
Following #299 this add an operation for permuting dimensions/columns of labels and labels in tensors. This will be useful as for sorting the rows as well.  

<!-- readthedocs-preview equistore start -->
----
:books: Documentation preview :books:: https://equistore--316.org.readthedocs.build/en/316/

<!-- readthedocs-preview equistore end -->