### PR TITLE
Raise error when checking keys in operations

### DIFF
--- a/python/equistore-operations/equistore/operations/_utils.py
+++ b/python/equistore-operations/equistore/operations/_utils.py
@@ -1,4 +1,4 @@
-from typing import List, Union
+from typing import List, Sequence
 
 import numpy as np
 
@@ -12,28 +12,36 @@ class NotEqualError(Exception):
 
 
 def _check_same_keys(a: TensorMap, b: TensorMap, fname: str) -> bool:
+    """
+    Returns true if the keys of 2 TensorMaps are the same, without specification of the
+    order, and false otherwise.
+    """
     return not bool(_check_same_keys_impl(a, b, fname))
 
 
 def _check_same_keys_raise(a: TensorMap, b: TensorMap, fname: str) -> None:
+    """
+    If the keys of 2 TensorMaps are not the same, raises a NotEqualError, othwerwise
+    returns None.
+    """
     message = _check_same_keys_impl(a, b, fname)
     if message != "":
         raise NotEqualError(message)
 
 
 def _check_same_keys_impl(a: TensorMap, b: TensorMap, fname: str) -> str:
-    """Check if metadata between two TensorMaps is consistent for an operation.
+    """
+    Checks if the keys of 2 TensorMaps are the same, without specification of the order.
+    Returns an empty str if they are the same, otherwise returns a str message of a
+    meaningful error.
 
-    The functions verifies that
-
-    1. The key names are the same.
-    2. The number of blocks in the same
-    3. The block key indices are the same.
+    The functions verifies that the key names and length are the same, and that the key
+    values are the same without specification of exact order.
 
     :param a: first :py:class:`TensorMap` for check
     :param b: second :py:class:`TensorMap` for check
     :param fname: name of the function where the check is performed. The input will be
-                  used to generate a meaningful error message.
+        used to generate a meaningful error message.
     """
 
     keys_a = a.keys
@@ -57,39 +65,80 @@ def _check_same_keys_impl(a: TensorMap, b: TensorMap, fname: str) -> str:
     return ""
 
 
-def _check_blocks(a: TensorBlock, b: TensorBlock, props: List[str], fname: str) -> str:
-    return not bool(_check_blocks_impl(a, b, props, fname))
+def _check_blocks(
+    a: TensorBlock,
+    b: TensorBlock,
+    fname: str,
+    check: Sequence[str] = ("samples", "components", "properties"),
+) -> bool:
+    """
+    Checks if the metadata of 2 TensorBlocks are the same. If not, returns false.
+    Otherwise returns true.
+    """
+    return not bool(_check_blocks_impl(a, b, fname, check))
 
 
 def _check_blocks_raise(
-    a: TensorBlock, b: TensorBlock, props: List[str], fname: str
+    a: TensorBlock,
+    b: TensorBlock,
+    fname: str,
+    check: Sequence[str] = ("samples", "components", "properties"),
 ) -> None:
-    message = _check_blocks_impl(a, b, props, fname)
+    """
+    Checks if the metadata of two TensorBlocks are the same. If not, raises a
+    NotEqualError. If invalid `check` are given, this function raises a `ValueError`.
+    Otherwise returns it None.
+
+    The message associated with the exception will contain more information on where the
+    two :py:class:`TensorBlock` differ. See :py:func:`_check_blocks_impl` for more
+    information on when two :py:class:`TensorBlock` are considered as equal.
+
+    :param a: first :py:class:`TensorBlock` for check
+    :param b: second :py:class:`TensorBlock` for check
+    :param fname: name of the function where the check is performed. The input will be
+        used to generate a meaningful error message.
+    :param check: A sequence of strings containing the metadata to check. Allowed values
+        are ``'properties'`` or ``'samples'``, ``'components'``.
+
+    :raises: :py:class:`equistore.NotEqualError` if the metadata of the blocks are
+        different
+    :raises: :py:class:`ValueError` if an invalid prop name in :param check: is
+        given. See :param check: description for valid prop names
+    """
+    message = _check_blocks_impl(a, b, fname, check)
     if message != "":
         raise NotEqualError(message)
 
 
 def _check_blocks_impl(
-    a: TensorBlock, b: TensorBlock, props: List[str], fname: str
+    a: TensorBlock,
+    b: TensorBlock,
+    fname: str,
+    check: Sequence[str] = ("samples", "components", "properties"),
 ) -> str:
-    """Check if metadata between two TensorBlocks is consistent for an operation.
+    """
+    Check if metadata between two TensorBlocks is consistent for an operation.
 
-    The functions verifies that that the metadata of the given props is the same
-    (length and indices).
+    The functions verifies that that the metadata of the given check is the same, in
+    terms of length, dimension names, and order of the values.
+
+    If they are not the same, an error message as a str is returned. Otherwise, an empty
+    str is returned.
 
     :param a: first :py:class:`TensorBlock` for check
     :param b: second :py:class:`TensorBlock` for check
-    :param props: A list of strings containing the property to check.
-                 Allowed values are ``'properties'`` or ``'samples'``,
-                 ``'components'`` and ``'gradients'``.
+    :param fname: name of the function where the check is performed. The input will be
+        used to generate a meaningful error message.
+    :param check: A sequence of strings containing the metadata to check. Allowed values
+        are ``'properties'`` or ``'samples'``, ``'components'``.
     """
