### PR TITLE
Make operations availble from equistore-torch

### DIFF
--- a/.github/workflows/torch-tests.yml
+++ b/.github/workflows/torch-tests.yml
@@ -14,7 +14,6 @@ jobs:
   rust-tests:
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.os }} / Torch ${{ matrix.torch-version }}
-    container: ${{ matrix.container }}
     strategy:
       matrix:
         include:
@@ -43,7 +42,6 @@ jobs:
 
       - name: setup rust
         uses: dtolnay/rust-toolchain@master
-        if: "!matrix.container"
         with:
           toolchain: stable
 

--- a/docs/src/reference/operations/index.rst
+++ b/docs/src/reference/operations/index.rst
@@ -3,8 +3,44 @@
 Python operations reference
 ===========================
 
-.. automodule:: equistore.operations
-    :undoc-members:
+The Python API for equistore also provides functions which operate on
+:py:class:`equistore.TensorMap`, :py:class:`equistore.TensorBlock`, and
+:py:class:`equistore.Labels` and can be used to build your own Machine Learning
+models.
+
+The list of all operations currently implemented is available below. If you need
+any other operation, please `open an issue
+<https://github.com/lab-cosmo/equistore/issues>`_!
+
+Using operations with PyTorch
+-----------------------------
+
+`PyTorch`_ is a very popular framework for machine learning, providing multiple
+tools to make writing and training models easier. There are two ways to use
+the operations with PyTorch:
+
+- Using the pure Python version of equistore, one can store values in a
+  :py:class:`equistore.TensorBlock` using :py:class:`torch.Tensor`. In this
+  case, all operations will be compatible with torch autograd (automatic
+  gradient tracking and differentiation). This allows to train models from
+  Python, but not to export the models to run without the Python interpreter.
+  When running a model with the pure Python version of equistore, you should use
+  the operations from ``equistore.<operation_name>``.
+
+- When using the :ref:`TorchScript version of equistore <torch-api-reference>`,
+  one can also compile the Python code to TorchScript and then run the model
+  without a Python interpreter. This is particularly useful to export and then
+  use an already trained model, for example to run molecular simulations. If you
+  want to do this, you should use classes and operations from
+  ``equistore.torch``, i.e. :py:class:`equistore.torch.TensorMap` and using the
+  operation from ``equistore.torch.<operation_name>``. All the operation above
+  are available in the ``equistore.torch`` module, but some might not yet be
+  fully TorchScript compatible.
+
+.. _PyTorch: https://pytorch.org/
+
+List of all operations
+----------------------
 
 .. toctree::
     :maxdepth: 2

--- a/python/equistore-operations/equistore/operations/__init__.py
+++ b/python/equistore-operations/equistore/operations/__init__.py
@@ -1,13 +1,3 @@
-"""
-The Python API for equistore also provides functions which operate on
-:py:class:`equistore.TensorMap`, :py:class:`equistore.TensorBlock`, and
-:py:class:`equistore.Labels` and can be used to build Machine Learning models.
-
-These functions can handle data stored with any of the compatible
-:py:class:`equistore.core.data.Array` types, automatically dispatching to the
-right function (e.g. :py:func:`numpy.sum` or :py:func:`torch.sum`) for a given
-:py:class:`equistore.TensorMap`.
-"""
 import sys
 
 if (sys.version_info.major >= 3) and (sys.version_info.minor >= 8):

--- a/python/equistore-operations/equistore/operations/_classes.py
+++ b/python/equistore-operations/equistore/operations/_classes.py
@@ -1,0 +1,21 @@
+# This file defines the default set of classes to use in equistore-operations
+#
+# The code from equistore-operations can be used in two different modes: either pure
+# Python mode or TorchScript mode. In the second case, we need to use a different
+# version of the classes above; to do without having to rewrite everything, we re-import
+# equistore-operations in a special context.
+#
+# See equistore-torch/equistore/torch/operations.py for more information.
+#
+# Any change to this file MUST be also be made to `equistore/torch/operations.py`.
+
+from equistore.core import Labels, TensorBlock, TensorMap
+
+
+TORCH_SCRIPT_MODE = False
+__all__ = [
+    "Labels",
+    "TensorBlock",
+    "TensorMap",
+    "TORCH_SCRIPT_MODE",
+]

