### PR TITLE
Make `one_hot()` torch-script-able

### DIFF
--- a/python/equistore-operations/equistore/operations/_dispatch.py
+++ b/python/equistore-operations/equistore/operations/_dispatch.py
@@ -110,6 +110,20 @@ def copy(array):
         return array.copy()
     else:
         raise TypeError(UNKNOWN_ARRAY_TYPE)
+    
+
+def eye_like(array, size: int):
+    """
+    Create an identity matrix with the given ``size``, and the same
+    dtype and device as ``array``.
+    """
+
+    if isinstance(array, TorchTensor):
+        return torch.eye(size).to(array.dtype).to(array.device)
+    elif isinstance(array, np.ndarray):
+        return np.eye(size, dtype=array.dtype)
+    else:
+        raise TypeError(UNKNOWN_ARRAY_TYPE)
 
 
 def list_to_array(array, data: List):

--- a/python/equistore-operations/equistore/operations/_dispatch.py
+++ b/python/equistore-operations/equistore/operations/_dispatch.py
@@ -110,7 +110,7 @@ def copy(array):
         return array.copy()
     else:
         raise TypeError(UNKNOWN_ARRAY_TYPE)
-    
+
 
 def eye_like(array, size: int):
     """

--- a/python/equistore-operations/equistore/operations/one_hot.py
+++ b/python/equistore-operations/equistore/operations/one_hot.py
@@ -71,5 +71,7 @@ def one_hot(labels: Labels, dimension: Labels):
             )
         indices[i] = position
 
-    one_hot_array = _dispatch.eye_like(dimension.values, len(dimension))[indices]
+    one_hot_array = _dispatch.eye_like(dimension.values, len(dimension))[
+        _dispatch.to_index_array(indices)
+    ]
     return one_hot_array

--- a/python/equistore-operations/equistore/operations/one_hot.py
+++ b/python/equistore-operations/equistore/operations/one_hot.py
@@ -1,9 +1,8 @@
-import numpy as np
-
+from . import _dispatch
 from ._classes import Labels
 
 
-def one_hot(labels: Labels, dimension: Labels) -> np.ndarray:
+def one_hot(labels: Labels, dimension: Labels):
     """Generates one-hot encoding from a Labels object.
 
     This function takes two ``Labels`` objects as inputs. The first
@@ -21,9 +20,9 @@ def one_hot(labels: Labels, dimension: Labels) -> np.ndarray:
         can take.
 
     :return:
-        A two-dimensional ``numpy.ndarray`` containing the one-hot
-        encoding along the selected dimension: its first dimension
-        matches the one in ``labels``, while the second contains 1
+        A two-dimensional ``numpy.ndarray`` or ``torch.Tensor`` containing
+        the one-hot encoding along the selected dimension: its first
+        dimension matches the one in ``labels``, while the second contains 1
         at the position corresponding to the original label and 0
         everywhere else
 
@@ -43,12 +42,12 @@ def one_hot(labels: Labels, dimension: Labels) -> np.ndarray:
     >>> # Get the one-hot encoded labels:
     >>> one_hot_encoding = equistore.one_hot(original_labels, possible_labels)
     >>> print(one_hot_encoding)