-    for prop in props:
-        err_msg = f"inputs to '{fname}' should have the same {prop}:\n"
-        err_msg_len = f"{prop} of the two `TensorBlock` have different lengths"
-        err_msg_1 = f"{prop} are not the same or not in the same order"
-        err_msg_names = f"{prop} names are not the same or not in the same order"
+    for metadata in check:
+        err_msg = f"inputs to '{fname}' should have the same {metadata}:\n"
+        err_msg_len = f"{metadata} of the two `TensorBlock` have different lengths"
+        err_msg_1 = f"{metadata} are not the same or not in the same order"
+        err_msg_names = f"{metadata} names are not the same or not in the same order"
 
-        if prop == "samples":
+        if metadata == "samples":
             if not len(a.samples) == len(b.samples):
                 return err_msg + err_msg_len
             if not a.samples.names == b.samples.names:
@@ -97,7 +146,7 @@ def _check_blocks_impl(
             if not np.all(a.samples == b.samples):
                 return err_msg + err_msg_1
 
-        elif prop == "properties":
+        elif metadata == "properties":
             if not len(a.properties) == len(b.properties):
                 return err_msg + err_msg_len
             if not a.properties.names == b.properties.names:
@@ -105,7 +154,7 @@ def _check_blocks_impl(
             if not np.all(a.properties == b.properties):
                 return err_msg + err_msg_1
 
-        elif prop == "components":
+        elif metadata == "components":
             if len(a.components) != len(b.components):
                 return err_msg + err_msg_len
 
@@ -118,74 +167,96 @@ def _check_blocks_impl(
 
                 if not np.all(c1 == c2):
                     return err_msg + err_msg_1
-
         else:
             raise ValueError(
-                f"{prop} is not a valid property to check, "
-                "choose from ['samples', 'properties', 'components']"
+                f"{metadata} is not a valid property to check, "
+                "choose from 'samples', 'properties' and 'components'"
             )
     return ""
 
 
 def _check_same_gradients(
-    a: TensorBlock, b: TensorBlock, props: List[str], fname: str
+    a: TensorBlock,
+    b: TensorBlock,
+    fname: str,
+    check: Sequence[str] = ("samples", "components", "properties"),
 ) -> bool:
     """
-    Check if metadata between two gradients's TensorBlocks is consistent
-     for an operation.
+    Check if metadata between the gradients of 2 TensorBlocks is consistent for an
+    operation. If they are the same, true is returned, otherwise false.
 
-    The functions verifies that the metadata of the given props is the same
-    (length, names, values) and in the same order.
+    The functions verifies that that the metadata of the given check is the same, in
+    terms of length, dimension names, and order of the values.
 
-    If props is None it only checks if the ``'parameters'`` are consistent.
+    If check is None it only checks if the ``'parameters'`` are consistent.
 
     :param a: first :py:class:`TensorBlock` for check
     :param b: second :py:class:`TensorBlock` for check
-    :param props: A list of strings containing the property to check. Allowed
-                 values are ``'samples'`` or ``'properties'``, ``'components'``.
-                 To check only if the ``'parameters'`` are consistent use
-                 ``props=None``, using ``'parameters'`` is allowed
-                  even though deprecated.
+    :param fname: name of the function where the check is performed. The input will be
+        used to generate a meaningful error message.
+    :param check: A sequence of strings containing the metadata to check. Allowed values
+        are ``'properties'`` or ``'samples'``, ``'components'``. To check only if the
+        ``'parameters'`` are consistent pass an empty tuple ``check=()``.
     """
-    return not bool(_check_same_gradients_impl(a, b, props, fname))
+    return not bool(_check_same_gradients_impl(a, b, fname, check))
 
 
 def _check_same_gradients_raise(
-    a: TensorBlock, b: TensorBlock, props: List[str], fname: str
+    a: TensorBlock,
+    b: TensorBlock,
+    fname: str,
+    check: Sequence[str] = ("samples", "components", "properties"),
 ) -> None:
     """
-    Check if metadata between two gradients's TensorBlocks is consistent for an
-    operation.
+    Check if two TensorBlocks gradients have identical metadata.
 
     The message associated with the exception will contain more information on where the
     gradients of the two :py:class:`TensorBlock` differ. See
-    :py:func:`_check_same_gradients` for more information on when gradients of
+    :py:func:`_check_same_gradients_impl` for more information on when gradients of
     :py:class:`TensorBlock` are considered as equal.
-
-    :raises: :py:class:`equistore.NotEqualError` if the gradients of the blocks are
-        different
 
     :param a: first :py:class:`TensorBlock` for check
     :param b: second :py:class:`TensorBlock` for check
-    :param props: A list of strings containing the property to check. Allowed values are
-                 ``'samples'`` or ``'properties'``, ``'components'``. To check only if
-                 the ``'parameters'`` are consistent use ``props=None``, using
-                 ``'parameters'`` is allowed
-                  even though deprecated.
-
-    :raises: :py:class:`NotImplementedError` if one of :py:class:`TensorBlock` inputs
-             has gradients of gradients
-    :raises: :py:class:`ValueError` if an invalid prop name in :param props: is given.
-             See :param props: description for valid prop names
+    :param fname: name of the function where the check is performed. The input will be
+        used to generate a meaningful error message.
+    :param check: A sequence of strings containing the metadata to check. Allowed values
+        are ``'properties'`` or ``'samples'``, ``'components'``. To check only if the
+        ``'parameters'`` are consistent pass an empty tuple ``check=()``.
+    :raises: :py:class:`equistore.NotEqualError` if the gradients of the blocks are
+        different
+    :raises: :py:class:`ValueError` if an invalid prop name in :param check: is
+        given. See :param check: description for valid prop names
     """
-    message = _check_same_gradients_impl(a, b, props, fname)
+    message = _check_same_gradients_impl(a, b, fname, check)
     if message != "":
         raise NotEqualError(message)
 
 
 def _check_same_gradients_impl(
-    a: TensorBlock, b: TensorBlock, props: List[str], fname: str
-) -> Union[str, None]:
+    a: TensorBlock,
+    b: TensorBlock,
+    fname: str,
+    check: Sequence[str] = ("samples", "components", "properties"),
+) -> str:
+    """
+    Check if metadata between the gradients of two TensorBlocks is consistent for an
+    operation.
+
+    The functions verifies that that the 2 TensorBlocks have the same gradient
+    parameters, then checks the metadata of the given ``check`` is the same, in terms of
+    length, dimension names, and order of the values.
+
+    If they are not the same, an error message as a str is returned. Otherwise, an empty
+    str is returned. If the 2 blocks have no gradients, an empty string is returned.
+
+    :param a: first :py:class:`TensorBlock` whose gradients are to be checked
+    :param b: second :py:class:`TensorBlock` whose gradients are to be checked
+    :param fname: name of the function where the check is performed. The input will be
+        used to generate a meaningful error message.
+    :param check: A sequence of strings containing the metadata to check. Allowed values
+        are ``'properties'`` or ``'samples'``, ``'components'``. To check only if the
+        ``'parameters'`` are consistent pass an empty tuple ``check=()``.
+    """
     err_msg = f"inputs to {fname} should have the same gradients:\n"
     gradients_list_a = a.gradients_list()
     gradients_list_b = b.gradients_list()
@@ -198,63 +269,63 @@ def _check_same_gradients_impl(
     for parameter, grad_a in a.gradients():
         grad_b = b.gradient(parameter)
 
-        _check_same_gradients(grad_a, grad_b, props=props, fname=fname)
+        for metadata in check:
+            err_msg_len = (
+                f"gradient '{parameter}' {metadata} of the two `TensorBlock` "
+                "have different lengths"
+            )
 
-        if props is not None:
-            for prop in props:
-                err_msg_len = (
-                    f"gradient '{parameter}' {prop} of the two `TensorBlock` "
-                    "have different lengths"
-                )
+            err_msg_1 = (
+                f"gradient '{parameter}' {metadata} are not the same or not in the "
+                "same order"
+            )
 
-                err_msg_1 = (
-                    f"gradient '{parameter}' {prop} are not the same or not in the "
-                    "same order"
-                )
+            err_msg_names = (
+                f"gradient '{parameter}' {metadata} names are not the same "
+                "or not in the same order"
+            )
 
-                err_msg_names = (
-                    f"gradient '{parameter}' {prop} names are not the same "
-                    "or not in the same order"
-                )
+            if metadata == "samples":
+                if not len(grad_a.samples) == len(grad_b.samples):
+                    return err_msg + err_msg_len
+                if not grad_a.samples.names == grad_b.samples.names:
+                    return err_msg + err_msg_names
+                if not np.all(grad_a.samples == grad_b.samples):
+                    return err_msg + err_msg_1
 
-                if prop == "samples":
-                    if not len(grad_a.samples) == len(grad_b.samples):
-                        return err_msg + err_msg_len
-                    if not grad_a.samples.names == grad_b.samples.names:
+            elif metadata == "properties":
+                if not len(grad_a.properties) == len(grad_b.properties):
+                    return err_msg + err_msg_len
+                if not grad_a.properties.names == grad_b.properties.names:
+                    return err_msg + err_msg_names
+                if not np.all(grad_a.properties == grad_b.properties):
+                    return err_msg + err_msg_1
+            elif metadata == "components":
+                if len(grad_a.components) != len(grad_b.components):
+                    return err_msg + err_msg_len
+
+                for c1, c2 in zip(grad_a.components, grad_b.components):
+                    if not (c1.names == c2.names):
                         return err_msg + err_msg_names
-                    if not np.all(grad_a.samples == grad_b.samples):
+
+                    if not np.all(c1 == c2):
                         return err_msg + err_msg_1
-
-                elif prop == "properties":
-                    if not len(grad_a.properties) == len(grad_b.properties):
-                        return err_msg + err_msg_len
-                    if not grad_a.properties.names == grad_b.properties.names:
-                        return err_msg + err_msg_names
-                    if not np.all(grad_a.properties == grad_b.properties):
-                        return err_msg + err_msg_1
-                elif prop == "components":
-                    if len(grad_a.components) != len(grad_b.components):
-                        return err_msg + err_msg_len
-
-                    for c1, c2 in zip(grad_a.components, grad_b.components):
-                        if not (c1.names == c2.names):
-                            return err_msg + err_msg_names
-
-                        if not np.all(c1 == c2):
-                            return err_msg + err_msg_1
-
-                elif prop != "parameters":
-                    # parameters are already checked at the beginning but i want
-                    # to give the opportunity to the 'user' to use it, without
-                    # problems
-                    raise ValueError(
-                        f"{prop} is not a valid property to check, "
-                        "choose from ['samples', 'properties', 'components']"
-                    )
+            else:
+                raise ValueError(
+                    f"{metadata} is not a valid property to check, "
+                    "choose from 'samples', 'properties' and 'components'"
+                )
     return ""
 
 
-def _check_gradient_presence(block: TensorBlock, parameters: List[str], fname: str):
+def _check_gradient_presence_raise(
+    block: TensorBlock, parameters: List[str], fname: str
+) -> None:
+    """
+    For a single TensorBlock checks if each of the passed ``parameters`` are present as
+    parameters of its gradients. If all of them are present, None is returned. Otherwise
+    a ValueError is raised.
+    """
     for parameter in parameters:
         if parameter not in block.gradients_list():
             raise ValueError(

--- a/python/equistore-operations/equistore/operations/add.py
+++ b/python/equistore-operations/equistore/operations/add.py
@@ -2,7 +2,11 @@ from typing import Union
 
 from equistore.core import TensorBlock, TensorMap
 
-from ._utils import _check_blocks, _check_same_gradients, _check_same_keys
+from ._utils import (
+    _check_blocks_raise,
+    _check_same_gradients_raise,
+    _check_same_keys_raise,
+)
 
 
 def add(A: TensorMap, B: Union[float, TensorMap]) -> TensorMap:
@@ -33,19 +37,19 @@ def add(A: TensorMap, B: Union[float, TensorMap]) -> TensorMap:
 
     blocks = []
     if isinstance(B, TensorMap):
-        _check_same_keys(A, B, "add")
+        _check_same_keys_raise(A, B, "add")
         for key, block_A in A.items():
             block_B = B[key]
-            _check_blocks(
+            _check_blocks_raise(
                 block_A,
                 block_B,
-                props=["samples", "components", "properties"],
+                check=("samples", "components", "properties"),
                 fname="add",
             )
-            _check_same_gradients(
+            _check_same_gradients_raise(
                 block_A,
                 block_B,
-                props=["samples", "components", "properties"],
+                check=("samples", "components", "properties"),
                 fname="add",
             )
             blocks.append(_add_block_block(block_1=block_A, block_2=block_B))

--- a/python/equistore-operations/equistore/operations/allclose.py
+++ b/python/equistore-operations/equistore/operations/allclose.py
@@ -49,7 +49,7 @@ def _allclose_block_impl(
     check_blocks_message = _check_blocks_impl(
         block_1,
         block_2,
-        props=["samples", "properties", "components"],
+        check=("samples", "properties", "components"),
         fname="allclose",
     )
     if check_blocks_message != "":
@@ -58,7 +58,7 @@ def _allclose_block_impl(
     check_same_gradient_message = _check_same_gradients_impl(
         block_1,
         block_2,
-        props=["samples", "properties", "components"],
+        check=("samples", "properties", "components"),
         fname="allclose",
     )
     if check_same_gradient_message != "":

--- a/python/equistore-operations/equistore/operations/divide.py
+++ b/python/equistore-operations/equistore/operations/divide.py
@@ -5,7 +5,11 @@ import numpy as np
 from equistore.core import TensorBlock, TensorMap
 
 from . import _dispatch
-from ._utils import _check_blocks, _check_same_gradients, _check_same_keys
+from ._utils import (
+    _check_blocks_raise,
+    _check_same_gradients_raise,
+    _check_same_keys_raise,
+)
 
 
 def divide(A: TensorMap, B: Union[float, TensorMap]) -> TensorMap:
@@ -37,19 +41,19 @@ def divide(A: TensorMap, B: Union[float, TensorMap]) -> TensorMap:
 
     blocks = []
     if isinstance(B, TensorMap):
-        _check_same_keys(A, B, "divide")
+        _check_same_keys_raise(A, B, "divide")
         for key, block_A in A.items():
             block_B = B.block(key)
-            _check_blocks(
+            _check_blocks_raise(
                 block_A,
                 block_B,
-                props=["samples", "components", "properties"],
+                check=("samples", "components", "properties"),
                 fname="divide",
             )
-            _check_same_gradients(
+            _check_same_gradients_raise(
                 block_A,
                 block_B,
-                props=["samples", "components", "properties"],
+                check=("samples", "components", "properties"),
                 fname="divide",
             )
             blocks.append(_divide_block_block(block_1=block_A, block_2=block_B))

--- a/python/equistore-operations/equistore/operations/dot.py
+++ b/python/equistore-operations/equistore/operations/dot.py
@@ -3,7 +3,7 @@ import numpy as np
 from equistore.core import TensorBlock, TensorMap
 
 from . import _dispatch
-from ._utils import _check_same_keys
+from ._utils import _check_same_keys_raise
 
 
 def dot(tensor_1: TensorMap, tensor_2: TensorMap) -> TensorMap:
@@ -71,7 +71,7 @@ def dot(tensor_1: TensorMap, tensor_2: TensorMap) -> TensorMap:
             ``B``; and the ``components`` equal to the ``components`` of ``A``
 
     """
-    _check_same_keys(tensor_1, tensor_2, "dot")
+    _check_same_keys_raise(tensor_1, tensor_2, "dot")
 
     blocks = []
     for key, block_1 in tensor_1.items():

--- a/python/equistore-operations/equistore/operations/empty_like.py
+++ b/python/equistore-operations/equistore/operations/empty_like.py
@@ -3,7 +3,7 @@ from typing import List, Union
 from equistore.core import TensorBlock, TensorMap
 
 from . import _dispatch
-from ._utils import _check_gradient_presence
+from ._utils import _check_gradient_presence_raise
 
 
 def empty_like(
@@ -133,7 +133,9 @@ def empty_like_block(
     if gradients is None:
         gradients = block.gradients_list()
     else:
-        _check_gradient_presence(block=block, parameters=gradients, fname="empty_like")
+        _check_gradient_presence_raise(
+            block=block, parameters=gradients, fname="empty_like"
+        )
 
     for parameter in gradients:
         gradient = block.gradient(parameter)

--- a/python/equistore-operations/equistore/operations/equal.py
+++ b/python/equistore-operations/equistore/operations/equal.py
@@ -30,20 +30,12 @@ def _equal_block_impl(block_1: TensorBlock, block_2: TensorBlock) -> str:
     if not _dispatch.all(block_1.values == block_2.values):
         return "values are not equal"
 
-    check_blocks_message = _check_blocks_impl(
-        block_1,
-        block_2,
-        props=["samples", "properties", "components"],
-        fname="equal",
-    )
+    check_blocks_message = _check_blocks_impl(block_1, block_2, fname="equal")
     if check_blocks_message != "":
         return check_blocks_message
 
     check_same_gradient_message = _check_same_gradients_impl(
-        block_1,
-        block_2,
-        props=["samples", "properties", "components"],
-        fname="equal",
+        block_1, block_2, fname="equal"
     )
     if check_same_gradient_message != "":
         return check_same_gradient_message

--- a/python/equistore-operations/equistore/operations/equal_metadata.py
+++ b/python/equistore-operations/equistore/operations/equal_metadata.py
@@ -1,7 +1,7 @@
 """
 Module for checking equivalence in metadata between 2 TensorMaps
 """
-from typing import List, Optional
+from typing import Optional, Sequence
 
 from equistore.core import TensorBlock, TensorMap
 
@@ -14,21 +14,19 @@ from ._utils import (
 
 
 def _equal_metadata_impl(
-    tensor_1: TensorMap, tensor_2: TensorMap, check: Optional[List] = None
+    tensor_1: TensorMap,
+    tensor_2: TensorMap,
+    check: Optional[Sequence[str]] = ("samples", "components", "properties"),
 ) -> str:
     if not isinstance(tensor_1, TensorMap):
         return f"`tensor_1` must be a TensorMap, not {type(tensor_1)}"
     if not isinstance(tensor_2, TensorMap):
         return f"`tensor_2` must be a TensorMap, not {type(tensor_2)}"
-    if not isinstance(check, (list, type(None))):
-        return f"`check` must be a list, not {type(check)}"
-    if check is None:
-        check = ["samples", "components", "properties"]
     for metadata in check:
         if not isinstance(metadata, str):
             return f"`check` must be a list of strings, got list of {type(metadata)}"
 
-        if metadata not in ["samples", "components", "properties"]:
+        if metadata not in ("samples", "components", "properties"):
             return f"Invalid metadata to check: {metadata}"
 
     message = _check_same_keys_impl(tensor_1, tensor_2, "equal_metadata_raise")
@@ -44,29 +42,33 @@ def _equal_metadata_impl(
 
 
 def _equal_metadata_block_impl(
-    block_1: TensorBlock, block_2: TensorBlock, check: Optional[List] = None
+    block_1: TensorBlock,
+    block_2: TensorBlock,
+    check: Optional[Sequence[str]] = ("samples", "components", "properties"),
 ) -> str:
     if not isinstance(block_1, TensorBlock):
         return f"`block_1` must be a TensorBlock, not {type(block_1)}"
     if not isinstance(block_2, TensorBlock):
         return f"`block_2` must be a TensorBlock, not {type(block_2)}"
-    if not isinstance(check, (list, type(None))):
-        return f"`check` must be a list, not {type(check)}"
-    if check is None:
-        check = ["samples", "components", "properties"]
     for metadata in check:
         if not isinstance(metadata, str):
             return f"`check` must be a list of strings, got list of {type(metadata)}"
-        if metadata not in ["samples", "components", "properties"]:
+        if metadata not in ("samples", "components", "properties"):
             return f"Invalid metadata to check: {metadata}"
 
     check_blocks_message = _check_blocks_impl(
-        block_1, block_2, check, "equal_metadata_block_raise"
+        block_1,
+        block_2,
+        "equal_metadata_block_raise",
+        check=check,
     )
     if check_blocks_message != "":
         return check_blocks_message
     check_same_gradient_message = _check_same_gradients_impl(
-        block_1, block_2, check, "equal_metadata_block_raise"
+        block_1,
+        block_2,
+        "equal_metadata_block_raise",
+        check=check,
     )
     if check_same_gradient_message != "":
         return check_same_gradient_message
@@ -75,7 +77,9 @@ def _equal_metadata_block_impl(
 
 
 def equal_metadata(
-    tensor_1: TensorMap, tensor_2: TensorMap, check: Optional[List] = None
+    tensor_1: TensorMap,
+    tensor_2: TensorMap,
+    check: Optional[Sequence[str]] = ("samples", "components", "properties"),
 ) -> bool:
     """
     Checks if two :py:class:`TensorMap` objects have the same metadata,
@@ -91,7 +95,7 @@ def equal_metadata(
 
     :param tensor_1: The first :py:class:`TensorMap`.
     :param tensor_2: The second :py:class:`TensorMap` to compare to the first.
-    :param check: A list of strings specifying which metadata of each block to
+    :param check: A sequence of strings specifying which metadata of each block to
         check. If none, all metadata is checked. Allowed values are "samples",
         "components", and "properties".
 
@@ -148,7 +152,7 @@ def equal_metadata(
     >>> equistore.equal_metadata(
     ...     tensor_1,
     ...     tensor_2,
-    ...     check=["samples", "components"],
+    ...     check=("samples", "components"),
     ... )
     True
     """
@@ -156,7 +160,9 @@ def equal_metadata(
 
 
 def equal_metadata_raise(
-    tensor_1: TensorMap, tensor_2: TensorMap, check: Optional[List] = None
+    tensor_1: TensorMap,
+    tensor_2: TensorMap,
+    check: Optional[Sequence[str]] = ("samples", "components", "properties"),
 ):
     """
     Raise a :py:class:`NotEqualError` if two :py:class:`TensorMap` have unequal
@@ -172,7 +178,7 @@ def equal_metadata_raise(
 
     :param tensor_1: The first :py:class:`TensorMap`.
     :param tensor_2: The second :py:class:`TensorMap` to compare to the first.
-    :param check: A list of strings specifying which metadata of each block to
+    :param check: A sequence of strings specifying which metadata of each block to
         check. If none, all metadata is checked. Allowed values are "samples",
         "components", and "properties".
     :raises NotEqualError: If the metadata is not the same.
@@ -230,7 +236,7 @@ def equal_metadata_raise(
     >>> equistore.equal_metadata_raise(
     ...     tensor_1,
     ...     tensor_2,
-    ...     check=["samples", "components"],
+    ...     check=("samples", "components"),
     ... )
     """  # noqa: E501
     message = _equal_metadata_impl(tensor_1, tensor_2, check)
@@ -239,7 +245,9 @@ def equal_metadata_raise(
 
 
 def equal_metadata_block(
-    block_1: TensorBlock, block_2: TensorBlock, check: Optional[List] = None
+    block_1: TensorBlock,
+    block_2: TensorBlock,
+    check: Optional[Sequence[str]] = ("samples", "components", "properties"),
 ) -> bool:
     """
     Checks if two :py:class:`TensorBlock` objects have the same metadata,
@@ -283,7 +291,7 @@ def equal_metadata_block(
     >>> equal_metadata_block(
     ...     block_1,
     ...     block_2,
-    ...     check=["samples", "components"],
+    ...     check=("samples", "components"),
     ... )
     True
     """
@@ -291,7 +299,9 @@ def equal_metadata_block(
 
 
 def equal_metadata_block_raise(
-    block_1: TensorBlock, block_2: TensorBlock, check: Optional[List] = None
+    block_1: TensorBlock,
+    block_2: TensorBlock,
+    check: Optional[Sequence[str]] = ("samples", "components", "properties"),
 ):
     """
     Raise a :py:class:`NotEqualError` if two :py:class:`TensorBlock` have unequal
@@ -306,7 +316,7 @@ def equal_metadata_block_raise(
 
     :param block_1: The first :py:class:`TensorBlock`.
     :param block_2: The second :py:class:`TensorBlock` to compare to the first.
-    :param check: A list of strings specifying which metadata of each block to
+    :param check: A sequence of strings specifying which metadata of each block to
         check. If none, all metadata is checked. Allowed values are "samples",
         "components", and "properties".
     :raises NotEqualError: If the metadata is not the same.
@@ -334,7 +344,7 @@ def equal_metadata_block_raise(
     equistore.operations._utils.NotEqualError: inputs to 'equal_metadata_block_raise' should have the same properties:
     properties names are not the same or not in the same order
     >>> equistore.equal_metadata_block_raise(
-    ...     block_1, block_2, check=["samples", "components"]
+    ...     block_1, block_2, check=("samples", "components")
     ... )
     """  # noqa: E501
     message = _equal_metadata_block_impl(block_1, block_2, check)

--- a/python/equistore-operations/equistore/operations/join.py
+++ b/python/equistore-operations/equistore/operations/join.py
@@ -6,7 +6,7 @@ import numpy as np
 
 from equistore.core import Labels, TensorBlock, TensorMap
 
-from ._utils import _check_same_keys
+from ._utils import _check_same_keys_raise
 from .manipulate_dimension import remove_dimension
 
 
@@ -205,7 +205,7 @@ def join(
         return tensors[0]
 
     for ts_to_join in tensors[1:]:
-        _check_same_keys(tensors[0], ts_to_join, "join")
+        _check_same_keys_raise(tensors[0], ts_to_join, "join")
 
     # Deduce if sample/property names are the same in all tensors.
     # If this is not the case we have to change unify the corresponding labels later.

--- a/python/equistore-operations/equistore/operations/multiply.py
+++ b/python/equistore-operations/equistore/operations/multiply.py
@@ -5,7 +5,11 @@ import numpy as np
 from equistore.core import TensorBlock, TensorMap
 
 from . import _dispatch
-from ._utils import _check_blocks, _check_same_gradients, _check_same_keys
+from ._utils import (
+    _check_blocks_raise,
+    _check_same_gradients_raise,
+    _check_same_keys_raise,
+)
 
 
 def multiply(A: TensorMap, B: Union[float, TensorMap]) -> TensorMap:
@@ -36,21 +40,11 @@ def multiply(A: TensorMap, B: Union[float, TensorMap]) -> TensorMap:
     """
     blocks = []
     if isinstance(B, TensorMap):
-        _check_same_keys(A, B, "multiply")
+        _check_same_keys_raise(A, B, "multiply")
         for key, block_A in A.items():
             block_B = B[key]
-            _check_blocks(
-                block_A,
-                block_B,
-                props=["samples", "components", "properties"],
-                fname="multiply",
-            )
-            _check_same_gradients(
-                block_A,
-                block_B,
-                props=["samples", "components", "properties"],
-                fname="multiply",
-            )
+            _check_blocks_raise(block_A, block_B, fname="multiply")
+            _check_same_gradients_raise(block_A, block_B, fname="multiply")
             blocks.append(_multiply_block_block(block_1=block_A, block_2=block_B))
 
     elif isinstance(B, (float, int)):

--- a/python/equistore-operations/equistore/operations/ones_like.py
+++ b/python/equistore-operations/equistore/operations/ones_like.py
@@ -3,7 +3,7 @@ from typing import List, Union
 from equistore.core import TensorBlock, TensorMap
 
 from . import _dispatch
-from ._utils import _check_gradient_presence
+from ._utils import _check_gradient_presence_raise
 
 
 def ones_like(
@@ -146,7 +146,9 @@ def ones_like_block(
     if gradients is None:
         gradients = block.gradients_list()
     else:
-        _check_gradient_presence(block=block, parameters=gradients, fname="ones_like")
+        _check_gradient_presence_raise(
+            block=block, parameters=gradients, fname="ones_like"
+        )
 
     for parameter in gradients:
         gradient = block.gradient(parameter)

--- a/python/equistore-operations/equistore/operations/random_like.py
+++ b/python/equistore-operations/equistore/operations/random_like.py
@@ -3,7 +3,7 @@ from typing import List, Union
 from equistore.core import TensorBlock, TensorMap
 
 from . import _dispatch
-from ._utils import _check_gradient_presence
+from ._utils import _check_gradient_presence_raise
 
 
 def random_uniform_like(
@@ -152,7 +152,7 @@ def random_uniform_like_block(
     if gradients is None:
         gradients = block.gradients_list()
     else:
-        _check_gradient_presence(
+        _check_gradient_presence_raise(
             block=block, parameters=gradients, fname="random_uniform_like"
         )
 

--- a/python/equistore-operations/equistore/operations/solve.py
+++ b/python/equistore-operations/equistore/operations/solve.py
@@ -3,7 +3,7 @@ import numpy as np
 from equistore.core import TensorBlock, TensorMap
 
 from . import _dispatch
-from ._utils import _check_same_gradients, _check_same_keys
+from ._utils import _check_same_gradients_raise, _check_same_keys_raise
 
 
 def solve(X: TensorMap, Y: TensorMap) -> TensorMap:
@@ -69,7 +69,7 @@ def solve(X: TensorMap, Y: TensorMap) -> TensorMap:
     >>> print(c.block().values)
     [[ 9.67680334 42.12534656]]
     """
-    _check_same_keys(X, Y, "solve")
+    _check_same_keys_raise(X, Y, "solve")
 
     for X_block in X:
         shape = X_block.values.shape
@@ -120,7 +120,7 @@ def _solve_block(X: TensorBlock, Y: TensorBlock) -> TensorBlock:
     Y_n_properties = Y.values.shape[-1]
     Y_values = Y.values.reshape(-1, Y_n_properties)
 
-    _check_same_gradients(X, Y, props=None, fname="solve")
+    _check_same_gradients_raise(X, Y, fname="solve")
 
     for parameter, X_gradient in X.gradients():
         X_gradient_values = X_gradient.values.reshape(-1, X_n_properties)

--- a/python/equistore-operations/equistore/operations/subtract.py
+++ b/python/equistore-operations/equistore/operations/subtract.py
@@ -2,7 +2,6 @@ from typing import Union
 
 from equistore.core import TensorMap
 
-from ._utils import _check_same_keys
 from .add import add
 from .multiply import multiply
 
@@ -33,7 +32,6 @@ def subtract(A: TensorMap, B: Union[float, TensorMap]) -> TensorMap:
     :return: New :py:class:`TensorMap` with the same metadata as ``A``.
     """
     if isinstance(B, TensorMap):
-        _check_same_keys(A, B, "subtract")
         B = multiply(B, -1)
     elif isinstance(B, (float, int)):
         B = -float(B)

--- a/python/equistore-operations/equistore/operations/zeros_like.py
+++ b/python/equistore-operations/equistore/operations/zeros_like.py
@@ -3,7 +3,7 @@ from typing import List, Union
 from equistore.core import TensorBlock, TensorMap
 
 from . import _dispatch
-from ._utils import _check_gradient_presence
+from ._utils import _check_gradient_presence_raise
 
 
 def zeros_like(
@@ -146,7 +146,9 @@ def zeros_like_block(
     if gradients is None:
         gradients = block.gradients_list()
     else:
-        _check_gradient_presence(block=block, parameters=gradients, fname="zeros_like")
+        _check_gradient_presence_raise(
+            block=block, parameters=gradients, fname="zeros_like"
+        )
 
     for parameter in gradients:
         gradient = block.gradient(parameter)

--- a/python/equistore-operations/tests/join.py
+++ b/python/equistore-operations/tests/join.py
@@ -18,9 +18,11 @@ def tensor():
         use_numpy=True,
     )
 
-    # Ensure that the tensor has at least one gradient. This avoids dropping
-    # gradient tests silently by removing gradients from the reference data
-    assert "positions" in tensor.block(0).gradients_list()
+    msg = (
+        "Tensor must have at least one gradient. When no gradients are present certain "
+        "tests will pass without testing anything."
+    )
+    assert len(tensor.block(0).gradients_list()) > 0, msg
 
     return tensor
 

--- a/python/equistore-operations/tests/lstsq.py
+++ b/python/equistore-operations/tests/lstsq.py
@@ -14,28 +14,28 @@ class TestLstsq(unittest.TestCase):
     def test_self_lstsq_nograd(self):
         block_1 = TensorBlock(
             values=np.array([[1, 2], [3, 5]]),
-            samples=Labels(["s"], np.array([[0], [2]])),
+            samples=Labels("s", np.array([[0], [2]])),
             components=[],
             properties=Labels.range("p", 2),
         )
         block_2 = TensorBlock(
             values=np.array([[1, 2], [3, 4], [5, 6]]),
-            samples=Labels(["s"], np.array([[0], [2], [7]])),
+            samples=Labels("s", np.array([[0], [2], [7]])),
             components=[],
             properties=Labels.range("p", 2),
         )
 
         block_3 = TensorBlock(
             values=np.array([[1], [2]]),
-            samples=Labels(["s"], np.array([[0], [2]])),
+            samples=Labels("s", np.array([[0], [2]])),
             components=[],
-            properties=Labels(["p"], np.array([[0]])),
+            properties=Labels("p", np.array([[0]])),
         )
         block_4 = TensorBlock(
             values=np.array([[23], [53], [83]]),
-            samples=Labels(["s"], np.array([[0], [2], [7]])),
+            samples=Labels("s", np.array([[0], [2], [7]])),
             components=[],
-            properties=Labels(["p"], np.array([[6]])),
+            properties=Labels("p", np.array([[6]])),
         )
         keys = Labels(names=["key_1", "key_2"], values=np.array([[0, 0], [1, 0]]))
         X = TensorMap(keys, [block_1, block_2])
@@ -88,7 +88,7 @@ class TestLstsq(unittest.TestCase):
             values=y,
             samples=Labels.range("s", 5),
             components=[],
-            properties=Labels(["p"], np.array([[2]])),
+            properties=Labels("p", np.array([[2]])),
         )
         block_Y.add_gradient(
             parameter="z",
@@ -123,7 +123,7 @@ class TestLstsq(unittest.TestCase):
         x, x_grad, y, y_grad = get_value_linear_solve()
         block_X = TensorBlock(
             values=x.reshape((1, x.shape[0], x.shape[1])),
-            samples=Labels(["s"], np.array([[0]])),
+            samples=Labels("s", np.array([[0]])),
             components=[Labels.range("c", 5)],
             properties=Labels.range("p", 2),
         )
@@ -142,9 +142,9 @@ class TestLstsq(unittest.TestCase):
 
         block_Y = TensorBlock(
             values=y.reshape((1, len(y), y.shape[-1])),
-            samples=Labels(["s"], np.array([[0]])),
+            samples=Labels("s", np.array([[0]])),
             components=[Labels.range("c", 5)],
-            properties=Labels(["p"], np.array([[2]])),
+            properties=Labels("p", np.array([[2]])),
         )
         block_Y.add_gradient(
             parameter="z",

--- a/python/equistore-operations/tests/same_raise.py
+++ b/python/equistore-operations/tests/same_raise.py
@@ -1,0 +1,89 @@
+"""Check that errors are raised for unequal meta data in several operations."""
+
+from os import path
+
+import numpy as np
+import pytest
+
+import equistore
+from equistore import NotEqualError
+
+
+DATA_ROOT = path.join(path.dirname(__file__), "data")
+
+
+def tensor():
+    tensor = equistore.load(
+        path.join(DATA_ROOT, "qm7-power-spectrum.npz"),
+        use_numpy=True,
+    )
+
+    msg = (
+        "Tensor must have at least one gradient. When no gradients are present certain "
+        "tests will pass without testing anything."
+    )
+    assert len(tensor.block(0).gradients_list()) > 0, msg
+
+    return tensor
+
+
+@pytest.mark.parametrize(
+    "operation_str",
+    ["add", "divide", "dot", "join", "lstsq", "multiply", "solve", "subtract"],
+)
+def test_different_keys(operation_str):
+    operation = getattr(equistore, operation_str)
+
+    A = tensor()
+    keys = equistore.Labels(names="foo", values=np.array([[0]]))
+    B = equistore.TensorMap(keys, [A[0].copy()])
+
+    with pytest.raises(NotEqualError, match="should have the same keys"):
+        if operation_str == "join":
+            operation([A, B], axis="properties")
+        elif operation_str == "lstsq":
+            operation(A, B, rcond=1)
+        else:
+            operation(A, B)
+
+
+@pytest.mark.parametrize(
+    "operation_str", ["add", "divide", "lstsq", "multiply", "subtract"]
+)
+def test_different_gradients(operation_str):
+    operation = getattr(equistore, operation_str)
+
+    A = tensor()
+    B = equistore.remove_gradients(tensor())
+
+    with pytest.raises(NotEqualError, match="should have the same gradient parameters"):
+        if operation_str == "lstsq":
+            operation(A, B, rcond=1)
+        else:
+            operation(A, B)
+
+
+@pytest.mark.parametrize("operation_str", ["add", "divide", "multiply", "subtract"])
+def test_different_blocks(operation_str):
+    operation = getattr(equistore, operation_str)
+
+    values = np.array([[0]])
+    samples = equistore.Labels.single()
+
+    properties_1 = equistore.Labels(names="props1", values=np.array([[0]]))
+    properties_2 = equistore.Labels(names="props2", values=np.array([[0]]))
+
+    block_1 = equistore.TensorBlock(
+        values=values, samples=samples, components=[], properties=properties_1
+    )
+    block_2 = equistore.TensorBlock(
+        values=values, samples=samples, components=[], properties=properties_2
+    )
+
+    keys = equistore.Labels(names="foo", values=np.array([[0]]))
+
+    A = equistore.TensorMap(keys, [block_1])
+    B = equistore.TensorMap(keys, [block_2])
+
+    with pytest.raises(NotEqualError, match="should have the same properties"):
+        operation(A, B)


### PR DESCRIPTION
In #280 we changed the naming of a lot of checking functions. However, we did not change these in the downstream methods where we use `_check_same_gradients` and `_check_same_keys`. Currently no errors are raised by all of the effected functions.

I hope I did not forgot some functions. I will also add some simple tests for this to prevent this in the future.

JWA edit: tagging relevant issue #318

# TODO
- [x] tests