--- a/python/equistore-operations/equistore/operations/_utils.py
+++ b/python/equistore-operations/equistore/operations/_utils.py
@@ -2,7 +2,7 @@ from typing import List, Sequence
 
 import numpy as np
 
-from equistore.core import TensorBlock, TensorMap
+from ._classes import TensorBlock, TensorMap
 
 
 class NotEqualError(Exception):

--- a/python/equistore-operations/equistore/operations/add.py
+++ b/python/equistore-operations/equistore/operations/add.py
@@ -1,7 +1,6 @@
 from typing import Union
 
-from equistore.core import TensorBlock, TensorMap
-
+from ._classes import TensorBlock, TensorMap
 from ._utils import (
     _check_blocks_raise,
     _check_same_gradients_raise,

--- a/python/equistore-operations/equistore/operations/allclose.py
+++ b/python/equistore-operations/equistore/operations/allclose.py
@@ -1,6 +1,5 @@
-from equistore.core import TensorBlock, TensorMap
-
 from . import _dispatch
+from ._classes import TensorBlock, TensorMap
 from ._utils import (
     NotEqualError,
     _check_blocks_impl,

--- a/python/equistore-operations/equistore/operations/block_from_array.py
+++ b/python/equistore-operations/equistore/operations/block_from_array.py
@@ -1,5 +1,6 @@
 import equistore.core
-from equistore.core import Labels, TensorBlock
+
+from ._classes import Labels, TensorBlock
 
 
 def block_from_array(array: equistore.core.data.Array) -> TensorBlock:

--- a/python/equistore-operations/equistore/operations/divide.py
+++ b/python/equistore-operations/equistore/operations/divide.py
@@ -2,9 +2,8 @@ from typing import Union
 
 import numpy as np
 
-from equistore.core import TensorBlock, TensorMap
-
 from . import _dispatch
+from ._classes import TensorBlock, TensorMap
 from ._utils import (
     _check_blocks_raise,
     _check_same_gradients_raise,

--- a/python/equistore-operations/equistore/operations/dot.py
+++ b/python/equistore-operations/equistore/operations/dot.py
@@ -1,8 +1,7 @@
 import numpy as np
 
-from equistore.core import TensorBlock, TensorMap
-
 from . import _dispatch
+from ._classes import TensorBlock, TensorMap
 from ._utils import _check_same_keys_raise
 
 

--- a/python/equistore-operations/equistore/operations/drop_blocks.py
+++ b/python/equistore-operations/equistore/operations/drop_blocks.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from equistore.core import Labels, TensorBlock, TensorMap
+from ._classes import Labels, TensorBlock, TensorMap
 
 
 def drop_blocks(tensor: TensorMap, keys: Labels, copy: bool = False) -> TensorMap:

--- a/python/equistore-operations/equistore/operations/empty_like.py
+++ b/python/equistore-operations/equistore/operations/empty_like.py
@@ -1,8 +1,7 @@
 from typing import List, Union
 
-from equistore.core import TensorBlock, TensorMap
-
 from . import _dispatch
+from ._classes import TensorBlock, TensorMap
 from ._utils import _check_gradient_presence_raise
 
 

--- a/python/equistore-operations/equistore/operations/equal.py
+++ b/python/equistore-operations/equistore/operations/equal.py
@@ -1,6 +1,5 @@
-from equistore.core import TensorBlock, TensorMap
-
 from . import _dispatch
+from ._classes import TensorBlock, TensorMap
 from ._utils import (
     NotEqualError,
     _check_blocks_impl,

--- a/python/equistore-operations/equistore/operations/equal_metadata.py
+++ b/python/equistore-operations/equistore/operations/equal_metadata.py
@@ -3,8 +3,7 @@ Module for checking equivalence in metadata between 2 TensorMaps
 """
 from typing import Optional, Sequence
 
-from equistore.core import TensorBlock, TensorMap
-
+from ._classes import TensorBlock, TensorMap
 from ._utils import (
     NotEqualError,
     _check_blocks_impl,

--- a/python/equistore-operations/equistore/operations/join.py
+++ b/python/equistore-operations/equistore/operations/join.py
@@ -4,8 +4,7 @@ from typing import List
 
 import numpy as np
 
-from equistore.core import Labels, TensorBlock, TensorMap
-
+from ._classes import Labels, TensorBlock, TensorMap
 from ._utils import _check_same_keys_raise
 from .manipulate_dimension import remove_dimension
 

--- a/python/equistore-operations/equistore/operations/lstsq.py
+++ b/python/equistore-operations/equistore/operations/lstsq.py
@@ -1,8 +1,7 @@
 import warnings
 
-from equistore.core import TensorBlock, TensorMap
-
 from . import _dispatch
+from ._classes import TensorBlock, TensorMap
 from ._utils import (
     _check_blocks_raise,
     _check_same_gradients_raise,

--- a/python/equistore-operations/equistore/operations/manipulate_dimension.py
+++ b/python/equistore-operations/equistore/operations/manipulate_dimension.py
@@ -19,7 +19,7 @@ from typing import List
 
 import numpy as np
 
-from equistore.core import TensorBlock, TensorMap
+from ._classes import TensorBlock, TensorMap
 
 
 def _check_axis(axis: str):

--- a/python/equistore-operations/equistore/operations/multiply.py
+++ b/python/equistore-operations/equistore/operations/multiply.py
@@ -2,9 +2,8 @@ from typing import Union
 
 import numpy as np
 
-from equistore.core import TensorBlock, TensorMap
-
 from . import _dispatch
+from ._classes import TensorBlock, TensorMap
 from ._utils import (
     _check_blocks_raise,
     _check_same_gradients_raise,

--- a/python/equistore-operations/equistore/operations/one_hot.py
+++ b/python/equistore-operations/equistore/operations/one_hot.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from equistore.core import Labels
+from ._classes import Labels
 
 
 def one_hot(labels: Labels, dimension: Labels) -> np.ndarray:

--- a/python/equistore-operations/equistore/operations/ones_like.py
+++ b/python/equistore-operations/equistore/operations/ones_like.py
@@ -1,8 +1,7 @@
 from typing import List, Union
 
-from equistore.core import TensorBlock, TensorMap
-
 from . import _dispatch
+from ._classes import TensorBlock, TensorMap
 from ._utils import _check_gradient_presence_raise
 
 

--- a/python/equistore-operations/equistore/operations/random_like.py
+++ b/python/equistore-operations/equistore/operations/random_like.py
@@ -1,8 +1,7 @@
 from typing import List, Union
 
-from equistore.core import TensorBlock, TensorMap
-
 from . import _dispatch
+from ._classes import TensorBlock, TensorMap
 from ._utils import _check_gradient_presence_raise
 
 

--- a/python/equistore-operations/equistore/operations/reduce_over_samples.py
+++ b/python/equistore-operations/equistore/operations/reduce_over_samples.py
@@ -44,9 +44,8 @@ from typing import List, Optional, Union
 
 import numpy as np
 
-from equistore.core import Labels, TensorBlock, TensorMap
-
 from . import _dispatch
+from ._classes import Labels, TensorBlock, TensorMap
 
 
 def _reduce_over_samples_block(

--- a/python/equistore-operations/equistore/operations/remove_gradients.py
+++ b/python/equistore-operations/equistore/operations/remove_gradients.py
@@ -24,8 +24,8 @@ def remove_gradients(
     if remove is None:
         remove = tensor.block(0).gradients_list()
 
-    blocks = []
-    for block in tensor:
+    blocks: List[TensorBlock] = []
+    for block in tensor.blocks():
         new_block = TensorBlock(
             values=block.values,
             samples=block.samples,

--- a/python/equistore-operations/equistore/operations/remove_gradients.py
+++ b/python/equistore-operations/equistore/operations/remove_gradients.py
@@ -1,6 +1,6 @@
 from typing import List, Optional
 
-from equistore.core import TensorBlock, TensorMap
+from ._classes import TensorBlock, TensorMap
 
 
 def remove_gradients(

--- a/python/equistore-operations/equistore/operations/slice.py
+++ b/python/equistore-operations/equistore/operations/slice.py
@@ -2,7 +2,7 @@ from typing import Union
 
 import numpy as np
 
-from equistore.core import Labels, TensorBlock, TensorMap
+from ._classes import Labels, TensorBlock, TensorMap
 
 
 def slice(tensor: TensorMap, axis: str, labels: Labels) -> TensorMap:

--- a/python/equistore-operations/equistore/operations/solve.py
+++ b/python/equistore-operations/equistore/operations/solve.py
@@ -1,8 +1,7 @@
 import numpy as np
 
-from equistore.core import TensorBlock, TensorMap
-
 from . import _dispatch
+from ._classes import TensorBlock, TensorMap
 from ._utils import _check_same_gradients_raise, _check_same_keys_raise
 
 

--- a/python/equistore-operations/equistore/operations/split.py
+++ b/python/equistore-operations/equistore/operations/split.py
@@ -1,7 +1,6 @@
 from typing import List, Union
 
-from equistore.core import Labels, TensorBlock, TensorMap
-
+from ._classes import Labels, TensorBlock, TensorMap
 from .slice import _slice_block
 
 

--- a/python/equistore-operations/equistore/operations/subtract.py
+++ b/python/equistore-operations/equistore/operations/subtract.py
@@ -1,7 +1,6 @@
 from typing import Union
 
-from equistore.core import TensorMap
-
+from ._classes import TensorMap
 from .add import add
 from .multiply import multiply
 

--- a/python/equistore-operations/equistore/operations/to.py
+++ b/python/equistore-operations/equistore/operations/to.py
@@ -1,8 +1,7 @@
 from typing import Optional
 
-from equistore.core import TensorBlock, TensorMap
-
 from . import _dispatch
+from ._classes import TensorBlock, TensorMap
 
 
 def to(

--- a/python/equistore-operations/equistore/operations/unique_metadata.py
+++ b/python/equistore-operations/equistore/operations/unique_metadata.py
@@ -5,7 +5,7 @@ from typing import List, Optional, Tuple, Union
 
 import numpy as np
 
-from equistore.core import Labels, TensorBlock, TensorMap
+from ._classes import Labels, TensorBlock, TensorMap
 
 
 def unique_metadata(

--- a/python/equistore-operations/equistore/operations/zeros_like.py
+++ b/python/equistore-operations/equistore/operations/zeros_like.py
@@ -1,8 +1,7 @@
 from typing import List, Union
 
-from equistore.core import TensorBlock, TensorMap
-
 from . import _dispatch
+from ._classes import TensorBlock, TensorMap
 from ._utils import _check_gradient_presence_raise
 
 

--- a/python/equistore-operations/tests/remove_gradients.py
+++ b/python/equistore-operations/tests/remove_gradients.py
@@ -1,5 +1,4 @@
 import os
-import unittest
 
 import equistore
 
@@ -7,35 +6,27 @@ import equistore
 DATA_ROOT = os.path.join(os.path.dirname(__file__), "data")
 
 
-class TestRemoveGradients(unittest.TestCase):
-    def test_remove_everything(self):
-        tensor = equistore.load(
-            os.path.join(DATA_ROOT, "qm7-power-spectrum.npz"),
-            # the npz is using DEFLATE compression, equistore only supports STORED
-            use_numpy=True,
-        )
+def test_remove_everything():
+    tensor = equistore.load(
+        os.path.join(DATA_ROOT, "qm7-power-spectrum.npz"),
+        # the npz is using DEFLATE compression, equistore only supports STORED
+        use_numpy=True,
+    )
 
-        self.assertEqual(
-            set(tensor.block(0).gradients_list()), set(["cell", "positions"])
-        )
+    assert set(tensor.block(0).gradients_list()) == set(["cell", "positions"])
 
-        tensor = equistore.remove_gradients(tensor)
-        self.assertEqual(tensor.block(0).gradients_list(), [])
-
-    def test_remove_subset(self):
-        tensor = equistore.load(
-            os.path.join(DATA_ROOT, "qm7-power-spectrum.npz"),
-            # the npz is using DEFLATE compression, equistore only supports STORED
-            use_numpy=True,
-        )
-
-        self.assertEqual(
-            set(tensor.block(0).gradients_list()), set(["cell", "positions"])
-        )
-
-        tensor = equistore.remove_gradients(tensor, ["positions"])
-        self.assertEqual(tensor.block(0).gradients_list(), ["cell"])
+    tensor = equistore.remove_gradients(tensor)
+    assert tensor.block(0).gradients_list() == []
 
 
-if __name__ == "__main__":
-    unittest.main()
+def test_remove_subset():
+    tensor = equistore.load(
+        os.path.join(DATA_ROOT, "qm7-power-spectrum.npz"),
+        # the npz is using DEFLATE compression, equistore only supports STORED
+        use_numpy=True,
+    )
+
+    assert set(tensor.block(0).gradients_list()) == set(["cell", "positions"])
+
+    tensor = equistore.remove_gradients(tensor, ["positions"])
+    assert tensor.block(0).gradients_list() == ["cell"]

--- a/python/equistore-torch/equistore/torch/__init__.py
+++ b/python/equistore-torch/equistore/torch/__init__.py
@@ -30,6 +30,29 @@ else:
     save = torch.ops.equistore.save
 
 
+try:
+    import equistore.operations  # noqa
+
+    HAS_EQUISTORE_OPERATIONS = True
+except ImportError:
+    HAS_EQUISTORE_OPERATIONS = False
+
+
+if HAS_EQUISTORE_OPERATIONS:
+    from . import operations  # noqa
+    from .operations import *  # noqa
+
+
+else:
+    # __getattr__ is called when a symbol can not be found, we use it to give
+    # the user a better error message if they don't have equistore-operations
+    def __getattr__(name):
+        raise AttributeError(
+            f"equistore.torch.{name} is not defined, are you sure you have the "
+            "equistore-operations package installed?"
+        )
+
+
 __all__ = [
     "Labels",
     "TensorBlock",

--- a/python/equistore-torch/equistore/torch/operations.py
+++ b/python/equistore-torch/equistore/torch/operations.py
@@ -1,0 +1,78 @@
+import importlib
+import sys
+
+import equistore.operations
+from equistore.torch import Labels, TensorBlock, TensorMap
+
+
+#                       CAREFUL ADVENTURER, HERE BE DRAGONS!
+#
+#                                         \||/
+#                                         |  @___oo
+#                               /\  /\   / (__,,,,|
+#                              ) /^\) ^\/ _)
+#                              )   /^\/   _)
+#                              )   _ /  / _)
+#                          /\  )/\/ ||  | )_)
+#                         <  >      |(,,) )__)
+#                          ||      /    \)___)\
+#                          | \____(      )___) )___
+#                           \______(_______;;; __;;;
+#
+#
+# This module tries to re-use code from `equistore-operations` to expose TorchScript
+# compatible functions. To achieve this we need two things:
+#  - the code needs to use TorchScript compatible operations only
+#  - the type annotation of the functions have to refer to classes TorchScript knows
+#    about
+#
+# To achieve this, we import the modules in a special mode with `importlib`, first
+# creating the `equistore.torch.operations._classes` module, containing all equistore
+# classes plus a `TORCH_SCRIPT_MODE` constant to change the code between Python and
+# TorchScript modes.
+#
+# We then import the code from `equistore-operations` into a custom module
+# `equistore.torch.operations`. When code in this module tries to `from ._classes import
+# ...`, the import is resolved to the values defined in the step above. This allows to
+# have the right type annotation on the functions.
+#
+# Overall, the same code is used to define two versions of each function: one will be
+# used in `equistore`, and one in `equistore.torch`.
+
+
+# Step 1: create te `_classes` module as an empty module
+spec = importlib.util.spec_from_loader(
+    "equistore.torch.operations._classes",
+    loader=None,
+)
+module = importlib.util.module_from_spec(spec)
+# This module only exposes a handful of things, defined here. Any changes here MUST also
+# be made to the `equistore/operations/_classes.py` file, which is used in non
+# TorchScript mode.
+module.__dict__["Labels"] = Labels
+module.__dict__["TensorBlock"] = TensorBlock
+module.__dict__["TensorMap"] = TensorMap
+module.__dict__["TORCH_SCRIPT_MODE"] = True
+
+# register the module in sys.modules, so future import find it directly
+sys.modules[spec.name] = module
+
+
+# Step 2: create a module named `equistore.torch.operations` (like the one that will be
+# created by importing the current file), but using code from `equistore.operations`
+spec = importlib.util.spec_from_file_location(
+    # create a module with this name
+    "equistore.torch.operations",
+    # using the code from there
+    equistore.operations.__file__,
+)
+
+module = importlib.util.module_from_spec(spec)
+# override `equistore.torch.operations` (the module associated with the current file)
+# with the newly created module
+sys.modules[spec.name] = module
+spec.loader.exec_module(module)
+
+# Step 3: override the objects/functions/classes exposed by this module with the data
+# from the module we just created.
+globals().update(module.__dict__)

--- a/python/equistore-torch/tests/operations/data.py
+++ b/python/equistore-torch/tests/operations/data.py
@@ -1,0 +1,49 @@
+import os
+
+import torch
+
+import equistore.core
+from equistore.torch import Labels, TensorBlock, TensorMap
+
+
+ROOT = os.path.realpath(
+    os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        "..",
+        "..",
+        "equistore-operations",
+        "tests",
+        "data",
+    )
+)
+
+
+def load_data(data: str):
+    # we need to load from equistore-core and then convert to the torch types since
+    # the files are using DEFLATE compression, while equistore only supports STORED
+    tensor = equistore.core.load(os.path.join(ROOT, data), use_numpy=True)
+
+    blocks = []
+    for block in tensor:
+        blocks.append(_block_to_torch(block))
+
+    return TensorMap(_labels_to_torch(tensor.keys), blocks)
+
+
+def _labels_to_torch(labels):
+    return Labels(labels.names, torch.tensor(labels.values))
+
+
+def _block_to_torch(block):
+    new_block = TensorBlock(
+        torch.tensor(block.values),
+        _labels_to_torch(block.samples),
+        [_labels_to_torch(c) for c in block.components],
+        _labels_to_torch(block.properties),
+    )
+
+    for parameter, gradient in block.gradients():
+        new_block.add_gradient(parameter, _block_to_torch(gradient))
+
+    return new_block

--- a/python/equistore-torch/tests/operations/remove_gradients.py
+++ b/python/equistore-torch/tests/operations/remove_gradients.py
@@ -1,0 +1,36 @@
+import torch
+from packaging import version
+
+import equistore.torch
+
+from .data import load_data
+
+
+def check_operation(remove_gradients):
+    # this only runs basic checks functionality checks, and that the code produces
+    # output with the right type
+    tensor = load_data("qm7-power-spectrum.npz")
+
+    assert isinstance(tensor, torch.ScriptObject)
+    if version.parse(torch.__version__) >= version.parse("2.1"):
+        assert tensor._type().name() == "TensorMap"
+
+    assert set(tensor.block(0).gradients_list()) == set(["cell", "positions"])
+
+    tensor = remove_gradients(tensor, ["positions"])
+
+    assert isinstance(tensor, torch.ScriptObject)
+    if version.parse(torch.__version__) >= version.parse("2.1"):
+        assert tensor._type().name() == "TensorMap"
+
+    assert tensor.block(0).gradients_list() == ["cell"]
+
+
+def test_operation_as_python():
+    check_operation(equistore.torch.remove_gradients)
+
+
+def test_operation_as_torch_script():
+    scripted = torch.jit.script(equistore.torch.remove_gradients)
+
+    check_operation(scripted)

--- a/tox.ini
+++ b/tox.ini
@@ -79,6 +79,9 @@ changedir = python/equistore-torch
 commands =
     # install equistore-torch
     pip install . {[testenv]build_single_wheel} --force-reinstall
+    # install equistore-operations
+    pip install ../equistore-operations {[testenv]build_single_wheel} --force-reinstall
+
     # run the unit tests
     pytest --import-mode=append {posargs}
 
@@ -91,6 +94,11 @@ deps =
     torch
 
     cmake
+
+setenv =
+    # ignore the fact that equistore.torch.operations was loaded from a file
+    # not in `equistore/torch/operations`
+    PY_IGNORE_IMPORTMISMATCH = 1
 
 commands =
     # equistore-core is installed by tox


### PR DESCRIPTION
Part of #133, this only introduces the infrastructure to import the code twice within two different contexts, and porting a single operation to be fully compatible with TorchScript. (the corresponding commit can be used as inspiration for the other operations, which I'll leave to future PR)

<!-- readthedocs-preview equistore start -->
----
:books: Documentation preview :books:: https://equistore--320.org.readthedocs.build/en/320/

<!-- readthedocs-preview equistore end -->