-    [[0. 1. 0.]
-     [1. 0. 0.]
-     [1. 0. 0.]
-     [1. 0. 0.]
-     [0. 1. 0.]
-     [1. 0. 0.]]
+    [[0 1 0]
+     [1 0 0]
+     [1 0 0]
+     [1 0 0]
+     [0 1 0]
+     [1 0 0]]
     """
 
     if len(dimension.names) != 1:
@@ -60,15 +59,17 @@ def one_hot(labels: Labels, dimension: Labels) -> np.ndarray:
 
     name = dimension.names[0]
 
-    indices = np.zeros(len(labels), dtype=np.int64)
-    for i, entry in enumerate(labels[name]):
-        position = dimension.position([entry])
+    indices = _dispatch.zeros_like(dimension.values, [len(labels)])
+    labels_name = labels.column(name)
+    for i in range(labels_name.shape[0]):
+        entry = labels_name[None, i]
+        position = dimension.position(entry)
         if position is None:
             raise ValueError(
-                f"{name}={entry} is present in the labels, but was not found in "
+                f"{name}={entry[0]} is present in the labels, but was not found in "
                 "the dimension"
             )
         indices[i] = position
 
-    one_hot_array = np.eye(len(dimension))[indices]
+    one_hot_array = _dispatch.eye_like(dimension.values, len(dimension))[indices]
     return one_hot_array

--- a/python/equistore-operations/tests/one_hot.py
+++ b/python/equistore-operations/tests/one_hot.py
@@ -21,7 +21,7 @@ def test_ordinary_usage():
             [0, 1],
             [1, 0],
         ],
-        dtype=np.float64,
+        dtype=np.int32,
     )
     one_hot_encoding = equistore.one_hot(original_labels, possible_labels)
     np.testing.assert_allclose(one_hot_encoding, correct_encoding)
@@ -43,7 +43,7 @@ def test_additional_value():
             [0, 1, 0],
             [1, 0, 0],
         ],
-        dtype=np.float64,
+        dtype=np.int32,
     )
     one_hot_encoding = equistore.one_hot(original_labels, possible_labels)
     np.testing.assert_allclose(one_hot_encoding, correct_encoding)

--- a/python/equistore-torch/tests/operations/one_hot.py
+++ b/python/equistore-torch/tests/operations/one_hot.py
@@ -1,0 +1,39 @@
+import torch
+
+import equistore.torch
+
+
+def check_operation(one_hot):
+    original_labels = equistore.torch.Labels(
+        names=["atom", "species"],
+        values=torch.tensor([[0, 6], [1, 1], [2, 1], [3, 1], [4, 6], [5, 1]]),
+    )
+    possible_labels = equistore.torch.Labels(names=["species"], values=torch.tensor([[1], [6]]))
+    correct_encoding = torch.tensor(
+        [
+            [0, 1],
+            [1, 0],
+            [1, 0],
+            [1, 0],
+            [0, 1],
+            [1, 0],
+        ],
+        dtype=torch.int32,
+    )
+    one_hot_encoding = one_hot(original_labels, possible_labels)
+
+    # check output type
+    assert isinstance(one_hot_encoding, torch.Tensor)
+
+    # check values
+    print(one_hot_encoding)
+    print(correct_encoding)
+    assert torch.allclose(one_hot_encoding, correct_encoding)
+
+
+def test_operation_as_python():
+    check_operation(equistore.torch.one_hot)
+
+
+def test_operation_as_torch_script():
+    check_operation(torch.jit.script(equistore.torch.one_hot))

--- a/python/equistore-torch/tests/operations/one_hot.py
+++ b/python/equistore-torch/tests/operations/one_hot.py
@@ -8,7 +8,9 @@ def check_operation(one_hot):
         names=["atom", "species"],
         values=torch.tensor([[0, 6], [1, 1], [2, 1], [3, 1], [4, 6], [5, 1]]),
     )
-    possible_labels = equistore.torch.Labels(names=["species"], values=torch.tensor([[1], [6]]))
+    possible_labels = equistore.torch.Labels(
+        names=["species"], values=torch.tensor([[1], [6]])
+    )
     correct_encoding = torch.tensor(
         [
             [0, 1],

--- a/python/equistore-torch/tests/operations/one_hot.py
+++ b/python/equistore-torch/tests/operations/one_hot.py
@@ -30,7 +30,7 @@ def check_operation(one_hot):
     # check values
     print(one_hot_encoding)
     print(correct_encoding)
-    assert torch.allclose(one_hot_encoding, correct_encoding)
+    assert torch.all(one_hot_encoding == correct_encoding)
 
 
 def test_operation_as_python():


### PR DESCRIPTION
Since torchscript doesn't seem to support `torch.get_default_dtype()`, I decided to output the encoding as integers

<!-- readthedocs-preview equistore start -->
----
:books: Documentation preview :books:: https://equistore--340.org.readthedocs.build/en/340/

<!-- readthedocs-preview equistore end -->