### PR TITLE
Make equistore.operations._utils TorchScript compatible

### DIFF
--- a/equistore-torch/include/equistore/torch/labels.hpp
+++ b/equistore-torch/include/equistore/torch/labels.hpp
@@ -70,7 +70,7 @@ public:
     LabelsHolder(equistore::Labels labels);
 
     /// Get the names of the dimensions/columns of these Labels
-    const std::vector<std::string>& names() const {
+    std::vector<std::string> names() const {
         return names_;
     }
 
@@ -233,7 +233,7 @@ public:
     }
 
     /// Get the names of the dimensions/columns of these Labels
-    const std::vector<std::string>& names() const {
+    std::vector<std::string> names() const {
         return labels_->names();
     }
 

--- a/equistore-torch/src/labels.cpp
+++ b/equistore-torch/src/labels.cpp
@@ -319,7 +319,7 @@ TorchLabels LabelsHolder::permute(std::vector<int64_t> dimensions_indexes) {
         }
         new_names.push_back(names[index]);
     }
- 
+
     auto new_values = this->values().index({torch::indexing::Slice(), torch::tensor(dimensions_indexes)});
 
     return torch::make_intrusive<LabelsHolder>(std::move(new_names), std::move(new_values));

--- a/python/equistore-operations/equistore/operations/_classes.py
+++ b/python/equistore-operations/equistore/operations/_classes.py
@@ -12,10 +12,16 @@
 from equistore.core import Labels, TensorBlock, TensorMap
 
 
-TORCH_SCRIPT_MODE = False
+def torch_jit_is_scripting():
+    return False
+
+
+check_isinstance = isinstance
+
 __all__ = [
     "Labels",
     "TensorBlock",
     "TensorMap",
-    "TORCH_SCRIPT_MODE",
+    "torch_jit_is_scripting",
+    "check_isinstance",
 ]

--- a/python/equistore-operations/equistore/operations/_utils.py
+++ b/python/equistore-operations/equistore/operations/_utils.py
@@ -19,7 +19,7 @@ def _check_same_keys(a: TensorMap, b: TensorMap, fname: str) -> bool:
 
 def _check_same_keys_raise(a: TensorMap, b: TensorMap, fname: str) -> None:
     """
-    If the keys of 2 TensorMaps are not the same, raises a NotEqualError, othwerwise
+    If the keys of 2 TensorMaps are not the same, raises a NotEqualError, otherwise
     returns None.
     """
     message = _check_same_keys_impl(a, b, fname)
@@ -47,18 +47,18 @@ def _check_same_keys_impl(a: TensorMap, b: TensorMap, fname: str) -> str:
 
     if keys_a.names != keys_b.names:
         return (
-            f"inputs to {fname} should have the same keys names, "
+            f"inputs to '{fname}' should have the same keys names, "
             f"got '{keys_a.names}' and '{keys_b.names}'"
         )
 
     if len(keys_a) != len(keys_b):
         return (
-            f"inputs to {fname} should have the same number of blocks, "
+            f"inputs to '{fname}' should have the same number of blocks, "
             f"got {len(keys_a)} and {len(keys_b)}"
         )
 
     if not all([keys_b[i] in keys_a for i in range(len(keys_b))]):
-        return f"inputs to {fname} should have the same keys"
+        return f"inputs to '{fname}' should have the same keys"
 
     return ""
 
