### PR TITLE
Fix documentation build by pinning sphinx

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-sphinx >=4.4
+sphinx ==7.1.2
 sphinx-toggleprompt # hide the prompt (>>>) in python doctests
 pygments >=2.11     # syntax highligthing
 breathe >=4.33      # C and C++ => sphinx through doxygen


### PR DESCRIPTION
Sphinx recently updated all path from string to pathlib, but some plugins we use are not yet updated.

We are hitting https://github.com/breathe-doc/breathe/issues/943 and https://github.com/pradyunsg/furo/discussions/693 for other versions of sphinx.

<!-- readthedocs-preview equistore start -->
----
:books: Documentation preview :books:: https://equistore--325.org.readthedocs.build/en/325/

<!-- readthedocs-preview equistore end -->