### PR TITLE
Make sure the Rust binding use the shared library on windows

### DIFF
--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -39,19 +39,19 @@ jobs:
             container: ubuntu:20.04
             rust-target: x86_64-unknown-linux-gnu
             cargo-build-flags: --features=rayon
-            extra-name: ", cmake 3.16, all features"
+            extra-name: ", cmake 3.16"
 
           - os: macos-11
             rust-version: stable
             rust-target: x86_64-apple-darwin
-            cargo-test-flags: --all-features
-            extra-name: ", all features"
+            cargo-test-flags: --features=rayon
+            extra-name: ""
 
           - os: windows-2019
             rust-version: stable
             rust-target: x86_64-pc-windows-msvc
-            cargo-build-flags: --all-features
-            extra-name: ", all features"
+            cargo-build-flags: --features=rayon
+            extra-name: ""
     steps:
       - name: install dependencies in container
         if: matrix.container == 'ubuntu:20.04'

--- a/equistore/src/c_api.rs
+++ b/equistore/src/c_api.rs
@@ -5,7 +5,8 @@
 //! should not be needed by most.
 
 #[cfg_attr(feature="static", link(name="equistore", kind = "static", modifiers = "-whole-archive"))]
-#[cfg_attr(not(feature="static"), link(name="equistore", kind = "dylib"))]
+#[cfg_attr(all(not(feature="static"), not(target_os="windows")), link(name="equistore", kind = "dylib"))]
+#[cfg_attr(all(not(feature="static"), target_os="windows"), link(name="equistore.dll", kind = "dylib"))]
 extern "C" {}
 
 pub const EQS_SUCCESS: i32 = 0;

--- a/scripts/update-declarations.sh
+++ b/scripts/update-declarations.sh
@@ -28,7 +28,8 @@ bindgen $ROOT_DIR/equistore-core/include/equistore.h -o $ROOT_DIR/equistore/src/
 //! should not be needed by most.
 
 #[cfg_attr(feature="static", link(name="equistore", kind = "static", modifiers = "-whole-archive"))]
-#[cfg_attr(not(feature="static"), link(name="equistore", kind = "dylib"))]
+#[cfg_attr(all(not(feature="static"), not(target_os="windows")), link(name="equistore", kind = "dylib"))]
+#[cfg_attr(all(not(feature="static"), target_os="windows"), link(name="equistore.dll", kind = "dylib"))]
 extern "C" {}'
 
 


### PR DESCRIPTION
The code was failing to find the shared library, and then defaulting to the static version. This caused issues when using the code from rascaline, since the corresponding Python module where using different versions of the code.

<!-- readthedocs-preview equistore start -->
----
:books: Documentation preview :books:: https://equistore--330.org.readthedocs.build/en/330/

<!-- readthedocs-preview equistore end -->