@@ -141,40 +141,30 @@ def _check_blocks_impl(
         metadata_to_check = check
 
     for metadata in metadata_to_check:
-        err_msg = f"inputs to '{fname}' should have the same {metadata}:\n"
-        err_msg_len = f"{metadata} of the two `TensorBlock` have different lengths"
-        err_msg_1 = f"{metadata} are not the same or not in the same order"
-        err_msg_names = f"{metadata} names are not the same or not in the same order"
-
         if metadata == "samples":
-            if not len(a.samples) == len(b.samples):
-                return err_msg + err_msg_len
-            if not a.samples.names == b.samples.names:
-                return err_msg + err_msg_names
             if not a.samples == b.samples:
-                return err_msg + err_msg_1
+                return (
+                    f"inputs to '{fname}' should have the same samples, "
+                    "but they are not the same or not in the same order"
+                )
 
         elif metadata == "properties":
-            if not len(a.properties) == len(b.properties):
-                return err_msg + err_msg_len
-            if not a.properties.names == b.properties.names:
-                return err_msg + err_msg_names
             if not a.properties == b.properties:
-                return err_msg + err_msg_1
+                return (
+                    f"inputs to '{fname}' should have the same properties, "
+                    "but they are not the same or not in the same order"
+                )
 
         elif metadata == "components":
             if len(a.components) != len(b.components):
-                return err_msg + err_msg_len
+                return f"inputs to '{fname}' have a different number of components"
 
             for c1, c2 in zip(a.components, b.components):
-                if not (c1.names == c2.names):
-                    return err_msg + err_msg_names
-
-                if not (len(c1) == len(c2)):
-                    return err_msg + err_msg_1
-
                 if not c1 == c2:
-                    return err_msg + err_msg_1
+                    return (
+                        f"inputs to '{fname}' should have the same components, "
+                        "but they are not the same or not in the same order"
+                    )
         else:
             raise ValueError(
                 f"{metadata} is not a valid property to check, "
@@ -277,57 +267,40 @@ def _check_same_gradients_impl(
     else:
         metadata_to_check = check
 
-    err_msg = f"inputs to {fname} should have the same gradients:\n"
+    err_msg = f"inputs to '{fname}' should have the same gradients: "
     gradients_list_a = a.gradients_list()
     gradients_list_b = b.gradients_list()
 
     if len(gradients_list_a) != len(gradients_list_b) or (
         not all([parameter in gradients_list_b for parameter in gradients_list_a])
     ):
-        return f"inputs to {fname} should have the same gradient parameters"
+        return f"inputs to '{fname}' should have the same gradient parameters"
 
     for parameter, grad_a in a.gradients():
         grad_b = b.gradient(parameter)
 
         for metadata in metadata_to_check:
-            err_msg_len = (
-                f"gradient '{parameter}' {metadata} of the two `TensorBlock` "
-                "have different lengths"
-            )
-
             err_msg_1 = (
                 f"gradient '{parameter}' {metadata} are not the same or not in the "
                 "same order"
             )
 
-            err_msg_names = (
-                f"gradient '{parameter}' {metadata} names are not the same "
-                "or not in the same order"
-            )
-
             if metadata == "samples":
-                if not len(grad_a.samples) == len(grad_b.samples):
-                    return err_msg + err_msg_len
-                if not grad_a.samples.names == grad_b.samples.names:
-                    return err_msg + err_msg_names
                 if not grad_a.samples == grad_b.samples:
                     return err_msg + err_msg_1
 
             elif metadata == "properties":
-                if not len(grad_a.properties) == len(grad_b.properties):
-                    return err_msg + err_msg_len
-                if not grad_a.properties.names == grad_b.properties.names:
-                    return err_msg + err_msg_names
                 if not grad_a.properties == grad_b.properties:
                     return err_msg + err_msg_1
+
             elif metadata == "components":
                 if len(grad_a.components) != len(grad_b.components):
-                    return err_msg + err_msg_len
+                    extra = (
+                        f"gradient '{parameter}' have different number of components"
+                    )
+                    return err_msg + extra
 
                 for c1, c2 in zip(grad_a.components, grad_b.components):
-                    if not (c1.names == c2.names):
-                        return err_msg + err_msg_names
-
                     if not c1 == c2:
                         return err_msg + err_msg_1
             else:
@@ -351,6 +324,6 @@ def _check_gradient_presence_raise(
     for parameter in parameters:
         if parameter not in block.gradients_list():
             raise ValueError(
-                f"requested gradient '{parameter}' in {fname} is not defined "
+                f"requested gradient '{parameter}' in '{fname}' is not defined "
                 "in this tensor"
             )

--- a/python/equistore-operations/equistore/operations/_utils.py
+++ b/python/equistore-operations/equistore/operations/_utils.py
@@ -134,11 +134,13 @@ def _check_blocks_impl(
     """
     if isinstance(check, str):
         if check == "all":
-            check = ["samples", "components", "properties"]
+            metadata_to_check = ["samples", "components", "properties"]
         else:
             raise ValueError("`check` must be a list of strings or 'all'")
+    else:
+        metadata_to_check = check
 
-    for metadata in check:
+    for metadata in metadata_to_check:
         err_msg = f"inputs to '{fname}' should have the same {metadata}:\n"
         err_msg_len = f"{metadata} of the two `TensorBlock` have different lengths"
         err_msg_1 = f"{metadata} are not the same or not in the same order"
@@ -269,9 +271,11 @@ def _check_same_gradients_impl(
     """
     if isinstance(check, str):
         if check == "all":
-            check = ["samples", "components", "properties"]
+            metadata_to_check = ["samples", "components", "properties"]
         else:
             raise ValueError("`check` must be a list of strings or 'all'")
+    else:
+        metadata_to_check = check
 
     err_msg = f"inputs to {fname} should have the same gradients:\n"
     gradients_list_a = a.gradients_list()
@@ -285,7 +289,7 @@ def _check_same_gradients_impl(
     for parameter, grad_a in a.gradients():
         grad_b = b.gradient(parameter)
 
-        for metadata in check:
+        for metadata in metadata_to_check:
             err_msg_len = (
                 f"gradient '{parameter}' {metadata} of the two `TensorBlock` "
                 "have different lengths"

--- a/python/equistore-operations/equistore/operations/add.py
+++ b/python/equistore-operations/equistore/operations/add.py
@@ -42,13 +42,11 @@ def add(A: TensorMap, B: Union[float, TensorMap]) -> TensorMap:
             _check_blocks_raise(
                 block_A,
                 block_B,
-                check=("samples", "components", "properties"),
                 fname="add",
             )
             _check_same_gradients_raise(
                 block_A,
                 block_B,
-                check=("samples", "components", "properties"),
                 fname="add",
             )
             blocks.append(_add_block_block(block_1=block_A, block_2=block_B))

--- a/python/equistore-operations/equistore/operations/allclose.py
+++ b/python/equistore-operations/equistore/operations/allclose.py
@@ -310,12 +310,11 @@ def allclose_raise(
     If this is executed yourself, you will see a nested exception explaining that the
     ``values`` of the two blocks are not `allclose`.
 
-    >>> try:
-    ...     allclose_raise(tensor_1, tensor_2)
-    ... except equistore.NotEqualError as e:
-    ...     print(f"got an exception: {e}")
-    ...
-    got an exception: blocks for key (key=0) are different: values are not allclose
+    >>> allclose_raise(tensor_1, tensor_2)
+    Traceback (most recent call last):
+        ...
+    equistore.operations._utils.NotEqualError: blocks for key (key=0) are different: \
+values are not allclose
 
     call :py:func:`equistore.allclose_raise()` again, but use ``equal_nan=True`` and
     ``rtol=1e-5`` This passes, as the two ``NaN`` are now considered equal, and the
@@ -508,13 +507,11 @@ def allclose_block_raise(
     :py:func:`equistore.NotEqualError` because the properties of the two blocks are not
     `equal`.
 
-    >>> try:
-    ...     allclose_block_raise(block_1, block_2)
-    ... except equistore.NotEqualError as e:
-    ...     print(f"got an exception: {e}")
-    ...
-    got an exception: inputs to 'allclose' should have the same properties:
-    properties names are not the same or not in the same order
+    >>> allclose_block_raise(block_1, block_2)
+    Traceback (most recent call last):
+        ...
+    equistore.operations._utils.NotEqualError: inputs to 'allclose' should have the \
+same properties, but they are not the same or not in the same order
     """
     message = _allclose_block_impl(
         block_1=block_1, block_2=block_2, rtol=rtol, atol=atol, equal_nan=equal_nan

--- a/python/equistore-operations/equistore/operations/allclose.py
+++ b/python/equistore-operations/equistore/operations/allclose.py
@@ -48,7 +48,6 @@ def _allclose_block_impl(
     check_blocks_message = _check_blocks_impl(
         block_1,
         block_2,
-        check=("samples", "properties", "components"),
         fname="allclose",
     )
     if check_blocks_message != "":

--- a/python/equistore-operations/equistore/operations/divide.py
+++ b/python/equistore-operations/equistore/operations/divide.py
@@ -46,13 +46,11 @@ def divide(A: TensorMap, B: Union[float, TensorMap]) -> TensorMap:
             _check_blocks_raise(
                 block_A,
                 block_B,
-                check=("samples", "components", "properties"),
                 fname="divide",
             )
             _check_same_gradients_raise(
                 block_A,
                 block_B,
-                check=("samples", "components", "properties"),
                 fname="divide",
             )
             blocks.append(_divide_block_block(block_1=block_A, block_2=block_B))

--- a/python/equistore-operations/equistore/operations/equal_metadata.py
+++ b/python/equistore-operations/equistore/operations/equal_metadata.py
@@ -1,7 +1,7 @@
 """
 Module for checking equivalence in metadata between 2 TensorMaps
 """
-from typing import Optional, Sequence
+from typing import List, Union
 
 from ._classes import TensorBlock, TensorMap
 from ._utils import (
@@ -15,18 +15,12 @@ from ._utils import (
 def _equal_metadata_impl(
     tensor_1: TensorMap,
     tensor_2: TensorMap,
-    check: Optional[Sequence[str]] = ("samples", "components", "properties"),
+    check: Union[List[str], str] = "all",
 ) -> str:
     if not isinstance(tensor_1, TensorMap):
         return f"`tensor_1` must be a TensorMap, not {type(tensor_1)}"
     if not isinstance(tensor_2, TensorMap):
         return f"`tensor_2` must be a TensorMap, not {type(tensor_2)}"
-    for metadata in check:
-        if not isinstance(metadata, str):
-            return f"`check` must be a list of strings, got list of {type(metadata)}"
-
-        if metadata not in ("samples", "components", "properties"):
-            return f"Invalid metadata to check: {metadata}"
 
     message = _check_same_keys_impl(tensor_1, tensor_2, "equal_metadata_raise")
     if message != "":
@@ -43,17 +37,12 @@ def _equal_metadata_impl(
 def _equal_metadata_block_impl(
     block_1: TensorBlock,
     block_2: TensorBlock,
-    check: Optional[Sequence[str]] = ("samples", "components", "properties"),
+    check: Union[List[str], str] = "all",
 ) -> str:
     if not isinstance(block_1, TensorBlock):
         return f"`block_1` must be a TensorBlock, not {type(block_1)}"
     if not isinstance(block_2, TensorBlock):
         return f"`block_2` must be a TensorBlock, not {type(block_2)}"
-    for metadata in check:
-        if not isinstance(metadata, str):
-            return f"`check` must be a list of strings, got list of {type(metadata)}"
-        if metadata not in ("samples", "components", "properties"):
-            return f"Invalid metadata to check: {metadata}"
 
     check_blocks_message = _check_blocks_impl(
         block_1,
@@ -61,14 +50,17 @@ def _equal_metadata_block_impl(
         "equal_metadata_block_raise",
         check=check,
     )
+
     if check_blocks_message != "":
         return check_blocks_message
+
     check_same_gradient_message = _check_same_gradients_impl(
         block_1,
         block_2,
         "equal_metadata_block_raise",
         check=check,
     )
+
     if check_same_gradient_message != "":
         return check_same_gradient_message
 
@@ -78,28 +70,29 @@ def _equal_metadata_block_impl(
 def equal_metadata(
     tensor_1: TensorMap,
     tensor_2: TensorMap,
-    check: Optional[Sequence[str]] = ("samples", "components", "properties"),
+    check: Union[List[str], str] = "all",
 ) -> bool:
     """
-    Checks if two :py:class:`TensorMap` objects have the same metadata,
-    returning a bool.
+    Checks if two :py:class:`TensorMap` objects have the same metadata, returning a
+    bool.
 
-    The equivalence of the keys of the two :py:class:`TensorMap` objects is
-    always checked. If ``check`` is none (the default), all metadata (i.e. the
-    samples, components, and properties of each block) is checked to contain the
-    same values in the same order.
+    The equivalence of the keys of the two :py:class:`TensorMap` objects is always
+    checked.
 
-    Passing ``check`` as a list of strings will only check the metadata specified.
-    Allowed values to pass are "samples", "components", and "properties".
+    If ``check`` is ``'all'`` (the default), all metadata (i.e. the samples, components,
+    and properties of each block) is checked to contain the same values in the same
+    order. Passing ``check`` as a list of strings will only check the specified
+    metadata. Allowed values to pass are ``'samples'``, ``'components'``, and
+    ``'properties'``.
 
     :param tensor_1: The first :py:class:`TensorMap`.
     :param tensor_2: The second :py:class:`TensorMap` to compare to the first.
-    :param check: A sequence of strings specifying which metadata of each block to
-        check. If none, all metadata is checked. Allowed values are "samples",
-        "components", and "properties".
+    :param check: Which parts of the metadata to check. This can be a list containing
+        any of ``'samples'``, ``'components'``, and ``'properties'``; or the string
+        ``'all'`` to check everything. Defaults to ``'all'``.
 
-    :return: True if the metadata of the two :py:class:`TensorMap` objects are
-        equal, False otherwise.
+    :return: True if the metadata of the two :py:class:`TensorMap` objects are equal,
+        False otherwise.
 
     Examples
     --------
@@ -161,25 +154,26 @@ def equal_metadata(
 def equal_metadata_raise(
     tensor_1: TensorMap,
     tensor_2: TensorMap,
-    check: Optional[Sequence[str]] = ("samples", "components", "properties"),
+    check: Union[List[str], str] = "all",
 ):
     """
     Raise a :py:class:`NotEqualError` if two :py:class:`TensorMap` have unequal
     metadata.
 
-    The equivalence of the keys of the two :py:class:`TensorMap` objects is
-    always checked. If ``check`` is none (the default), all metadata (i.e. the
-    samples, components, and properties of each block) is checked to contain the
-    same values in the same order.
+    The equivalence of the keys of the two :py:class:`TensorMap` objects is always
+    checked.
 
-    Passing ``check`` as a list of strings will only check the metadata specified.
-    Allowed values to pass are "samples", "components", and "properties".
+    If ``check`` is ``'all'`` (the default), all metadata (i.e. the samples, components,
+    and properties of each block) is checked to contain the same values in the same
+    order. Passing ``check`` as a list of strings will only check the specified
+    metadata. Allowed values to pass are ``'samples'``, ``'components'``, and
+    ``'properties'``.
 
     :param tensor_1: The first :py:class:`TensorMap`.
     :param tensor_2: The second :py:class:`TensorMap` to compare to the first.
-    :param check: A sequence of strings specifying which metadata of each block to
-        check. If none, all metadata is checked. Allowed values are "samples",
-        "components", and "properties".
+    :param check: Which parts of the metadata to check. This can be a list containing
+        any of ``'samples'``, ``'components'``, and ``'properties'``; or the string
+        ``'all'`` to check everything. Defaults to ``'all'``.
     :raises NotEqualError: If the metadata is not the same.
 
     Examples
@@ -246,27 +240,26 @@ def equal_metadata_raise(
 def equal_metadata_block(
     block_1: TensorBlock,
     block_2: TensorBlock,
-    check: Optional[Sequence[str]] = ("samples", "components", "properties"),
+    check: Union[List[str], str] = "all",
 ) -> bool:
     """
-    Checks if two :py:class:`TensorBlock` objects have the same metadata,
-    returning a bool.
+    Checks if two :py:class:`TensorBlock` objects have the same metadata, returning a
+    bool.
 
-    If ``check`` is none (the default), all metadata (i.e. the samples,
-    components, and properties of each block) is checked to contain the same
-    values in the same order.
-
-    Passing ``check`` as a list of strings will only check the metadata specified.
-    Allowed values to pass are "samples", "components", and "properties".
+    If ``check`` is ``'all'`` (the default), all metadata (i.e. the samples, components,
+    and properties of each block) is checked to contain the same values in the same
+    order. Passing ``check`` as a list of strings will only check the specified
+    metadata. Allowed values to pass are ``'samples'``, ``'components'``, and
+    ``'properties'``.
 
     :param block_1: The first :py:class:`TensorBlock`.
     :param block_2: The second :py:class:`TensorBlock` to compare to the first.
-    :param check: A list of strings specifying which metadata of each block to
-        check. If none, all metadata is checked. Allowed values are "samples",
-        "components", and "properties".
+    :param check: Which parts of the metadata to check. This can be a list containing
+        any of ``'samples'``, ``'components'``, and ``'properties'``; or the string
+        ``'all'`` to check everything. Defaults to ``'all'``.
 
-    :return: True if the metadata of the two :py:class:`TensorBlock` objects are
-        equal, False otherwise.
+    :return: True if the metadata of the two :py:class:`TensorBlock` objects are equal,
+        False otherwise.
 
     Examples
     --------
@@ -300,18 +293,17 @@ def equal_metadata_block(
 def equal_metadata_block_raise(
     block_1: TensorBlock,
     block_2: TensorBlock,
-    check: Optional[Sequence[str]] = ("samples", "components", "properties"),
+    check: Union[List[str], str] = "all",
 ):
     """
     Raise a :py:class:`NotEqualError` if two :py:class:`TensorBlock` have unequal
     metadata.
 
-    If ``check`` is none (the default), all metadata (i.e. the samples,
-    components, and properties of each block) is checked to contain the same
-    values in the same order.
-
-    Passing ``check`` as a list of strings will only check the metadata specified.
-    Allowed values to pass are "samples", "components", and "properties".
+    If ``check`` is ``'all'`` (the default), all metadata (i.e. the samples, components,
+    and properties of each block) is checked to contain the same values in the same
+    order. Passing ``check`` as a list of strings will only check the specified
+    metadata. Allowed values to pass are ``'samples'``, ``'components'``, and
+    ``'properties'``.
 
     :param block_1: The first :py:class:`TensorBlock`.
     :param block_2: The second :py:class:`TensorBlock` to compare to the first.

--- a/python/equistore-operations/equistore/operations/equal_metadata.py
+++ b/python/equistore-operations/equistore/operations/equal_metadata.py
@@ -3,7 +3,7 @@ Module for checking equivalence in metadata between 2 TensorMaps
 """
 from typing import List, Union
 
-from ._classes import TensorBlock, TensorMap
+from ._classes import TensorBlock, TensorMap, check_isinstance, torch_jit_is_scripting
 from ._utils import (
     NotEqualError,
     _check_blocks_impl,
@@ -17,16 +17,17 @@ def _equal_metadata_impl(
     tensor_2: TensorMap,
     check: Union[List[str], str] = "all",
 ) -> str:
-    if not isinstance(tensor_1, TensorMap):
-        return f"`tensor_1` must be a TensorMap, not {type(tensor_1)}"
-    if not isinstance(tensor_2, TensorMap):
-        return f"`tensor_2` must be a TensorMap, not {type(tensor_2)}"
+    if not torch_jit_is_scripting():
+        if not check_isinstance(tensor_1, TensorMap):
+            return f"`tensor_1` must be a TensorMap, not {type(tensor_1)}"
+        if not check_isinstance(tensor_2, TensorMap):
+            return f"`tensor_2` must be a TensorMap, not {type(tensor_2)}"
 
     message = _check_same_keys_impl(tensor_1, tensor_2, "equal_metadata_raise")
     if message != "":
         return message
 
-    for key in tensor_1.keys:
+    for key in [tensor_1.keys[i] for i in range(len(tensor_1.keys))]:
         message = _equal_metadata_block_impl(tensor_1[key], tensor_2[key], check=check)
         if message != "":
             return message
@@ -39,10 +40,11 @@ def _equal_metadata_block_impl(
     block_2: TensorBlock,
     check: Union[List[str], str] = "all",
 ) -> str:
-    if not isinstance(block_1, TensorBlock):
-        return f"`block_1` must be a TensorBlock, not {type(block_1)}"
-    if not isinstance(block_2, TensorBlock):
-        return f"`block_2` must be a TensorBlock, not {type(block_2)}"
+    if not torch_jit_is_scripting():
+        if not check_isinstance(block_1, TensorBlock):
+            return f"`block_1` must be a TensorBlock, not {type(block_1)}"
+        if not check_isinstance(block_2, TensorBlock):
+            return f"`block_2` must be a TensorBlock, not {type(block_2)}"
 
     check_blocks_message = _check_blocks_impl(
         block_1,

--- a/python/equistore-operations/equistore/operations/equal_metadata.py
+++ b/python/equistore-operations/equistore/operations/equal_metadata.py
@@ -226,8 +226,7 @@ def equal_metadata_raise(
     >>> equistore.equal_metadata_raise(tensor_1, tensor_2)
     Traceback (most recent call last):
         ...
-    equistore.operations._utils.NotEqualError: inputs to 'equal_metadata_block_raise' should have the same properties:
-    properties names are not the same or not in the same order
+    equistore.operations._utils.NotEqualError: inputs to 'equal_metadata_block_raise' should have the same properties, but they are not the same or not in the same order
     >>> equistore.equal_metadata_raise(
     ...     tensor_1,
     ...     tensor_2,
@@ -334,8 +333,8 @@ def equal_metadata_block_raise(
     >>> equistore.equal_metadata_block_raise(block_1, block_2)
     Traceback (most recent call last):
         ...
-    equistore.operations._utils.NotEqualError: inputs to 'equal_metadata_block_raise' should have the same properties:
-    properties names are not the same or not in the same order
+    equistore.operations._utils.NotEqualError: inputs to 'equal_metadata_block_raise' \
+should have the same properties, but they are not the same or not in the same order
     >>> equistore.equal_metadata_block_raise(
     ...     block_1, block_2, check=("samples", "components")
     ... )

--- a/python/equistore-operations/equistore/operations/lstsq.py
+++ b/python/equistore-operations/equistore/operations/lstsq.py
@@ -112,8 +112,8 @@ def lstsq(X: TensorMap, Y: TensorMap, rcond, driver=None) -> TensorMap:
 
 
 def _lstsq_block(X: TensorBlock, Y: TensorBlock, rcond, driver) -> TensorBlock:
-    _check_blocks_raise(X, Y, check=("samples", "components"), fname="lstsq")
-    _check_same_gradients_raise(X, Y, check=("samples", "components"), fname="lstsq")
+    _check_blocks_raise(X, Y, check=["samples", "components"], fname="lstsq")
+    _check_same_gradients_raise(X, Y, check=["samples", "components"], fname="lstsq")
 
     # reshape components together with the samples
     X_n_properties = X.values.shape[-1]

--- a/python/equistore-operations/tests/allclose.py
+++ b/python/equistore-operations/tests/allclose.py
@@ -198,15 +198,15 @@ def test_self_allclose_exceptions():
     assert not equistore.allclose_block(block_1, block_2)
 
     message = (
-        "inputs to 'allclose' should have the same samples:\n"
-        "samples names are not the same or not in the same order"
+        "inputs to 'allclose' should have the same samples, "
+        "but they are not the same or not in the same order"
     )
     with pytest.raises(NotEqualError, match=message):
         equistore.allclose_block_raise(block_1, block_2)
 
     message = (
-        "inputs to 'allclose' should have the same samples:\n"
-        "samples are not the same or not in the same order"
+        "inputs to 'allclose' should have the same samples, "
+        "but they are not the same or not in the same order"
     )
     with pytest.raises(NotEqualError, match=message):
         equistore.allclose_block_raise(block_1, block_3)
@@ -216,15 +216,15 @@ def test_self_allclose_exceptions():
         equistore.allclose_block_raise(block_1, block_4)
 
     message = (
-        "inputs to 'allclose' should have the same components:\n"
-        "components names are not the same or not in the same order"
+        "inputs to 'allclose' should have the same components, "
+        "but they are not the same or not in the same order"
     )
     with pytest.raises(NotEqualError, match=message):
         equistore.allclose_block_raise(block_5, block_4)
 
     message = (
-        "inputs to 'allclose' should have the same samples:\n"
-        "samples are not the same or not in the same order"
+        "inputs to 'allclose' should have the same samples, "
+        "but they are not the same or not in the same order"
     )
     with pytest.raises(NotEqualError, match=message):
         equistore.allclose_block_raise(block_6, block_4)
@@ -266,8 +266,8 @@ def test_self_allclose_exceptions_gradient():
     )
 
     message = (
-        "inputs to allclose should have the same gradients:\n"
-        "gradient 'g' samples names are not the same or not in the same order"
+        "inputs to 'allclose' should have the same gradients: "
+        "gradient 'g' samples are not the same or not in the same order"
     )
     with pytest.raises(NotEqualError, match=message):
         equistore.allclose_block_raise(block_1, block_2)
@@ -328,7 +328,7 @@ def test_self_allclose_exceptions_gradient():
     )
 
     message = (
-        "inputs to allclose should have the same gradients:\n"
+        "inputs to 'allclose' should have the same gradients: "
         "gradient 'g' components are not the same or not in the same order"
     )
     with pytest.raises(NotEqualError, match=message):

--- a/python/equistore-operations/tests/empty_like.py
+++ b/python/equistore-operations/tests/empty_like.py
@@ -30,7 +30,7 @@ def test_empty_like_error():
         use_numpy=True,
     )
 
-    message = "requested gradient 'err' in empty_like is not defined in this tensor"
+    message = "requested gradient 'err' in 'empty_like' is not defined in this tensor"
     with pytest.raises(ValueError, match=message):
         tensor = equistore.empty_like(tensor, gradients=["positions", "err"])
 

--- a/python/equistore-operations/tests/equal.py
+++ b/python/equistore-operations/tests/equal.py
@@ -195,15 +195,15 @@ def test_self_equal_exceptions():
     assert not equistore.equal_block(block_1, block_2)
 
     message = (
-        "inputs to 'equal' should have the same samples:\n"
-        "samples names are not the same or not in the same order"
+        "inputs to 'equal' should have the same samples, "
+        "but they are not the same or not in the same order"
     )
     with pytest.raises(NotEqualError, match=message):
         equistore.equal_block_raise(block_1, block_2)
 
     message = (
-        "inputs to 'equal' should have the same samples:\n"
-        "samples are not the same or not in the same order"
+        "inputs to 'equal' should have the same samples, "
+        "but they are not the same or not in the same order"
     )
     with pytest.raises(NotEqualError, match=message):
         equistore.equal_block_raise(block_1, block_3)
@@ -212,15 +212,15 @@ def test_self_equal_exceptions():
         equistore.equal_block_raise(block_1, block_4)
 
     message = (
-        "inputs to 'equal' should have the same components:\n"
-        "components names are not the same or not in the same order"
+        "inputs to 'equal' should have the same components, "
+        "but they are not the same or not in the same order"
     )
     with pytest.raises(NotEqualError, match=message):
         equistore.equal_block_raise(block_5, block_4)
 
     message = (
-        "inputs to 'equal' should have the same samples:\n"
-        "samples are not the same or not in the same order"
+        "inputs to 'equal' should have the same samples, "
+        "but they are not the same or not in the same order"
     )
     with pytest.raises(NotEqualError, match=message):
         equistore.equal_block_raise(block_6, block_4)
@@ -258,8 +258,8 @@ def test_self_equal_exceptions():
     assert not equistore.equal_block(block_8, block_9)
 
     message = (
-        "inputs to 'equal' should have the same components:\n"
-        "components are not the same or not in the same order"
+        "inputs to 'equal' should have the same components, "
+        "but they are not the same or not in the same order"
     )
     with pytest.raises(NotEqualError, match=message):
         equistore.equal_block_raise(block_7, block_8)
@@ -304,8 +304,8 @@ def test_self_equal_exceptions_gradient():
     )
 
     message = (
-        "inputs to equal should have the same gradients:\n"
-        "gradient 'g' samples names are not the same or not in the same order"
+        "inputs to 'equal' should have the same gradients: "
+        "gradient 'g' samples are not the same or not in the same order"
     )
     with pytest.raises(NotEqualError, match=message):
         equistore.equal_block_raise(block_1, block_2)
@@ -365,7 +365,7 @@ def test_self_equal_exceptions_gradient():
     )
 
     message = (
-        "inputs to equal should have the same gradients:\n"
+        "inputs to 'equal' should have the same gradients: "
         "gradient 'g' components are not the same or not in the same order"
     )
     with pytest.raises(NotEqualError, match=message):
@@ -389,8 +389,8 @@ def test_self_equal_exceptions_gradient():
     )
 
     message = (
-        "inputs to equal should have the same gradients:\n"
-        "gradient 'g' samples names are not the same or not in the same order"
+        "inputs to 'equal' should have the same gradients: "
+        "gradient 'g' samples are not the same or not in the same order"
     )
     with pytest.raises(NotEqualError, match=message):
         equistore.equal_block_raise(block_5, block_6)

--- a/python/equistore-operations/tests/equal_metadata.py
+++ b/python/equistore-operations/tests/equal_metadata.py
@@ -166,7 +166,9 @@ def test_two_tensors_block(test_tensor_block_1, test_tensor_block_2):
 
 def test_two_tensors_block_raise(test_tensor_block_1, test_tensor_block_2):
     """check error raise if the metadata of two tensor maps are equal"""
-    error_message = "components of the two `TensorBlock` have different lengths"
+    error_message = (
+        "inputs to 'equal_metadata_block_raise' have a different number of components"
+    )
     with pytest.raises(NotEqualError, match=error_message):
         equistore.equal_metadata_block_raise(test_tensor_block_1, test_tensor_block_2)
 

--- a/python/equistore-operations/tests/equal_metadata.py
+++ b/python/equistore-operations/tests/equal_metadata.py
@@ -191,68 +191,53 @@ def test_after_drop_raise(test_tensor_map_1):
         equistore.equal_metadata_raise(test_tensor_map_1, new_tensor)
 
 
-def test_single_nonexisting_meta(test_tensor_map_1, test_tensor_map_2):
+def test_single_nonexisting_meta(test_tensor_map_1):
     """check behavior if non existing metadata is provided"""
     # wrong metadata key alone
     wrong_meta = "species"
-    error_message = f"Invalid metadata to check: {wrong_meta}"
-    with pytest.raises(NotEqualError, match=error_message):
+    error_message = (
+        "species is not a valid property to check, choose from "
+        "'samples', 'properties' and 'components'"
+    )
+
+    with pytest.raises(ValueError, match=error_message):
         equistore.equal_metadata_raise(
             tensor_1=test_tensor_map_1,
             tensor_2=test_tensor_map_1,
             check=[wrong_meta],
         )
-    with pytest.raises(NotEqualError, match=error_message):
-        equistore.equal_metadata_raise(
-            tensor_1=test_tensor_map_1,
-            tensor_2=test_tensor_map_2,
-            check=[wrong_meta],
-        )
+
     # wrong metadata key with another correct one
     correct_meta = "properties"
-    with pytest.raises(NotEqualError, match=error_message):
+    with pytest.raises(ValueError, match=error_message):
         equistore.equal_metadata_raise(
             tensor_1=test_tensor_map_1,
             tensor_2=test_tensor_map_1,
             check=[correct_meta, wrong_meta],
         )
-    with pytest.raises(NotEqualError, match=error_message):
-        equistore.equal_metadata_raise(
-            tensor_1=test_tensor_map_1,
-            tensor_2=test_tensor_map_2,
-            check=[correct_meta, wrong_meta],
-        )
 
 
-def test_single_nonexisting_meta_block(test_tensor_block_1, test_tensor_block_2):
+def test_single_nonexisting_meta_block(test_tensor_block_1):
     """check behavior if non existing metadata is provided"""
     # wrong metadata key alone
     wrong_meta = "species"
-    error_message = f"Invalid metadata to check: {wrong_meta}"
-    with pytest.raises(NotEqualError, match=error_message):
+    error_message = (
+        "species is not a valid property to check, choose from "
+        "'samples', 'properties' and 'components'"
+    )
+    with pytest.raises(ValueError, match=error_message):
         equistore.equal_metadata_block_raise(
             block_1=test_tensor_block_1,
             block_2=test_tensor_block_1,
             check=[wrong_meta],
         )
-    with pytest.raises(NotEqualError, match=error_message):
-        equistore.equal_metadata_block_raise(
-            block_1=test_tensor_block_1,
-            block_2=test_tensor_block_2,
-            check=[wrong_meta],
-        )
+
     # wrong metadata key with another correct one
     correct_meta = "properties"
-    with pytest.raises(NotEqualError, match=error_message):
+    with pytest.raises(ValueError, match=error_message):
         equistore.equal_metadata_block_raise(
             block_1=test_tensor_block_1,
             block_2=test_tensor_block_1,
-            check=[correct_meta, wrong_meta],
-        )
-    with pytest.raises(NotEqualError, match=error_message):
-        equistore.equal_metadata_block_raise(
-            block_1=test_tensor_block_1,
-            block_2=test_tensor_block_2,
             check=[correct_meta, wrong_meta],
         )
 

--- a/python/equistore-operations/tests/ones_like.py
+++ b/python/equistore-operations/tests/ones_like.py
@@ -41,7 +41,7 @@ def test_ones_like_error():
         use_numpy=True,
     )
 
-    message = "requested gradient 'err' in ones_like is not defined in this tensor"
+    message = "requested gradient 'err' in 'ones_like' is not defined in this tensor"
     with pytest.raises(ValueError, match=message):
         tensor = equistore.ones_like(tensor, gradients=["positions", "err"])
 

--- a/python/equistore-operations/tests/random_like.py
+++ b/python/equistore-operations/tests/random_like.py
@@ -43,7 +43,8 @@ def test_random_uniform_like_error():
     )
 
     message = (
-        "requested gradient 'err' in random_uniform_like is not defined in this tensor"
+        "requested gradient 'err' in 'random_uniform_like' is not defined "
+        "in this tensor"
     )
     with pytest.raises(ValueError, match=message):
         tensor = equistore.random_uniform_like(tensor, gradients=["positions", "err"])

--- a/python/equistore-operations/tests/zeros_like.py
+++ b/python/equistore-operations/tests/zeros_like.py
@@ -41,7 +41,7 @@ def test_zeros_like_error():
         use_numpy=True,
     )
 
-    message = "requested gradient 'err' in zeros_like is not defined in this tensor"
+    message = "requested gradient 'err' in 'zeros_like' is not defined in this tensor"
     with pytest.raises(ValueError, match=message):
         tensor = equistore.zeros_like(tensor, gradients=["positions", "err"])
 

--- a/python/equistore-torch/tests/operations/equal_metadata.py
+++ b/python/equistore-torch/tests/operations/equal_metadata.py
@@ -1,0 +1,20 @@
+import torch
+
+import equistore.torch
+
+from .data import load_data
+
+
+def check_operation(equal_metadata):
+    tensor = load_data("qm7-power-spectrum.npz")
+    assert equal_metadata(tensor, tensor)
+
+
+def test_operation_as_python():
+    check_operation(equistore.torch.equal_metadata)
+
+
+def test_operation_as_torch_script():
+    scripted = torch.jit.script(equistore.torch.equal_metadata)
+
+    check_operation(scripted)


### PR DESCRIPTION
- typing.Sequence is not TorchScript compatible
- change iterator to `range(len(keys)))`
- removed np.all operations for comparison (I don't know if this has been changed in the API, but a comparison between Labels returns a boolean in the current version)

~TODO torch script tests~

<!-- readthedocs-preview equistore start -->
----
:books: Documentation preview :books:: https://equistore--322.org.readthedocs.build/en/322/

<!-- readthedocs-preview equistore end -->