### PR TITLE
Make `reduce_over_samples` torch-script-able

### DIFF
--- a/python/equistore-operations/equistore/operations/_dispatch.py
+++ b/python/equistore-operations/equistore/operations/_dispatch.py
@@ -72,7 +72,7 @@ def allclose(
         raise TypeError(UNKNOWN_ARRAY_TYPE)
 
 
-def bincount(input, weights: Optional[TorchTensor] = None, minlength : int = 0):
+def bincount(input, weights: Optional[TorchTensor] = None, minlength: int = 0):
     """Count number of occurrences of each value in array of non-negative ints.
     Equivalent of ``numpy.bitcount(input, weights, minlength)``
 
@@ -99,10 +99,10 @@ def bincount(input, weights: Optional[TorchTensor] = None, minlength : int = 0):
         return np.bincount(input, weights=weights, minlength=minlength)
     else:
         raise TypeError(UNKNOWN_ARRAY_TYPE)
-    
+
 
 def copy(array):
-    """Returns a copy of ``array``. 
+    """Returns a copy of ``array``.
     The new data is not shared with the original array"""
     if isinstance(array, TorchTensor):
         return array.clone()
@@ -230,7 +230,9 @@ def lstsq(X, Y, rcond, driver=None):
         raise TypeError(UNKNOWN_ARRAY_TYPE)
 
 
-def nan_to_num(X, nan: float = 0.0, posinf: Optional[float] = None, neginf: Optional[float] = None):
+def nan_to_num(
+    X, nan: float = 0.0, posinf: Optional[float] = None, neginf: Optional[float] = None
+):
     """Equivalent to np.nan_to_num(X, nan, posinf, neginf)"""
     if isinstance(X, TorchTensor):
         return torch.nan_to_num(X, nan=nan, posinf=posinf, neginf=neginf)
@@ -275,9 +277,7 @@ def index_add(output_array, input_array, index):
         raise ValueError("index should be 1D array")
     if isinstance(input_array, TorchTensor):
         _check_all_torch_tensor([output_array, input_array, index])
-        output_array.index_add_(
-            0, index.to(torch.long), input_array
-        )
+        output_array.index_add_(0, index.to(torch.long), input_array)
     elif isinstance(input_array, np.ndarray):
         _check_all_np_ndarray([output_array, input_array, index])
         np.add.at(output_array, index, input_array)
@@ -464,12 +464,9 @@ def to(array, backend: str = None, dtype=None, device=None, requires_grad=None):
     else:
         # Only numpy and torch arrays currently supported
         raise TypeError(UNKNOWN_ARRAY_TYPE)
-    
 
-def unique_with_inverse(
-    array,
-    axis: Optional[int] = None
-):
+
+def unique_with_inverse(array, axis: Optional[int] = None):
     """Return the unique entries of `array`, along with inverse indices.
 
     Specifying return_inverse=True explicitly seems to be necessary, as
@@ -477,9 +474,7 @@ def unique_with_inverse(
     in torchscript.
     """
     if isinstance(array, TorchTensor):
-        return torch.unique(
-            array, return_inverse=True, dim=axis
-        )
+        return torch.unique(array, return_inverse=True, dim=axis)
     elif isinstance(array, np.ndarray):
         return np.unique(array, return_inverse=True, axis=axis)
     else:

--- a/python/equistore-operations/equistore/operations/_dispatch.py
+++ b/python/equistore-operations/equistore/operations/_dispatch.py
@@ -453,6 +453,38 @@ def to(array, backend: str = None, dtype=None, device=None, requires_grad=None):
     else:
         # Only numpy and torch arrays currently supported
         raise TypeError(UNKNOWN_ARRAY_TYPE)
+    
+
+def unique(
+    array,
+    return_inverse: bool = False,
+    return_counts: bool = False,
+    axis: Optional[int] = None
+):
+    """Return the unique entries of `array`.
+
+    This function only supports common functionalities
+    of the corresponding numpy and torch versions.
+    The return values are given consistently with torch.
+    """
+    if isinstance(array, TorchTensor):
+        return torch.unique(
+            array, return_inverse=return_inverse, return_counts=return_counts, dim=axis
+        )
+    elif isinstance(array, np.ndarray):
+        # Cover all cases to yield a consistent return type (a tuple of three objects)
+        # consistent with torch.unique
+        result = np.unique(array, return_inverse=return_inverse, return_counts=return_counts, axis=axis)
+        if return_inverse and return_counts:
+            return result
+        elif return_inverse and not return_counts:
+            return result[0], result[1], None
+        elif not return_inverse and return_counts:
+            return result[0], None, result[1]
+        else:  # only unique values
+            return result, None, None
+    else:
+        raise TypeError(UNKNOWN_ARRAY_TYPE)
 
 
 def where(array):

--- a/python/equistore-operations/equistore/operations/reduce_over_samples.py
+++ b/python/equistore-operations/equistore/operations/reduce_over_samples.py
@@ -42,8 +42,6 @@ TensorBlock operations
 
 from typing import List, Optional, Union
 
-import numpy as np
-
 from . import _dispatch
 from ._classes import Labels, TensorBlock, TensorMap
 
@@ -78,7 +76,8 @@ def _reduce_over_samples_block(
         assert sample_names is not None
         remaining_samples_final: List[str] = []
         for s_name in block_samples.names:
-            if s_name in sample_names: continue
+            if s_name in sample_names:
+                continue
             remaining_samples_final.append(s_name)
     else:
         remaining_samples_final = remaining_samples
@@ -272,7 +271,6 @@ def _reduce_over_samples_block(
                     )
                 else:  # std
                     for i, s in enumerate(new_gradient_samples):
-                        
                         gradient_values_result[i] = (
                             values_grad_result[i]
                             - (gradient_values_result[i] * values_mean[s[0]])
@@ -314,9 +312,11 @@ def _reduce_over_samples(
     "std" or "var"
     """
     if isinstance(sample_names, str):
-        sample_names = [sample_names]
+        sample_names_list = [sample_names]
+    else:
+        sample_names_list = sample_names
 
-    for sample in sample_names:
+    for sample in sample_names_list:
         if sample not in tensor.sample_names:
             raise ValueError(
                 f"one of the requested sample name ({sample}) is not part of "
@@ -325,7 +325,8 @@ def _reduce_over_samples(
 
     remaining_samples: List[str] = []
     for s_name in tensor.sample_names:
-        if s_name in sample_names: continue
+        if s_name in sample_names_list:
+            continue
         remaining_samples.append(s_name)
 
     blocks: List[TensorBlock] = []
@@ -502,7 +503,9 @@ def mean_over_samples_block(
     )
 
 
-def mean_over_samples(tensor: TensorMap, sample_names: List[str]) -> TensorMap:
+def mean_over_samples(
+    tensor: TensorMap, sample_names: Union[str, List[str]]
+) -> TensorMap:
     """Compute the mean of a :py:class:`TensorMap`, combining the samples according to
     ``sample_names``.
 
@@ -550,7 +553,9 @@ def std_over_samples_block(
     )
 
 
-def std_over_samples(tensor: TensorMap, sample_names: List[str]) -> TensorMap:
+def std_over_samples(
+    tensor: TensorMap, sample_names: Union[str, List[str]]
+) -> TensorMap:
     r"""Compute the standard deviation of a :py:class:`TensorMap`, combining the samples
     according to ``sample_names``.
 
@@ -605,7 +610,9 @@ def var_over_samples_block(
     )
 
 
-def var_over_samples(tensor: TensorMap, sample_names: List[str]) -> TensorMap:
+def var_over_samples(
+    tensor: TensorMap, sample_names: Union[str, List[str]]
+) -> TensorMap:
     r"""Compute the variance of a :py:class:`TensorMap`, combining the
     samples according to ``sample_names``.
 

--- a/python/equistore-operations/equistore/operations/reduce_over_samples.py
+++ b/python/equistore-operations/equistore/operations/reduce_over_samples.py
@@ -92,36 +92,36 @@ def _reduce_over_samples_block(
 
     if remaining_samples is None:
         assert sample_names is not None
-        remaining_samples_final: List[str] = []
+        remaining_samples_names: List[str] = []
         for s_name in block_samples.names:
             if s_name in sample_names:
                 continue
-            remaining_samples_final.append(s_name)
+            remaining_samples_names.append(s_name)
     else:
-        remaining_samples_final = remaining_samples
+        remaining_samples_names = remaining_samples
 
-    for sample in remaining_samples_final:
+    for sample in remaining_samples_names:
         assert sample in block_samples.names
 
     assert reduction in ["sum", "mean", "var", "std"]
     # get the indices of the selected sample
     sample_selected = [
-        block_samples.names.index(sample) for sample in remaining_samples_final
+        block_samples.names.index(sample) for sample in remaining_samples_names
     ]
 
     # checks if it is a zero sample TensorBlock
     if len(block.samples) == 0:
         # Here is different from the general case where we use Labels.single() if
-        # if len(remaining_samples_final) == 0
+        # if len(remaining_samples_names) == 0
         # Labels.single() cannot be used because Labels.single() has not
         # an np.empty() array as values but has one values, it has dimension (1,...)
         # we want (0,...).
-        # here if len(remaining_samples_final) == 0 ->
+        # here if len(remaining_samples_names) == 0 ->
         # Labels([], shape=(0, 0), dtype=int32)
 
         samples_label = Labels(
-            remaining_samples_final,
-            _dispatch.zeros_like(block.values, [0, len(remaining_samples_final)]),
+            remaining_samples_names,
+            _dispatch.zeros_like(block.values, [0, len(remaining_samples_names)]),
         )
 
         result_block = TensorBlock(
@@ -195,11 +195,11 @@ def _reduce_over_samples_block(
                 values_result = _dispatch.sqrt(values_result)
 
     # check if the reduce operation reduce all the samples
-    if len(remaining_samples_final) == 0:
+    if len(remaining_samples_names) == 0:
         samples_label = Labels.single()
     else:
         samples_label = Labels(
-            remaining_samples_final,
+            remaining_samples_names,
             new_samples,
         )
 

--- a/python/equistore-operations/equistore/operations/reduce_over_samples.py
+++ b/python/equistore-operations/equistore/operations/reduce_over_samples.py
@@ -246,7 +246,7 @@ def _reduce_over_samples_block(
                 for i in range(gradient.samples.values.shape[0]):
                     s = gradient.samples.entry(i)
                     values_times_gradient_values[i] = (
-                        gradient_values[i] * block_values[s[0]]
+                        gradient_values[i] * block_values[int(s[0])]
                     )
 
                 values_grad_result = _dispatch.zeros_like(
@@ -265,7 +265,7 @@ def _reduce_over_samples_block(
                 if reduction == "var":
                     for i, s in enumerate(new_gradient_samples):
                         gradient_values_result[i] = (
-                            gradient_values_result[i] * values_mean[s[0]]
+                            gradient_values_result[i] * values_mean[int(s[0])]
                         )
                     gradient_values_result = 2 * (
                         values_grad_result - gradient_values_result
@@ -274,8 +274,8 @@ def _reduce_over_samples_block(
                     for i, s in enumerate(new_gradient_samples):
                         gradient_values_result[i] = (
                             values_grad_result[i]
-                            - (gradient_values_result[i] * values_mean[s[0]])
-                        ) / values_result[s[0]]
+                            - (gradient_values_result[i] * values_mean[int(s[0])])
+                        ) / values_result[int(s[0])]
 
                         gradient_values_result[i] = _dispatch.nan_to_num(
                             gradient_values_result[i], nan=0.0, posinf=0.0, neginf=0.0

--- a/python/equistore-operations/equistore/operations/reduce_over_samples.py
+++ b/python/equistore-operations/equistore/operations/reduce_over_samples.py
@@ -366,6 +366,7 @@ def sum_over_samples_block(
     :returns:
         a :py:class:`TensorBlock` containing the reduced values and sample labels
 
+    >>> import numpy as np
     >>> from equistore import Labels, TensorBlock, TensorMap
     >>> block = TensorBlock(
     ...     values=np.array(
@@ -432,6 +433,7 @@ def sum_over_samples(
     :returns:
         a :py:class:`TensorMap` containing the reduced values and sample labels
 
+    >>> import numpy as np
     >>> from equistore import Labels, TensorBlock, TensorMap
     >>> block = TensorBlock(
     ...     values=np.array(

--- a/python/equistore-operations/equistore/operations/reduce_over_samples.py
+++ b/python/equistore-operations/equistore/operations/reduce_over_samples.py
@@ -94,15 +94,15 @@ def _reduce_over_samples_block(
     # checks if it is a zero sample TensorBlock
     if len(block.samples) == 0:
         # Here is different from the general case where we use Labels.single() if
-        # if len(remaining_samples) == 0
+        # if len(remaining_samples_final) == 0
         # Labels.single() cannot be used because Labels.single() has not
         # an np.empty() array as values but has one values, it has dimension (1,...)
         # we want (0,...).
-        # here if len(remaining_samples) == 0 -> Labels([], shape=(0, 0), dtype=int32)
+        # here if len(remaining_samples_final) == 0 -> Labels([], shape=(0, 0), dtype=int32)
 
         samples_label = Labels(
-            remaining_samples,
-            _dispatch.zeros_like(block.values, [0, len(remaining_samples)]),
+            remaining_samples_final,
+            _dispatch.zeros_like(block.values, [0, len(remaining_samples_final)]),
         )
 
         result_block = TensorBlock(
@@ -176,11 +176,11 @@ def _reduce_over_samples_block(
                 values_result = _dispatch.sqrt(values_result)
 
     # check if the reduce operation reduce all the samples
-    if len(remaining_samples) == 0:
+    if len(remaining_samples_final) == 0:
         samples_label = Labels.single()
     else:
         samples_label = Labels(
-            remaining_samples,
+            remaining_samples_final,
             new_samples,
         )
 

--- a/python/equistore-operations/equistore/operations/reduce_over_samples.py
+++ b/python/equistore-operations/equistore/operations/reduce_over_samples.py
@@ -98,7 +98,8 @@ def _reduce_over_samples_block(
         # Labels.single() cannot be used because Labels.single() has not
         # an np.empty() array as values but has one values, it has dimension (1,...)
         # we want (0,...).
-        # here if len(remaining_samples_final) == 0 -> Labels([], shape=(0, 0), dtype=int32)
+        # here if len(remaining_samples_final) == 0 ->
+        # Labels([], shape=(0, 0), dtype=int32)
 
         samples_label = Labels(
             remaining_samples_final,
@@ -220,7 +221,7 @@ def _reduce_over_samples_block(
 
         # change the first columns of the samples array with the mapping
         # between samples and gradient.samples
-        samples[:, 0] = index[samples[:, 0]]
+        samples[:, 0] = index[_dispatch.to_index_array(samples[:, 0])]
 
         new_gradient_samples, index_gradient = _dispatch.unique_with_inverse(
             samples[:, :], axis=0

--- a/python/equistore-operations/equistore/operations/reduce_over_samples.py
+++ b/python/equistore-operations/equistore/operations/reduce_over_samples.py
@@ -40,16 +40,28 @@ TensorBlock operations
 .. autofunction:: equistore.std_over_samples_block
 """
 
-from typing import List, Optional, Union
+from typing import Any, List, Optional, Union
 
 import numpy as np
+
 from . import _dispatch
 from ._classes import Labels, TensorBlock, TensorMap, torch_jit_is_scripting
 
 
-def np_errstate_torch_script(divide: str, invalid: str) -> None:
+class NpErrstateTorchScriptContext:
+    def __init__(self) -> None:
+        pass
+
+    def __enter__(self) -> None:
+        pass
+
+    def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None:
+        pass
+
+
+def np_errstate_torch_script(divide: str, invalid: str) -> NpErrstateTorchScriptContext:
     # Placeholder for np.errstate while torch-scripting
-    return None
+    return NpErrstateTorchScriptContext()
 
 
 def _reduce_over_samples_block(

--- a/python/equistore-torch/tests/operations/reduce_over_samples.py
+++ b/python/equistore-torch/tests/operations/reduce_over_samples.py
@@ -8,7 +8,8 @@ from .data import load_data
 
 def check_operation(reduce_over_samples):
     tensor = load_data("qm7-power-spectrum.npz")
-    reduced_tensor = reduce_over_samples(tensor)
+    print(tensor.block(0).samples)
+    reduced_tensor = reduce_over_samples(tensor, "structure")
     assert isinstance(reduced_tensor, torch.ScriptObject)
 
 

--- a/python/equistore-torch/tests/operations/reduce_over_samples.py
+++ b/python/equistore-torch/tests/operations/reduce_over_samples.py
@@ -1,0 +1,21 @@
+import torch
+from packaging import version
+
+import equistore.torch
+
+from .data import load_data
+
+
+def check_operation(reduce_over_samples):
+    tensor = load_data("qm7-power-spectrum.npz")
+    reduced_tensor = reduce_over_samples(tensor)
+    assert isinstance(reduced_tensor, torch.ScriptObject)
+
+
+def test_operation_as_python():
+    check_operation(equistore.torch.sum_over_samples)
+
+
+def test_operation_as_torch_script():
+    scripted = torch.jit.script(equistore.torch.sum_over_samples)
+    check_operation(scripted)

--- a/python/equistore-torch/tests/operations/reduce_over_samples.py
+++ b/python/equistore-torch/tests/operations/reduce_over_samples.py
@@ -1,5 +1,4 @@
 import torch
-from packaging import version
 
 import equistore.torch
 
@@ -8,15 +7,23 @@ from .data import load_data
 
 def check_operation(reduce_over_samples):
     tensor = load_data("qm7-power-spectrum.npz")
-    print(tensor.block(0).samples)
-    reduced_tensor = reduce_over_samples(tensor, "structure")
+
+    assert tensor.sample_names == ["structure", "center"]
+    reduced_tensor = reduce_over_samples(tensor, "center")
+
     assert isinstance(reduced_tensor, torch.ScriptObject)
+    assert reduced_tensor.sample_names == ["structure"]
 
 
-def test_operation_as_python():
+def test_operations_as_python():
     check_operation(equistore.torch.sum_over_samples)
+    check_operation(equistore.torch.mean_over_samples)
+    check_operation(equistore.torch.std_over_samples)
+    check_operation(equistore.torch.var_over_samples)
 
 
-def test_operation_as_torch_script():
-    scripted = torch.jit.script(equistore.torch.sum_over_samples)
-    check_operation(scripted)
+def test_operations_as_torch_script():
+    check_operation(torch.jit.script(equistore.torch.sum_over_samples))
+    check_operation(torch.jit.script(equistore.torch.mean_over_samples))
+    check_operation(torch.jit.script(equistore.torch.std_over_samples))
+    check_operation(torch.jit.script(equistore.torch.var_over_samples))


### PR DESCRIPTION
I had to eliminate the `with np.errstate()` block because it was incompatible with TorchScript.
Perhaps we can document instead in what cases the numpy warning will be given

<!-- readthedocs-preview equistore start -->
----
:books: Documentation preview :books:: https://equistore--332.org.readthedocs.build/en/332/

<!-- readthedocs-preview equistore end -->